### PR TITLE
Rewrite clients to use python sessions

### DIFF
--- a/sym_api_client_python/auth/auth.py
+++ b/sym_api_client_python/auth/auth.py
@@ -1,6 +1,8 @@
 import json
 import logging
 import time
+import requests
+
 from requests import Session
 from requests_pkcs12 import Pkcs12Adapter
 
@@ -18,29 +20,29 @@ class Auth:
         self.last_auth_time = 0
         self.session_token = None
         self.key_manager_token = None
-        if self.config.data['proxyURL']:
-            if self.config.data['proxyUsername']:
-                self.proxies = {
-                    "https": "https://'" +
-                             str(self.config.data['proxyUsername']) +
-                             "':'" + str(self.config.data['proxyPassword']) +
-                             "'@" + self.config.data['proxyURL'] + ':' +
-                             str(self.config.data['proxyPort'])
-                }
-                self.proxiesMasked = {
-                    "https": "https://'*******:*******@" +
-                             self.config.data['proxyURL'] +
-                             ':' + str(self.config.data['proxyPort'])
-                }
-                print(self.proxiesMasked)
-            else:
-                self.proxies = {
-                    "https": 'https://' + self.config.data['proxyURL'] +
-                             ':' + str(self.config.data['proxyPort'])
-                }
-                print(self.proxies)
+        self.auth_session = requests.Session()
+        if (self.config.data['truststorePath']):
+            logging.debug("Setting trusstorePath for auth to {}".format(self.config.data['truststorePath']))
+            self.auth_session.verify=self.config.data['truststorePath']
+        if self.config.data['completeProxyURL']:
+            self.auth_session.proxies.update({
+                "http": self.config.data['completeProxyURL'],
+                "https": self.config.data['completeProxyURL']})
         else:
             self.proxies = {}
+
+        self.auth_session.mount(
+            self.config.data['sessionAuthHost'],
+            Pkcs12Adapter(
+                pkcs12_filename=self.config.data['p.12'],
+                pkcs12_password=self.config.data['botCertPassword']
+            ))
+        self.auth_session.mount(
+            self.config.data['keyAuthHost'],
+            Pkcs12Adapter(
+                pkcs12_filename=self.config.data['p.12'],
+                pkcs12_password=self.config.data['botCertPassword']
+            ))
 
     def get_session_token(self):
         """Return the session token"""
@@ -75,16 +77,7 @@ class Auth:
         passed in through Request Session object
         """
         logging.debug('Auth/get_session_token()')
-
-        with Session() as session:
-            session.mount(
-                self.config.data['sessionAuthHost'],
-                Pkcs12Adapter(
-                    pkcs12_filename=self.config.data['p.12'],
-                    pkcs12_password=self.config.data['botCertPassword']
-                )
-            )
-            response = session.post(
+        response = self.auth_session.post(
                 self.config.data['sessionAuthHost'] +
                 '/sessionauth/v1/authenticate'
             )
@@ -105,19 +98,10 @@ class Auth:
         passed in through Request Session object
         """
         logging.debug('Auth/get_keyauth()')
-
-        with Session() as session:
-            session.mount(
-                self.config.data['sessionAuthHost'],
-                Pkcs12Adapter(
-                    pkcs12_filename=self.config.data['p.12'],
-                    pkcs12_password=self.config.data['botCertPassword']
-                )
-            )
-            response = session.post(
-                self.config.data['sessionAuthHost'] +
-                '/keyauth/v1/authenticate'
-            )
+        response = self.auth_session.post(
+            self.config.data['keyAuthHost'] +
+            '/keyauth/v1/authenticate'
+        )
 
         if response.status_code == 200:
             data = json.loads(response.text)

--- a/sym_api_client_python/clients/api_client.py
+++ b/sym_api_client_python/clients/api_client.py
@@ -22,7 +22,7 @@ class APIClient:
         elif response.status_code == 401:
             logging.debug('handling 401 error')
             if not bot_client:
-                bot_client.get_sym_auth().authenticate()
+                bot_client.reauth_client()
                 raise UnauthorizedException(
                     'User, unauthorized, refreshing tokens: {}'
                         .format(response.status_code))

--- a/sym_api_client_python/clients/datafeed_client.py
+++ b/sym_api_client_python/clients/datafeed_client.py
@@ -24,4 +24,8 @@ class DataFeedClient(APIClient):
     def read_datafeed(self, datafeed_id):
         logging.debug('DataFeedClient/read_datafeed()')
         url = '/agent/v4/datafeed/{0}/read'.format(datafeed_id)
-        return self.bot_client.execute_rest_call("GET", url)
+        new_events = []
+        datafeed_read = self.bot_client.execute_rest_call("GET", url)
+        if (datafeed_read != []):
+            new_events.append(datafeed_read)
+        return new_events

--- a/sym_api_client_python/clients/datafeed_client.py
+++ b/sym_api_client_python/clients/datafeed_client.py
@@ -10,66 +10,18 @@ class DataFeedClient(APIClient):
 
     def __init__(self, bot_client):
         self.bot_client = bot_client
-        self.config = self.bot_client.get_sym_config()
-        if self.config.data['proxyURL']:
-            self.proxies = {"http": self.config.data['proxyURL']}
-        else:
-            self.proxies = {}
 
     # raw api call to create_datafeed --> returns datafeed_id
     def create_datafeed(self):
         logging.debug('DataFeedClient/create_datafeed()')
         # messaging_logger.debug('DataFeedClient/create_datafeed()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token(),
-            'keyManagerToken': self.bot_client.get_sym_auth().get_key_manager_token()
-        }
-        response = requests.post(
-            self.config.data['agentHost'] + '/agent/v4/datafeed/create',
-            proxies=self.proxies, headers=headers
-        )
-        if response.status_code == 200:
-            logging.debug(
-                'DataFeedClient/create_datafeed() succeeded: {}'.format(response.status_code)
-            )
-            data = json.loads(response.text)
-            datafeed_id = data['id']
-            return datafeed_id
-
-        else:
-            try:
-                logging.debug('DataFeedClient/create_datafeed() failed: {}'
-                              .format(response.status_code))
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                # should take 30 second to get here so after it
-                # reauthorizes, catch it and re create df
-                self.create_datafeed()
+        url = '/agent/v4/datafeed/create'
+        response = self.bot_client.execute_rest_call("POST", url)
+        return response['id']
 
     # raw api call to read_datafeed --> returns an array of events returned
     # from DataFeed
     def read_datafeed(self, datafeed_id):
         logging.debug('DataFeedClient/read_datafeed()')
-        datafeed_events = []
-        headers = {
-            'sessionToken':
-                self.bot_client.get_sym_auth().get_session_token(),
-            'keyManagerToken':
-                self.bot_client.get_sym_auth().get_key_manager_token()
-        }
-        url = self.config.data['agentHost']+'/agent/v4/datafeed/{0}/read'.\
-            format(datafeed_id)
-        response = requests.get(url, headers=headers)
-        if response.status_code == 204:
-            datafeed_events = []
-        elif response.status_code == 200:
-            x = json.loads(response.text)
-            datafeed_events.append(x)
-        else:
-            logging.debug(
-                'DataFeedClient/read_datafeed() failed: {}'.
-                    format(response.status_code)
-            )
-            super().handle_error(response, self.bot_client)
-
-        return datafeed_events
+        url = '/agent/v4/datafeed/{0}/read'.format(datafeed_id)
+        return self.bot_client.execute_rest_call("GET", url)

--- a/sym_api_client_python/clients/message_client.py
+++ b/sym_api_client_python/clients/message_client.py
@@ -13,7 +13,6 @@ class MessageClient(APIClient):
 
     def __init__(self, bot_client):
         self.bot_client = bot_client
-        self.config = self.bot_client.get_sym_config()
 
     def get_msg_from_stream(self, stream_id, since, **kwargs):
         logging.debug('MessageClient/get_msg_from_stream()')

--- a/sym_api_client_python/clients/message_client.py
+++ b/sym_api_client_python/clients/message_client.py
@@ -14,60 +14,21 @@ class MessageClient(APIClient):
     def __init__(self, bot_client):
         self.bot_client = bot_client
         self.config = self.bot_client.get_sym_config()
-        if self.config.data['proxyURL']:
-            self.proxies = {
-                "https": 'https://' + self.config.data['proxyURL'] + ':'
-                         + str(self.config.data['proxyPort'])
-            }
-        else:
-            self.proxies = {}
 
     def get_msg_from_stream(self, stream_id, since):
         logging.debug('MessageClient/getMessages()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token(),
-            'keyManagerToken': self.bot_client.get_sym_auth().get_key_manager_token()
-        }
-        url = self.config.data['agentHost'] + \
-              '/agent/v4/stream/{0}/message?since={1}'.format(stream_id, since)
-        response = requests.get(url, headers=headers, proxies=self.proxies)
-        if response.status_code == 204:
-            result = []
-            return result
-        elif response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.get_msg_from_stream(stream_id, since)
+        url = '/agent/v4/stream/{0}/message?since={1}'.format(stream_id, since)
+        return self.bot_client.execute_rest_call('GET', url)
 
     def send_msg(self, stream_id, outbound_msg):
         print(stream_id + " streamID to play with")
         logging.debug('MessageClient/createMessage()')
-        url = self.config.data['agentHost'] + \
-              '/agent/v4/stream/{0}/message/create'.format(stream_id)
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token(),
-            'keyManagerToken': self.bot_client.get_sym_auth().get_key_manager_token()
-        }
-        response = requests.post(url, files=outbound_msg,
-                                 headers=headers, proxies=self.proxies)
-        if response.status_code == 204:
-            result = []
-            return result
-        elif response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.send_msg(stream_id, outbound_msg)
+        url = '/agent/v4/stream/{0}/message/create'.format(stream_id)
+        return self.bot_client.execute_rest_call('POST', url, files=outbound_msg)
 
     def send_msg_with_attachment(self, stream_id, msg,
                                  filename, path_to_attachment):
-        url = self.config.data['agentHost'] + \
-              '/agent/v4/stream/{0}/message/create'.format(stream_id)
+        url = '/agent/v4/stream/{0}/message/create'.format(stream_id)
         print(url)
         data = MultipartEncoder(
             fields={'message': msg,
@@ -75,55 +36,20 @@ class MessageClient(APIClient):
                     filename, open(path_to_attachment, 'rb'), 'file')}
         )
         headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token(),
-            'keyManagerToken': self.bot_client.get_sym_auth().get_key_manager_token(),
             'Content-Type': data.content_type
         }
-        response = requests.post(url, data=data, headers=headers,
-                                 proxies=self.proxies)
-        if response.status_code == 204:
-            result = []
-            return result
-        elif response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.send_msg(stream_id, msg)
-
-        pass
+        return self.bot_client.execute_rest_call("POST", url, data=data, headers=headers)
 
     def get_msg_attachments(self, stream_id, msg_id, file_id):
         logging.debug('MessageClient/getAttachments()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token(),
-            'keyManagerToken': self.bot_client.get_sym_auth().get_key_manager_token()
-        }
-        url = self.config.data['agentHost'] + \
-              '/agent/v1/stream/{0}/attachment?msg_id={1}&file_id={2}'\
-                  .format(stream_id, msg_id, file_id)
-        response = requests.get(url, headers=headers, proxies=self.proxies)
-        if response.status_code == 204:
-            result = []
-            return result
-        elif response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.get_msg_attachments(stream_id, msg_id, file_id)
+        url = '/agent/v1/stream/{0}/attachment?msg_id={1}&file_id={2}'.format(stream_id, msg_id, file_id)
+        return self.bot_client.execute_rest_call("GET", url)
 
     # go on admin clients --> Contains sample data just for example's sake
     def import_message(self):
         logging.debug('MessageClient/import_message()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token(),
-            'keyManagerToken': self.bot_client.get_sym_auth().get_key_manager_token()
-        }
-        url = self.config.data['agentHost']+'/agent/v4/message/import'
-        payload = {
+        url = '/agent/v4/message/import'
+        data = {
             "message": "<messageML>Imported message</messageML>",
             "format": "MESSAGEML",
             "intendedMessageTimestamp": 1433045622000,
@@ -132,126 +58,37 @@ class MessageClient(APIClient):
             "originalMessageId": "",
             "streamId": ""
         }
-        response = requests.post(
-            url, headers=headers,
-            data=payload, proxies=self.proxies
-        )
-        if response.status_code == 204:
-            result = []
-            return result
-        elif response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.import_message()
+        return self.bot_client.execute_rest_call("POST", url, data=data)
 
     # go on admin clients
     def suppress_message(self, id):
         logging.debug('MessageClient/suppress_message()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token(),
-            'keyManagerToken': self.bot_client.get_sym_auth().get_key_manager_token()
-        }
-        url = self.config.data['podHost'] + \
-              '/pod/v1/admin/messagesuppression/{0}/suppress'.format(id)
-        response = requests.post(url, headers=headers, proxies=self.proxies)
-        if response.status_code == 204:
-            result = []
-            return result
-        elif response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.suppress_message(id)
+        url = '/pod/v1/admin/messagesuppression/{0}/suppress'.format(id)
+        return self.bot_client.execute_rest_call("POST", url)
 
     def post_msg_search(self):
         logging.debug('MessageClient/post_msg_search()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token(),
-            'keyManagerToken': self.bot_client.get_sym_auth().get_key_manager_token()
-        }
-        url = self.config.data['agentHost']+'/agent/v1/message/search'
-        payload = {
+        url = '/agent/v1/message/search'
+        data = {
             'hashtag': 'reed'
         }
-        response = requests.post(
-            url, headers=headers,
-            json=payload, proxies=self.proxies
-        )
-        if response.status_code == 204:
-            result = []
-            return result
-        elif response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.post_msg_search(id)
+        return self.bot_client.execute_rest_call("POST", url, json=data)
 
     # contains sample query for example
     def get_msg_search(self):
         logging.debug('MessageClient/get_msg_search()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token(),
-            'keyManagerToken': self.bot_client.get_sym_auth().get_key_manager_token()
-        }
-        url = self.config.data['agentHost']+'/agent/v1/message/search'
+        url = '/agent/v1/message/search'
         query = {
             'query': 'hashtag:reed'
         }
-        response = requests.get(url, headers=headers,
-                                params=query, proxies=self.proxies)
-        if response.status_code == 204:
-            result = []
-            return result
-        elif response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.get_msg_search(id)
+        return self.bot_client.execute_rest_call("GET", url, params=query)
 
     def get_msg_status(self, msg_id):
         logging.debug('MessageClient/get_msg_status()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token()
-        }
-        url = self.config.data['podHost'] + '/pod/v1/message/{0}/status'\
-            .format(msg_id)
-        response = requests.get(url, headers=headers, proxies=self.proxies)
-        if response.status_code == 204:
-            result = []
-            return result
-        elif response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.get_msg_status(msg_id)
+        url = '/pod/v1/message/{0}/status'.format(msg_id)
+        return self.bot_client.execute_rest_call("GET", url)
 
     def get_supported_attachment_types(self):
         logging.debug('MessageClient/getAttachmentTypes()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token()
-        }
-        url = self.config.data['podHost']+'/pod/v1/files/allowedTypes'
-        response = requests.get(url, headers=headers, proxies=self.proxies)
-        if response.status_code == 204:
-            result = []
-            return result
-        elif response.status_code == 200:
-            logging.debug('200')
-            return json.loads(response.text)
-        else:
-            logging.debug(response.status_code)
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.get_supported_attachment_types()
+        url = '/pod/v1/files/allowedTypes'
+        return self.bot_client.execute_rest_call("GET", url)

--- a/sym_api_client_python/clients/message_client.py
+++ b/sym_api_client_python/clients/message_client.py
@@ -15,21 +15,24 @@ class MessageClient(APIClient):
         self.bot_client = bot_client
         self.config = self.bot_client.get_sym_config()
 
-    def get_msg_from_stream(self, stream_id, since):
-        logging.debug('MessageClient/getMessages()')
-        url = '/agent/v4/stream/{0}/message?since={1}'.format(stream_id, since)
-        return self.bot_client.execute_rest_call('GET', url)
+    def get_msg_from_stream(self, stream_id, since, **kwargs):
+        logging.debug('MessageClient/get_msg_from_stream()')
+        url = '/agent/v4/stream/{0}/message'.format(stream_id)
+        params = {
+            'since': since
+        }
+        params = params.update(kwargs)
+        return self.bot_client.execute_rest_call('GET', url, params=params)
 
     def send_msg(self, stream_id, outbound_msg):
-        print(stream_id + " streamID to play with")
-        logging.debug('MessageClient/createMessage()')
+        logging.debug('MessageClient/send_msg()')
         url = '/agent/v4/stream/{0}/message/create'.format(stream_id)
         return self.bot_client.execute_rest_call('POST', url, files=outbound_msg)
 
     def send_msg_with_attachment(self, stream_id, msg,
                                  filename, path_to_attachment):
+        logging.debug('MessageClient/send_msg_with_attachment()')
         url = '/agent/v4/stream/{0}/message/create'.format(stream_id)
-        print(url)
         data = MultipartEncoder(
             fields={'message': msg,
                     'attachment': (
@@ -41,24 +44,19 @@ class MessageClient(APIClient):
         return self.bot_client.execute_rest_call("POST", url, data=data, headers=headers)
 
     def get_msg_attachments(self, stream_id, msg_id, file_id):
-        logging.debug('MessageClient/getAttachments()')
-        url = '/agent/v1/stream/{0}/attachment?msg_id={1}&file_id={2}'.format(stream_id, msg_id, file_id)
-        return self.bot_client.execute_rest_call("GET", url)
+        logging.debug('MessageClient/get_msg_attachments()')
+        url = '/agent/v1/stream/{0}/attachment'.format(stream_id)
+        params = {
+            'msg_id': msg_id,
+            'file_id': file_id
+        }
+        return self.bot_client.execute_rest_call("GET", url, params=params)
 
     # go on admin clients --> Contains sample data just for example's sake
-    def import_message(self):
+    def import_message(self, importedMessage):
         logging.debug('MessageClient/import_message()')
         url = '/agent/v4/message/import'
-        data = {
-            "message": "<messageML>Imported message</messageML>",
-            "format": "MESSAGEML",
-            "intendedMessageTimestamp": 1433045622000,
-            "intendedMessageFromUserId": 7215545057281,
-            "originatingSystemId": "",
-            "originalMessageId": "",
-            "streamId": ""
-        }
-        return self.bot_client.execute_rest_call("POST", url, data=data)
+        return self.bot_client.execute_rest_call("POST", url, json=importedMessage)
 
     # go on admin clients
     def suppress_message(self, id):
@@ -66,22 +64,20 @@ class MessageClient(APIClient):
         url = '/pod/v1/admin/messagesuppression/{0}/suppress'.format(id)
         return self.bot_client.execute_rest_call("POST", url)
 
-    def post_msg_search(self):
+    def post_msg_search(self, query, **kwargs):
         logging.debug('MessageClient/post_msg_search()')
         url = '/agent/v1/message/search'
-        data = {
-            'hashtag': 'reed'
-        }
-        return self.bot_client.execute_rest_call("POST", url, json=data)
+        return self.bot_client.execute_rest_call("POST", url, json=query, params=kwargs)
 
     # contains sample query for example
-    def get_msg_search(self):
+    def get_msg_search(self, query, **kwargs):
         logging.debug('MessageClient/get_msg_search()')
         url = '/agent/v1/message/search'
-        query = {
-            'query': 'hashtag:reed'
+        params = {
+            'query': query
         }
-        return self.bot_client.execute_rest_call("GET", url, params=query)
+        params = params.update(kwargs)
+        return self.bot_client.execute_rest_call("GET", url, params=params)
 
     def get_msg_status(self, msg_id):
         logging.debug('MessageClient/get_msg_status()')
@@ -92,3 +88,13 @@ class MessageClient(APIClient):
         logging.debug('MessageClient/getAttachmentTypes()')
         url = '/pod/v1/files/allowedTypes'
         return self.bot_client.execute_rest_call("GET", url)
+
+    def get_msg_ids_by_timestamp(self, msg_id, **kwargs):
+        logging.debug('MessageClient/get_msg_ids_by_timestamp()')
+        url = '/pod/v2/admin/streams/{0}/messageIds'.format(msg_id)
+        return self.bot_client.execute_rest_call('GET', url, params=kwargs)
+
+    def list_msg_receipts(self, msg_id):
+        logging.debug('MessageClient/list_msg_receipts()')
+        url = '/pod/v1/admin/messages/{0}/receipts'.format(msg_id)
+        return self.bot_client.example('GET', url)

--- a/sym_api_client_python/clients/stream_client.py
+++ b/sym_api_client_python/clients/stream_client.py
@@ -24,39 +24,55 @@ class StreamClient(APIClient):
         url = '/pod/v1/admin/im/create'
         return self.bot_client.execute_rest_call("POST", url, json=users_array)
 
-    # contains sample data for example's sake
-    def create_room(self):
+    # Example Room Object. All required
+    # '{   
+    #     "name": (string) Room name,
+    #     "description": (string) Room description,
+    #     "keywords": [
+    #         {"key": "key1", "value": "value1"},
+    #         {"key": "key2", "value": "value2"}
+    #         ...
+    #     ],
+    #     "membersCanInvite": (bool) If true, any chat room participant can add new participants. If false, only owners can add new participants,
+    #     "discoverable": (bool) If true, this chat room (name, description and messages) non-participants can search for this room. If false, only participants can search for this room,
+    #     "public": (bool) If true, this is a public chatroom. If false, a private chatroom. Note: Once this value is set for a room, it is read-only and can’t be updated,
+    #     "readOnly": (bool) If true, only stream owners can send messages. Once this value is set for a room, it is read-only and can’t be updated,
+    #     "copyProtected": (bool) If true, users cannot copy content from this room. Once this value is set to true for a room, it is read-only and can’t be updated,
+    #     "crossPod": (bool) If true, this room is a cross-pod room,
+    #     "viewHistory": (bool) If true, new members can view the room chat history of the room,
+    #     "multiLateralRoom": (bool) If true, this is a multilateral room where users belonging to more than 2 companies can be found
+    # }'
+    def create_room(self, roomToCreate):
         logging.debug('StreamClient/create_room()')
         url = '/pod/v3/room/create'
-        data = {
-            "name": "butlahsroom",
-            "description": "meant for testing with butler"
-        }
-        return self.bot_client.execute_rest_call("POST", url, json=data)
+        return self.bot_client.execute_rest_call("POST", url, json=roomToCreate)
 
-    # contains example data dictionary for example sake
-    def update_room(self, stream_id):
+    # Pass attributes you want to update into **kwargs
+    def update_room(self, stream_id, **kwargs):
         logging.debug('StreamClient/update_room()')
         url = '/pod/v3/room/{0}/update'.format(stream_id)
-        data = {
-            "name": "updatedRoomName"
-        }
-        return self.bot_client.execute_rest_call('POST', url, json=data)
+        return self.bot_client.execute_rest_call('POST', url, json=kwargs)
 
     def get_room_info(self, stream_id):
-        logging.debug('StreamClient/roomInfo()')
+        logging.debug('StreamClient/get_room_info()')
         url = '/pod/v3/room/{0}/info'.format(stream_id)
         return self.bot_client.execute_rest_call('GET', url)
 
-    def activate_room(self, stream_id, active=True):
+    def activate_room(self, stream_id):
         logging.debug('StreamClient/activate_room()')
-        url = '/pod/v1/room/{0}/setActive?active={1}'.format(stream_id, active)
-        return self.bot_client.execute_rest_call('POST', url)
+        url = '/pod/v1/room/{0}/setActive'.format(stream_id)
+        params = {
+            'active': True
+        }
+        return self.bot_client.execute_rest_call('POST', url, params=params)
 
-    def deactivate_room(self, stream_id, active=False):
+    def deactivate_room(self, stream_id):
         logging.debug('StreamClient/activate_room()')
-        url = '/pod/v1/room/{0}/setActive?active={1}'.format(stream_id, active)
-        return self.bot_client.execute_rest_call('POST', url)
+        url = '/pod/v1/room/{0}/setActive'.format(stream_id)
+        params = {
+            'active': False
+        }
+        return self.bot_client.execute_rest_call('POST', url, params=params)
 
     def get_room_members(self, stream_id):
         logging.debug('StreamClient/get_room_members()')
@@ -64,109 +80,135 @@ class StreamClient(APIClient):
         return self.bot_client.execute_rest_call('GET', url)
 
     def add_member_to_room(self, stream_id, user_id):
-        logging.debug('StreamClient/addMember()')
+        logging.debug('StreamClient/add_member_to_room()')
         url = '/pod/v1/room/{0}/membership/add'.format(stream_id)
         data = {'id': user_id}
         return self.bot_client.execute_rest_call('POST', url, json=data)
 
-    # contains sample data dictionary for example --> see documentation for
-    # further detail
-    def share_room(self, stream_id):
+    # Content Object. * is required. Either articleId or articleUrl must be specified
+    # "content":{
+    #     "articleId": (string) A unique ID for this article, not used by any other article,
+    #     "title": (string) The title of the article,
+    #     "subTitle": (string) The subtitle of the article
+    #     "description": (string) The description of the article,
+    #     "message" : (string) The message text that can be sent along with the shared article,
+    #     "publisher": (string)* Publisher of the article,
+    #     "publishDate": (string) Article publish date in unix timestamp,
+    #     "thumbnailUrl": (string) URL to the thumbnail image,
+    #     "author": (string)* Author of the article,
+    #     "articleUrl": (string) URL to the article,
+    #     "summary": (string) Preview summary of the article,
+    #     "appId": (string)* App ID of the calling application,
+    #     "appName": (string) App name of the calling application,
+    #     "appIconUrl": (string) App icon URL of the calling application
+    # }
+    def share_room(self, stream_id, content):
         logging.debug('StreamClient/share_room()')
         url = '/agent/v3/stream/{0}/share'.format(stream_id)
         data = {
             "type": "com.symphony.sharing.article",
-            "content":{
-                "articleId": "tsla",
-                "title": "The Secrets Out: Tesla Enters China and Is Winning",
-                "description": "Check this out",
-                "publisher": "Capital Market Laboratories",
-                "thumbnailUrl": "http://www.cmlviz.com/cmld3b/images/tesla-supercharger-stop.jpg",
-                "author": "OPHIRGOTTLIEB",
-                "articleUrl": "http://ophirgottlieb.tumblr.com/post/146623530819/the-secrets-out-tesla-enters-china-and-is",
-                "summary": "Tesla Motors Inc. (NASDAQ:TSLA) has a CEO more famous than the firm itself, perhaps. Elon Musk has made some bold predictions, first stating that the firm would grow sales from 50,000 units in 2015 to 500,000 by 2020 powered by the less expensive Model 3 and the massive manufacturing capability of the Gigafactory.",
-                "appId": "ticker",
-                "appName": "Market Data Demo",
-                "appIconUrl": "https://apps-dev.symphony.com/ticker/assets/images/logo.png"
-            }
+            "content": content
         }
         return self.bot_client.execute_rest_call('POST', url, json=data)
 
     def remove_member_from_room(self, stream_id, user_id):
-        logging.debug('StreamClient/removeMember()')
+        logging.debug('StreamClient/remove_member_from_room()')
         url = '/pod/v1/room/{0}/membership/remove'.format(stream_id)
         data = {'id': user_id}
         return self.bot_client.execute_rest_call('POST', url, json=data)
 
     def promote_user_to_owner(self, stream_id, user_id):
-        logging.debug('StreamClient/promoteOwner()')
+        logging.debug('StreamClient/promote_user_to_owner()')
         url = '/pod/v1/room/{0}/membership/promoteOwner'.format(stream_id)
         data = {'id': user_id}
         return self.bot_client.execute_rest_call('POST', url, json=data)
 
     def demote_user_from_owner(self, stream_id, user_id):
-        logging.debug('StreamClient/demoteOwner()')
+        logging.debug('StreamClient/demote_user_from_owner()')
         url = '/pod/v1/room/{0}/membership/demoteOwner'.format(stream_id)
         data = {'id': user_id}
         return self.bot_client.execute_rest_call('POST', url, json=data)
 
-    def search_rooms(self, skip=0, limit=50):
-        logging.debug('StreamClient/roomSearch()')
+    # Available kwargs:
+    # labels: A list of room keywords whose values will be queried.
+    # active: If true, restricts the search to active rooms. If false, restricts the search to inactive rooms. If not specified, includes both active and inactive rooms.
+    # private: If true, includes public and private rooms in the search results. If false or unspecified only public rooms are returned.
+    # creator: If provided, restricts the search to rooms created by the specified user.
+    # owner: If provided, restricts the search to rooms owned by the specified user.
+    # member: If provided, restricts the search to rooms where the specified user is a member.
+    # sortOrder: Sort algorithm to be used. Supports two values: BASIC (legacy algorithm) and RELEVANCE (enhanced algorithm).
+    def search_rooms(self, query, skip=0, limit=50, **kwargs):
+        logging.debug('StreamClient/search_rooms()')
         url = '/pod/v3/room/search'
-        params = {'skip': skip, 'limit':limit}
-        data = {'query': 'butlahsroom'}
+        params = {
+            'skip': skip,
+            'limit':limit
+        }
+        data = {
+            'query': query
+        }
+        data = data.update(kwargs)
         return self.bot_client.execute_rest_call('POST', url, params=params, json=data)
 
-    def get_user_streams(self, skip=0, limit=50):
-        logging.debug('StreamClient/listUserStreams()')
+    def get_user_streams(self, skip=0, limit=50, stream_types = 'ALL', include_inactive = True):
+        logging.debug('StreamClient/get_user_streams()')
         url = '/pod/v1/streams/list'
+        if (stream_types == 'ALL'):
+            stream_types = {
+                "streamTypes": [
+                    {"type": "IM"},
+                    {"type": "MIM"},
+                    {"type": "ROOM"},
+                    {"type": "POST"}
+                ],
+            }
         data = {
-            "streamTypes": [
-                {"type": "IM"},
-                {"type": "MIM"},
-                {"type": "ROOM"},
-                {"type": "POST"}
-            ],
-            "includeInactiveStreams": True
+            'streamTypes': stream_types,
+            'includeInactiveStream': include_inactive
         }
-        return self.bot_client.execute_rest_call('POST', url, json=data)
+        params = {
+            'skip': skip,
+            'limit': limit
+        }
+        return self.bot_client.execute_rest_call('POST', url, json=data, params=params)
 
     def stream_info_v2(self, stream_id):
         logging.debug('StreamClient/stream_info_v2()')
         url = '/pod/v2/streams/{0}/info'.format(stream_id)
         return self.bot_client.execute_rest_call('GET', url)
 
-    def list_streams_enterprise(self, skip=0, limit=50):
+    # Available kwargs:
+    # streamTypes: A list of stream types that will be returned (IM, MIM, ROOM). If not specified, streams of all types are returned.
+    # scope: The scope of the stream: INTERNAL (restricted to members of the calling user's company) or EXTERNAL (including members of the calling user's company, as well as another firm). If not specified, returns streams of either scope.
+    # origin: The origin of the room: INTERNAL (created by a user of the calling user's company) or EXTERNAL (created by a user of another company). If not specified, returns streams of either origin. Only applies to chatrooms with External scope.
+    # privacy: The privacy setting of the room: PRIVATE (members must be added) OR PUBLIC (anyone can join). If not specified, returns both private and public rooms. Only applies to chatrooms with internal scope.
+    # status: The status of the room: ACTIVE or INACTIVE. If not specified, both active and inactive streams are returned.
+    # startDate: Restricts result set to rooms that have been modified since this date (an Epoch timestamp specified in milliseconds). When specified along with endDate, enables the developer to specify rooms modified within a given time range.
+    # endDate: Restricts result set to rooms that have been modified prior to this date (an Epoch timestamp specified in milliseconds). When specified along with startDate, enables the developer to specify rooms modified within a given time range.
+    def list_streams_enterprise(self, skip=0, limit=50, **kwargs):
         logging.debug('StreamClient/list_streams_enterprise()')
         url = '/pod/v1/admin/streams/list'
-        params = {'skip': skip, 'limit': limit}
-        data = {
-              "streamTypes": [{"type": "ROOM"}],
-              "scope": "EXTERNAL",
-              "origin": "EXTERNAL",
-              "privacy": "PRIVATE",
-              "status": "ACTIVE",
-              "startDate": 1481575056047,
-              "endDate": 1483038089833
+        params = {
+            'skip': skip,
+            'limit': limit
         }
-        return self.bot_client.execute_rest_call('POST', url, params=params, json=data)
+        return self.bot_client.execute_rest_call('POST', url, params=params, json=kwargs)
 
-    def list_streams_enterprise_v2(self, skip=0, limit=50):
+    # Available kwargs same as list_streams_enterprise
+    def list_streams_enterprise_v2(self, skip=0, limit=50, **kwargs):
         logging.debug('StreamClient/list_streams_enterprise_v2()')
         url = '/pod/v2/admin/streams/list'
-        params = {'skip': skip, 'limit': limit}
-        data = {
-              "streamTypes": [{"type": "ROOM"}],
-              "scope": "EXTERNAL",
-              "origin": "EXTERNAL",
-              "privacy": "PRIVATE",
-              "status": "ACTIVE",
-              "startDate": 1481575056047,
-              "endDate": 1483038089833
+        params = {
+            'skip': skip,
+            'limit': limit
         }
-        return self.bot_client.execute_rest_call('POST', url, params=params, json=data)
+        return self.bot_client.execute_rest_call('POST', url, params=params, json=kwargs)
 
     def get_stream_members(self, stream_id, skip=0, limit=100):
         logging.debug('StreamClient/get_stream_members()')
         url = '/pod/v1/admin/stream/{0}/membership/list'.format(stream_id)
-        return self.bot_client.execute_rest_call('POST', url)
+        params = {
+            'skip': skip,
+            'limit': limit
+        }
+        return self.bot_client.execute_rest_call('POST', url, params=params)

--- a/sym_api_client_python/clients/stream_client.py
+++ b/sym_api_client_python/clients/stream_client.py
@@ -167,7 +167,7 @@ class StreamClient(APIClient):
             try:
                 super().handle_error(response, self.bot_client)
             except UnauthorizedException:
-                self.get_room_members()
+                self.get_room_members(stream_id)
 
     def add_member_to_room(self, stream_id, user_id):
         logging.debug('StreamClient/addMember()')
@@ -215,7 +215,7 @@ class StreamClient(APIClient):
             }
         }
         response = requests.post(
-            url, headers=headers, json=data
+            url, headers=headers, json=data, proxies=self.proxies
         )
         if response.status_code == 200:
             return json.loads(response.text)
@@ -344,7 +344,7 @@ class StreamClient(APIClient):
             try:
                 super().handle_error(response, self.bot_client)
             except UnauthorizedException:
-                self.stream_info_v2()
+                self.stream_info_v2(stream_id)
 
     def list_streams_enterprise(self, skip=0, limit=50):
         logging.debug('StreamClient/list_streams_enterprise()')

--- a/sym_api_client_python/clients/stream_client.py
+++ b/sym_api_client_python/clients/stream_client.py
@@ -13,191 +13,67 @@ class StreamClient(APIClient):
 
     def __init__(self, bot_client):
         self.bot_client = bot_client
-        self.config = self.bot_client.get_sym_config()
-        if self.config.data['proxyURL']:
-            self.proxies = {"https": self.config.data['proxyURL']}
-        else:
-            self.proxies = {}
 
     def create_im(self, users_array):
         logging.debug('StreamClient/create_im()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token()
-        }
-        url = self.config.data['podHost']+'/pod/v1/im/create'
-        response = requests.post(
-            url, json=users_array, headers=headers, proxies=self.proxies
-        )
-        if response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.create_im(users_array)
+        url = '/pod/v1/im/create'
+        return self.bot_client.execute_rest_call("POST", url, json=users_array)
 
     def create_im_admin(self, users_array):
         logging.debug('StreamClient/create_im_admin()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token()
-        }
-        url = self.config.data['podHost']+'/pod/v1/admin/im/create'
-        response = requests.post(
-            url, json=users_array, headers=headers, proxies=self.proxies
-        )
-        if response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.create_im_admin(users_array)
+        url = '/pod/v1/admin/im/create'
+        return self.bot_client.execute_rest_call("POST", url, json=users_array)
 
     # contains sample data for example's sake
     def create_room(self):
         logging.debug('StreamClient/create_room()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token()
-        }
-        url = self.config.data['podHost']+'/pod/v3/room/create'
+        url = '/pod/v3/room/create'
         data = {
             "name": "butlahsroom",
             "description": "meant for testing with butler"
         }
-        response = requests.post(
-            url, headers=headers, json=data, proxies=self.proxies
-        )
-        if response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.create_room()
+        return self.bot_client.execute_rest_call("POST", url, json=data)
 
     # contains example data dictionary for example sake
     def update_room(self, stream_id):
         logging.debug('StreamClient/update_room()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token()
-        }
-        url = self.config.data['podHost'] + \
-              '/pod/v3/room/{0}/update'.format(stream_id)
+        url = '/pod/v3/room/{0}/update'.format(stream_id)
         data = {
             "name": "updatedRoomName"
         }
-        response = requests.post(
-            url, headers=headers, json=data, proxies=self.proxies
-        )
-        if response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.update_room(stream_id)
+        return self.bot_client.execute_rest_call('POST', url, json=data)
 
     def get_room_info(self, stream_id):
         logging.debug('StreamClient/roomInfo()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token()
-        }
-        url = self.config.data['podHost'] + \
-              '/pod/v3/room/{0}/info'.format(stream_id)
-        response = requests.get(
-            url, headers=headers, proxies=self.proxies
-        )
-        if response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.get_room_info(stream_id)
+        url = '/pod/v3/room/{0}/info'.format(stream_id)
+        return self.bot_client.execute_rest_call('GET', url)
 
     def activate_room(self, stream_id, active=True):
         logging.debug('StreamClient/activate_room()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token()
-        }
-        url = self.config.data['podHost'] + \
-              '/pod/v1/room/{0}/setActive?active={1}'.format(stream_id, active)
-        response = requests.post(
-            url, headers=headers, proxies=self.proxies
-        )
-        if response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.activate_room(stream_id, active=True)
+        url = '/pod/v1/room/{0}/setActive?active={1}'.format(stream_id, active)
+        return self.bot_client.execute_rest_call('POST', url)
 
     def deactivate_room(self, stream_id, active=False):
-        logging.debug('StreamClient/deactivate_room()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token()
-        }
-        url = self.config.data['podHost'] + \
-              '/pod/v1/room/{0}/setActive?active={1}'.format(stream_id, active)
-        response = requests.post(
-            url, headers=headers, proxies=self.proxies
-        )
-        if response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.deactivate_room(stream_id, active=False)
+        logging.debug('StreamClient/activate_room()')
+        url = '/pod/v1/room/{0}/setActive?active={1}'.format(stream_id, active)
+        return self.bot_client.execute_rest_call('POST', url)
 
     def get_room_members(self, stream_id):
         logging.debug('StreamClient/get_room_members()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token()
-        }
-        url = self.config.data['podHost'] + \
-              '/pod/v2/room/{0}/membership/list'.format(stream_id)
-        response = requests.get(
-            url, headers=headers, proxies=self.proxies
-        )
-        if response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.get_room_members(stream_id)
+        url = '/pod/v2/room/{0}/membership/list'.format(stream_id)
+        return self.bot_client.execute_rest_call('GET', url)
 
     def add_member_to_room(self, stream_id, user_id):
         logging.debug('StreamClient/addMember()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token()
-        }
-        url = self.config.data['podHost'] + \
-              '/pod/v1/room/{0}/membership/add'.format(stream_id)
+        url = '/pod/v1/room/{0}/membership/add'.format(stream_id)
         data = {'id': user_id}
-        response = requests.post(
-            url, headers=headers, json=data, proxies=self.proxies
-        )
-        if response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.add_member_to_room(stream_id, user_id)
+        return self.bot_client.execute_rest_call('POST', url, json=data)
 
     # contains sample data dictionary for example --> see documentation for
     # further detail
     def share_room(self, stream_id):
         logging.debug('StreamClient/share_room()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token(),
-            'keyManagerToken': self.bot_client.get_sym_auth().get_key_manager_token()
-        }
-        url = self.config.data['agentHost'] + \
-              '/agent/v3/stream/{0}/share'.format(stream_id)
+        url = '/agent/v3/stream/{0}/share'.format(stream_id)
         data = {
             "type": "com.symphony.sharing.article",
             "content":{
@@ -214,100 +90,36 @@ class StreamClient(APIClient):
                 "appIconUrl": "https://apps-dev.symphony.com/ticker/assets/images/logo.png"
             }
         }
-        response = requests.post(
-            url, headers=headers, json=data, proxies=self.proxies
-        )
-        if response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.share_room(stream_id)
+        return self.bot_client.execute_rest_call('POST', url, json=data)
 
     def remove_member_from_room(self, stream_id, user_id):
         logging.debug('StreamClient/removeMember()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token()
-        }
-        url = self.config.data['podHost'] + \
-              '/pod/v1/room/{0}/membership/remove'.format(stream_id)
+        url = '/pod/v1/room/{0}/membership/remove'.format(stream_id)
         data = {'id': user_id}
-        response = requests.post(
-            url, headers=headers, json=data, proxies=self.proxies
-        )
-        if response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.remove_member_from_room(stream_id, user_id)
+        return self.bot_client.execute_rest_call('POST', url, json=data)
 
     def promote_user_to_owner(self, stream_id, user_id):
         logging.debug('StreamClient/promoteOwner()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token()
-        }
-        url = self.config.data['podHost'] + \
-              '/pod/v1/room/{0}/membership/promoteOwner'.format(stream_id)
+        url = '/pod/v1/room/{0}/membership/promoteOwner'.format(stream_id)
         data = {'id': user_id}
-        response = requests.post(
-            url, headers=headers, json=data, proxies=self.proxies
-        )
-        if response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.promote_user_to_owner(stream_id, user_id)
+        return self.bot_client.execute_rest_call('POST', url, json=data)
 
     def demote_user_from_owner(self, stream_id, user_id):
         logging.debug('StreamClient/demoteOwner()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token()
-        }
-        url = self.config.data['podHost'] + \
-              '/pod/v1/room/{0}/membership/demoteOwner'.format(stream_id)
+        url = '/pod/v1/room/{0}/membership/demoteOwner'.format(stream_id)
         data = {'id': user_id}
-        response = requests.post(
-            url, headers=headers, json=data, proxies=self.proxies
-        )
-        if response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.demote_user_from_owner(stream_id, user_id)
+        return self.bot_client.execute_rest_call('POST', url, json=data)
 
     def search_rooms(self, skip=0, limit=50):
         logging.debug('StreamClient/roomSearch()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token()
-        }
-        url = self.config.data['podHost']+'/pod/v3/room/search'
+        url = '/pod/v3/room/search'
         params = {'skip': skip, 'limit':limit}
         data = {'query': 'butlahsroom'}
-        response = requests.post(
-            url, headers=headers, params=params, json=data,
-            proxies=self.proxies
-        )
-        if response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.search_rooms(skip=0, limit=50)
+        return self.bot_client.execute_rest_call('POST', url, params=params, json=data)
 
     def get_user_streams(self, skip=0, limit=50):
         logging.debug('StreamClient/listUserStreams()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token()
-        }
-        url = self.config.data['podHost']+'/pod/v1/streams/list'
+        url = '/pod/v1/streams/list'
         data = {
             "streamTypes": [
                 {"type": "IM"},
@@ -317,41 +129,16 @@ class StreamClient(APIClient):
             ],
             "includeInactiveStreams": True
         }
-        response = requests.post(
-            url, headers=headers, json=data, proxies=self.proxies
-        )
-        if response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.get_user_streams(skip=0, limit=50)
+        return self.bot_client.execute_rest_call('POST', url, json=data)
 
     def stream_info_v2(self, stream_id):
         logging.debug('StreamClient/stream_info_v2()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token()
-        }
-        url = self.config.data['podHost'] + \
-              '/pod/v2/streams/{0}/info'.format(stream_id)
-        response = requests.get(
-            url, headers=headers, proxies=self.proxies
-        )
-        if response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.stream_info_v2(stream_id)
+        url = '/pod/v2/streams/{0}/info'.format(stream_id)
+        return self.bot_client.execute_rest_call('GET', url)
 
     def list_streams_enterprise(self, skip=0, limit=50):
         logging.debug('StreamClient/list_streams_enterprise()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token()
-        }
-        url = self.config.data['podHost'] + '/pod/v1/admin/streams/list'
+        url = '/pod/v1/admin/streams/list'
         params = {'skip': skip, 'limit': limit}
         data = {
               "streamTypes": [{"type": "ROOM"}],
@@ -362,24 +149,11 @@ class StreamClient(APIClient):
               "startDate": 1481575056047,
               "endDate": 1483038089833
         }
-        response = requests.post(
-            url, headers=headers, params=params, json=data,
-            proxies=self.proxies
-        )
-        if response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.list_streams_enterprise()
+        return self.bot_client.execute_rest_call('POST', url, params=params, json=data)
 
     def list_streams_enterprise_v2(self, skip=0, limit=50):
         logging.debug('StreamClient/list_streams_enterprise_v2()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token()
-        }
-        url = self.config.data['podHost'] + '/pod/v2/admin/streams/list'
+        url = '/pod/v2/admin/streams/list'
         params = {'skip': skip, 'limit': limit}
         data = {
               "streamTypes": [{"type": "ROOM"}],
@@ -390,32 +164,9 @@ class StreamClient(APIClient):
               "startDate": 1481575056047,
               "endDate": 1483038089833
         }
-        response = requests.post(
-            url, headers=headers, params=params, json=data,
-            proxies=self.proxies
-        )
-        if response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.list_streams_enterprise_v2()
+        return self.bot_client.execute_rest_call('POST', url, params=params, json=data)
 
     def get_stream_members(self, stream_id, skip=0, limit=100):
         logging.debug('StreamClient/get_stream_members()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token()
-        }
-        url = self.config.data['podHost'] + \
-              '/pod/v1/admin/stream/{0}/membership/list'.format(stream_id)
-        response = requests.post(
-            url, headers=headers, proxies=self.proxies
-        )
-        if response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.get_stream_members(stream_id)
+        url = '/pod/v1/admin/stream/{0}/membership/list'.format(stream_id)
+        return self.bot_client.execute_rest_call('POST', url)

--- a/sym_api_client_python/clients/sym_bot_client.py
+++ b/sym_api_client_python/clients/sym_bot_client.py
@@ -1,5 +1,6 @@
 import requests
 import json
+import logging
 
 from .datafeed_client import DataFeedClient
 from ..datafeed_event_service import DataFeedEventService
@@ -71,10 +72,13 @@ class SymBotClient(APIClient):
         if self.pod_session is None:
             self.pod_session = requests.Session()
             self.pod_session.headers.update({'sessionToken' : self.auth.get_session_token()})
-            if (self.config.data['truststorePath'] and self.config.data['truststorePath'] is not ""):
+            if (self.config.data['truststorePath']):
+                logging.debug("Setting trusstorePath for pod to {}".format(self.config.data['truststorePath']))
                 self.pod_session.verify=self.config.data['truststorePath']
-            if self.config.data['proxyURL']:
-                self.pod_session.proxies.update({"http": self.config.data['proxyURL']})
+            if self.config.data['completeProxyURL']:
+                self.pod_session.proxies.update({
+                    "http": self.config.data['completeProxyURL'],
+                    "https": self.config.data['completeProxyURL']})
         return self.pod_session
 
     def get_agent_session(self):
@@ -84,11 +88,13 @@ class SymBotClient(APIClient):
                 {'sessionToken' : self.auth.get_session_token(), 
                 'keyManagerToken': self.auth.get_key_manager_token()
                 })
-            if (self.config.data['truststorePath'] and self.config.data['truststorePath'] is not ""):
+            if (self.config.data['truststorePath']):
+                logging.debug("Setting trusstorePath for agent to {}".format(self.config.data['truststorePath']))
                 self.agent_session.verify=self.config.data['truststorePath']
-                print("Setting trusstorePath to {}".format(self.config.data['truststorePath']))
-            if self.config.data['proxyURL']:
-                self.agent_session.proxies.update({"http": self.config.data['proxyURL']})
+            if self.config.data['completeProxyURL']:
+                self.agent_session.proxies.update({
+                    "http": self.config.data['completeProxyURL'],
+                    "https": self.config.data['completeProxyURL']})
         return self.agent_session
     
     def execute_rest_call(self, method, path, **kwargs):

--- a/sym_api_client_python/clients/sym_bot_client.py
+++ b/sym_api_client_python/clients/sym_bot_client.py
@@ -1,9 +1,13 @@
+import requests
+import json
+
 from .datafeed_client import DataFeedClient
 from ..datafeed_event_service import DataFeedEventService
 from .message_client import MessageClient
 from .stream_client import StreamClient
 from .api_client import APIClient
 from .user_client import UserClient
+from ..exceptions.UnauthorizedException import UnauthorizedException
 
 # SymBotClient class is the Client class that has access to all of the other
 # client classes upon initialization, SymBotClient class gets an instance of
@@ -14,7 +18,7 @@ from .user_client import UserClient
 # REST API calls
 
 
-class SymBotClient:
+class SymBotClient(APIClient):
 
     def __init__(self, auth, config):
         self.auth = auth
@@ -25,6 +29,8 @@ class SymBotClient:
         self.stream_client = None
         self.user_client = None
         self.api_client = None
+        self.pod_session = None
+        self.agent_session = None
 
     def get_datafeed_event_service(self):
         if self.datafeed_event_service is None:
@@ -59,3 +65,62 @@ class SymBotClient:
 
     def get_sym_auth(self):
         return self.auth
+
+    def get_pod_session(self):
+        if self.pod_session is None:
+            self.pod_session = requests.Session()
+            self.pod_session.headers.update({'sessionToken' : self.auth.get_session_token()})
+            if (self.config.data['truststorePath'] and self.config.data['truststorePath'] is not ""):
+                self.pod_session.verify=self.config.data['truststorePath']
+            if self.config.data['proxyURL']:
+                self.pod_session.proxies.update({"http": self.config.data['proxyURL']})
+        return self.pod_session
+
+    def get_agent_session(self):
+        if self.agent_session is None:
+            self.agent_session = requests.Session()
+            self.agent_session.headers.update(
+                {'sessionToken' : self.auth.get_session_token(), 
+                'keyManagerToken': self.auth.get_key_manager_token()
+                })
+            if (self.config.data['truststorePath'] and self.config.data['truststorePath'] is not ""):
+                self.agent_session.verify=self.config.data['truststorePath']
+                print("Setting trusstorePath to {}".format(self.config.data['truststorePath']))
+            if self.config.data['proxyURL']:
+                self.agent_session.proxies.update({"http": self.config.data['proxyURL']})
+        return self.agent_session
+    
+    def execute_rest_call(self, method, path, **kwargs):
+        results = None
+        url = None
+        session = None
+        if path.startswith("/agent/"):
+            url = self.config.data["agentHost"] + path
+            session = self.get_agent_session()
+        elif path.startswith("/pod/"):
+            url = self.config.data["sessionHost"] + path
+            session = self.get_pod_session()
+        else:
+            url = path
+        
+        response = session.request(method, url, **kwargs)
+        if response.status_code == 204:
+            results = []
+        elif response.status_code == 200:
+            results = json.loads(response.text)
+        else:
+            try:
+                super().handle_error(response, self)
+            except UnauthorizedException:
+                self.execute_rest_call(method, path, **kwargs)
+        return results
+
+    def reauth_client(self):
+        self.auth.authenticate()
+        if (self.pod_session is not None):
+            self.pod_session.headers.update({'sessionToken' : self.auth.get_session_token()})
+        if (self.agent_session is not None):
+            self.agent_session.headers.update(
+                {'sessionToken' : self.auth.get_session_token(), 
+                'keyManagerToken': self.auth.get_key_manager_token()
+                })

--- a/sym_api_client_python/clients/sym_bot_client.py
+++ b/sym_api_client_python/clients/sym_bot_client.py
@@ -31,6 +31,7 @@ class SymBotClient(APIClient):
         self.api_client = None
         self.pod_session = None
         self.agent_session = None
+        self.bot_user_info = None
 
     def get_datafeed_event_service(self):
         if self.datafeed_event_service is None:
@@ -98,7 +99,7 @@ class SymBotClient(APIClient):
             url = self.config.data["agentHost"] + path
             session = self.get_agent_session()
         elif path.startswith("/pod/"):
-            url = self.config.data["sessionHost"] + path
+            url = self.config.data["podHost"] + path
             session = self.get_pod_session()
         else:
             url = path
@@ -124,3 +125,8 @@ class SymBotClient(APIClient):
                 {'sessionToken' : self.auth.get_session_token(), 
                 'keyManagerToken': self.auth.get_key_manager_token()
                 })
+
+    def get_bot_user_info(self):
+        if (self.bot_user_info is None):
+            self.bot_user_info = self.get_user_client().get_session_user()
+        return self.bot_user_info

--- a/sym_api_client_python/clients/user_client.py
+++ b/sym_api_client_python/clients/user_client.py
@@ -95,7 +95,7 @@ class UserClient(APIClient):
             try:
                 super().handle_error(response, self.bot_client)
             except UnauthorizedException:
-                self.get_users_from_id_list(id_list)
+                self.get_users_from_id_list(user_id_list)
 
     def get_users_from_email_list(self, email_list, local=False):
         logging.debug('UserClient/get_users_from_email_list()')

--- a/sym_api_client_python/clients/user_client.py
+++ b/sym_api_client_python/clients/user_client.py
@@ -31,7 +31,7 @@ class UserClient(APIClient):
         return self.bot_client.execute_rest_call('GET', url, params=params)
 
     def get_user_from_id(self, user_id, local=False):
-        logging.debug('UserClient/get_user_from_id')
+        logging.debug('UserClient/get_user_from_id()')
         url = '/pod/v2/user'
         params = {'uid': user_id, 'local':local}
         return self.bot_client.execute_rest_call('GET', url, params=params)

--- a/sym_api_client_python/clients/user_client.py
+++ b/sym_api_client_python/clients/user_client.py
@@ -57,3 +57,7 @@ class UserClient(APIClient):
         params = {'local': local, 'skip': skip, 'limit': limit}
         data = {'query':query, 'filters': filters}
         return self.bot_client.execute_rest_call('GET', url, params=params, json=data)
+
+    def get_session_user(self):
+        logging.debug('UserClient/get_session_user()')
+        url = ''

--- a/sym_api_client_python/clients/user_client.py
+++ b/sym_api_client_python/clients/user_client.py
@@ -60,4 +60,5 @@ class UserClient(APIClient):
 
     def get_session_user(self):
         logging.debug('UserClient/get_session_user()')
-        url = ''
+        url = '/pod/v2/sessioninfo'
+        return self.bot_client.execute_rest_call('GET', url)

--- a/sym_api_client_python/clients/user_client.py
+++ b/sym_api_client_python/clients/user_client.py
@@ -17,125 +17,43 @@ class UserClient(APIClient):
 
     def __init__(self, bot_client):
         self.bot_client = bot_client
-        self.config = self.bot_client.get_sym_config()
-        if self.config.data['proxyURL']:
-            self.proxies = {"https": self.config.data['proxyURL']}
-        else:
-            self.proxies = {}
 
     def get_user_from_user_name(self, user_name):
         logging.debug('UserClient/get_user_from_user_name()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token()
-        }
-        url = self.config.data['podHost']+'/pod/v2/user'
+        url = '/pod/v2/user'
         params = {'username': user_name}
-        response = requests.get(
-            url, headers=headers, params=params, proxies=self.proxies
-        )
-        if response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.get_user_from_user_name(user_name)
+        return self.bot_client.execute_rest_call('GET', url, params=params)
 
     def get_user_from_email(self, email, local=False):
         logging.debug('UserClient/get_user_from_email()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token()
-        }
-        url = self.config.data['podHost']+'/pod/v2/user'
+        url = '/pod/v2/user'
         params = {'email': email, 'local':local}
-        response = requests.get(
-            url, headers=headers, params=params, proxies=self.proxies
-        )
-        if response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.get_user_from_email(email)
+        return self.bot_client.execute_rest_call('GET', url, params=params)
 
     def get_user_from_id(self, user_id, local=False):
         logging.debug('UserClient/get_user_from_id')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token()
-        }
-        url = self.config.data['podHost']+'/pod/v2/user'
+        url = '/pod/v2/user'
         params = {'uid': user_id, 'local':local}
-        response = requests.get(
-            url, headers=headers, params=params, proxies=self.proxies
-        )
-        if response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.get_user_from_id(user_id)
+        return self.bot_client.execute_rest_call('GET', url, params=params)
 
     def get_users_from_id_list(self, user_id_list, local=False):
         logging.debug('UserClient/get_users_from_id_list()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token()
-        }
-        url = self.config.data['podHost']+'/pod/v3/users'
+        url = '/pod/v3/users'
         users_array = ','.join(map(str, user_id_list))
         params = {'uid': users_array, 'local': local}
-        response = requests.get(
-            url, headers=headers, params=params, proxies=self.proxies
-        )
-        print(response.url)
-        if response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.get_users_from_id_list(user_id_list)
+        return self.bot_client.execute_rest_call('GET', url, params=params)
 
     def get_users_from_email_list(self, email_list, local=False):
         logging.debug('UserClient/get_users_from_email_list()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token()
-        }
-        url = self.config.data['podHost']+'/pod/v3/users'
+        url = '/pod/v3/users'
         usersArray = ','.join(map(str, email_list))
         print(usersArray)
         params = {'email': usersArray, 'local': local}
-        response = requests.get(
-            url, headers=headers, params=params, proxies=self.proxies
-        )
-        print(response.url)
-        if response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.get_users_from_email_list(email_list)
+        return self.bot_client.execute_rest_call('GET', url, params=params)
 
     def search_users(self, query, local=False, skip=0, limit=50, filters={}):
         logging.debug('UserClient/search_users()')
-        headers = {
-            'sessionToken': self.bot_client.get_sym_auth().get_session_token()
-        }
-        url = self.config.data['podHost']+'/pod/v1/user/search'
+        url = '/pod/v1/user/search'
         params = {'local': local, 'skip': skip, 'limit': limit}
         data = {'query':query, 'filters': filters}
-        response = requests.post(
-            url, headers=headers, params=params, json=data,
-            proxies=self.proxies
-        )
-        print(response.url)
-        if response.status_code == 200:
-            return json.loads(response.text)
-        else:
-            print(response.status_code)
-            try:
-                super().handle_error(response, self.bot_client)
-            except UnauthorizedException:
-                self.search_users(query, local, skip, limit)
+        return self.bot_client.execute_rest_call('GET', url, params=params, json=data)

--- a/sym_api_client_python/configure/configure.py
+++ b/sym_api_client_python/configure/configure.py
@@ -53,7 +53,7 @@ class SymConfig:
         logging.debug('SymConfig/build_proxy_url()')
         proxy_builder = ""
         if (self.data['proxyURL']):
-            proxy_builder = 'http://'
+            proxy_builder = ''
             if (self.data['proxyUsername']):
                 proxy_builder += self.data['proxyUsername']
                 if (self.data['proxyPassword']):

--- a/sym_api_client_python/configure/configure.py
+++ b/sym_api_client_python/configure/configure.py
@@ -23,6 +23,7 @@ class SymConfig:
             self.data['proxyPort'] = data['proxyPort']
             self.data['proxyUsername'] = data['proxyUsername']
             self.data['proxyPassword'] = data['proxyPassword']
+            self.data['truststorePath'] = data['truststorePath']
             read_file.close()
 
     # load Certificate configuration variables into SymConfig data
@@ -40,4 +41,5 @@ class SymConfig:
             self.data['proxyPort'] = data['proxyPort']
             self.data['proxyUsername'] = data['proxyUsername']
             self.data['proxyPassword'] = data['proxyPassword']
+            self.data['truststorePath'] = data['truststorePath']
             read_file.close()

--- a/sym_api_client_python/configure/configure.py
+++ b/sym_api_client_python/configure/configure.py
@@ -1,7 +1,6 @@
 import json
 import logging
 
-
 class SymConfig:
     # initialize object by passing in path to config file
     # store configuration data in variable data
@@ -21,7 +20,6 @@ class SymConfig:
             self.data['botUsername'] = data['botUsername']
             self.data['botEmailAddress'] = data['botEmailAddress']
             self.data['proxyURL'] = data['proxyURL']
-            self.data['proxyPort'] = data['proxyPort']
             self.data['proxyUsername'] = data['proxyUsername']
             self.data['proxyPassword'] = data['proxyPassword']
             self.data['truststorePath'] = data['truststorePath']
@@ -41,7 +39,6 @@ class SymConfig:
             self.data['botEmailAddress'] = data['botEmailAddress']
             self.data['p.12'] = data['botCertPath'] + data['botCertName']
             self.data['proxyURL'] = data['proxyURL']
-            self.data['proxyPort'] = data['proxyPort']
             self.data['proxyUsername'] = data['proxyUsername']
             self.data['proxyPassword'] = data['proxyPassword']
             self.data['truststorePath'] = data['truststorePath']
@@ -51,15 +48,18 @@ class SymConfig:
 
     def build_proxy_url(self):
         logging.debug('SymConfig/build_proxy_url()')
-        proxy_builder = ""
+        built_proxy_string = ''
         if (self.data['proxyURL']):
-            proxy_builder = ''
+            proxy_url = self.data['proxyURL']
+            proxy_user_password_string = ''
             if (self.data['proxyUsername']):
-                proxy_builder += self.data['proxyUsername']
+                proxy_user_password_string = self.data['proxyUsername']
                 if (self.data['proxyPassword']):
-                    proxy_builder += ':' + self.data['proxyPassword']
-                proxy_builder += '@' + self.data['proxyURL']
-                if(self.data['proxyPort']):
-                    proxy_builder += ':' + self.data['proxyPort']
-        logging.debug('Proxy is set to: ' + proxy_builder)
-        return proxy_builder
+                    proxy_user_password_string += ':' + self.data['proxyPassword']
+                proxy_user_password_string += '@'
+            hostname_index = self.data['proxyURL'].find("://")
+            if (hostname_index != -1):
+                hostname_index += 3
+                built_proxy_string = proxy_url[:hostname_index] + proxy_user_password_string + proxy_url[hostname_index:]
+        logging.debug('Proxy is set to: ' + built_proxy_string)
+        return built_proxy_string

--- a/sym_api_client_python/configure/configure.py
+++ b/sym_api_client_python/configure/configure.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 
 class SymConfig:
@@ -24,6 +25,8 @@ class SymConfig:
             self.data['proxyUsername'] = data['proxyUsername']
             self.data['proxyPassword'] = data['proxyPassword']
             self.data['truststorePath'] = data['truststorePath']
+            self.data['completeProxyURL'] = self.build_proxy_url()
+            
             read_file.close()
 
     # load Certificate configuration variables into SymConfig data
@@ -42,4 +45,21 @@ class SymConfig:
             self.data['proxyUsername'] = data['proxyUsername']
             self.data['proxyPassword'] = data['proxyPassword']
             self.data['truststorePath'] = data['truststorePath']
+            self.data['completeProxyURL'] = self.build_proxy_url()
+
             read_file.close()
+
+    def build_proxy_url(self):
+        logging.debug('SymConfig/build_proxy_url()')
+        proxy_builder = ""
+        if (self.data['proxyURL']):
+            proxy_builder = 'http://'
+            if (self.data['proxyUsername']):
+                proxy_builder += self.data['proxyUsername']
+                if (self.data['proxyPassword']):
+                    proxy_builder += ':' + self.data['proxyPassword']
+                proxy_builder += '@' + self.data['proxyURL']
+                if(self.data['proxyPort']):
+                    proxy_builder += ':' + self.data['proxyPort']
+        logging.debug('Proxy is set to: ' + proxy_builder)
+        return proxy_builder

--- a/sym_api_client_python/datafeed_event_service.py
+++ b/sym_api_client_python/datafeed_event_service.py
@@ -84,7 +84,7 @@ class DataFeedEventService:
     # to proper handling function there is a handle_event function that
     # corresponds to each eventType
     def handle_event(self, payload):
-        print('event handler')
+        logging.debug('DataFeedEventService/handle_event()')
         event_type = str(payload['type'])
         if event_type == 'MESSAGESENT':
             self.msg_sent_handler(payload)

--- a/sym_api_client_python/datafeed_event_service.py
+++ b/sym_api_client_python/datafeed_event_service.py
@@ -64,8 +64,8 @@ class DataFeedEventService:
                             events[0]['payload'])
                     )
                     for event in events:
-                        if event['initiator']['user']['email'] != \
-                                self.bot_client.config.data['botEmailAddress']:
+                        if event['initiator']['user']['userId'] != \
+                                self.bot_client.get_bot_user_info()['id']:
                             self.handle_event(event)
                 else:
                     logging.debug(


### PR DESCRIPTION
Moved over requests to sessions for consistent headers, proxies and truststore
Fixed auth using sessionAuth for both sessionAuth and keyAuth
Fixed functions that prepopulated payload to accept params
Datafeed now utilizes session user to determine userId