### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Python client is built in an event handler architecture. If you are building
 
 
 ## Configuration
-There are two methods of authentication.  You can either authenticate your bot using certificates or using RSA.  If you are going to authenticate using certificates, make sure you have a config.json file in your project which includes the following properties:
+There are two methods of authentication.  You can either authenticate your bot using certificates or using RSA.  If you are going to authenticate using certificates, make sure you have a config.json file in your project which includes the following properties (make sure that your "botCertPath" or "botRSAPath" include a trailing "/"):
 
         {
           "sessionAuthHost": "COMPANYNAME-api.symphony.com",
@@ -44,7 +44,7 @@ If you are going to authenticate using RSA, use the following rsa_config.json fi
           "agentPort": 443,
           "botRSAPath": "PATH-TO-PRIVATEKEY",
           "botRSAName": "PRIVATEKEY.PEM-NAME",
-          "botUsername": "BOT-USERNAME",
+          "botUserName": "BOT-USERNAME",
           "botEmailAddress": "BOT-EMAIL-ADDRESS",
           "appCertPath": "",
           "appCertName": "",
@@ -57,6 +57,9 @@ If you are going to authenticate using RSA, use the following rsa_config.json fi
         }
 
 ## Example main class (using certificates)
+Adjust the following paths in the sample to match your configuration
+ - "sym_api_client_python/logs/example.log"
+ - "sym_api_client_python/resources/config.json"
 
     from sym_api_client_python.configure.configure import SymConfig
     from sym_api_client_python.auth.auth import Auth
@@ -98,6 +101,9 @@ If you are going to authenticate using RSA, use the following rsa_config.json fi
         main()
 
 ## Example main class (using RSA)
+Adjust the following paths in the sample to match your configuration
+ - "sym_api_client_python/logs/example.log"
+ - "sym_api_client_python/resources/config.json"
 
     from sym_api_client_python.configure.configure import SymConfig
     from sym_api_client_python.auth.auth import Auth


### PR DESCRIPTION
RSA config.json botUserName was missing a capital "N" the config reader was bugging.
Also the config reader is not capable to handle if the path has a trailing "/" or not , I so added this comment:
(make sure that your "botCertPath" or "botRSAPath" include a trailing "/")

Suggested for the newbies to adjust the paths that are hardcoded in the example