### PR TITLE
APP-2935: fixed relative paths in unit tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,8 +22,10 @@ idna~=2.9
 urllib3~=1.25.9
 certifi~=2020.4.5.2
 cffi~=1.14.0
-jose~=1.0.0
+python-jose~=3.2.0
 requests~=2.24.0
 soupsieve~=2.0.1
 setuptools~=47.3.1
 aioresponses~=0.6.4
+pytest~=6.0.1
+

--- a/setup.py
+++ b/setup.py
@@ -5,17 +5,6 @@ def readme():
     with open('README.md') as f:
         return f.read()
 
-test_dependencies = [
-    'pytest',
-]
-
-# This means dependencies for testing can be installed with:
-# pip install .[test]
-# See this Stackoverflow answer for details
-# https://stackoverflow.com/a/41398850
-extras = {
-    "test": test_dependencies,
-}
 
 setuptools.setup(
     name="sym_api_client_python",
@@ -35,7 +24,7 @@ setuptools.setup(
         'pyOpenSSL',
         'rsa',
         'requests',
-        'python-jose',
+        'python-jose~=3.2.0',
         'python-json-logger==0.1.11',
         'beautifulsoup4==4.8.0',
         'Jinja2==2.10.1',
@@ -45,7 +34,7 @@ setuptools.setup(
         'yattag==1.12.2',
         'defusedxml==0.6.0'
     ],
-    extras_require=extras,
+    tests_require=['pytest'],
     include_package_data=True,
     classifiers=(
         "Programming Language :: Python :: 3.6",

--- a/tests/clients/api/test_datafeed_client_v2.py
+++ b/tests/clients/api/test_datafeed_client_v2.py
@@ -8,6 +8,7 @@ from sym_api_client_python.clients.sym_bot_client import SymBotClient
 from sym_api_client_python.configure.configure import SymConfig
 
 
+@patch('sym_api_client_python.clients.sym_bot_client.requests.sessions.Session.request')
 class TestDataFeedClientV2(unittest.TestCase):
     def setUp(self):
         configure = SymConfig(get_path_relative_to_resources_folder('./bot-config.json'))
@@ -18,21 +19,19 @@ class TestDataFeedClientV2(unittest.TestCase):
 
         self.datafeed_client = bot_client.get_datafeed_client()
 
-    def test_create_datafeed(self):
-        with patch('sym_api_client_python.clients.sym_bot_client.requests.sessions.Session.request') as mock_request:
-            mock_response, url_call = mocked_response('CREATE_DATAFEED', self.datafeed_client.config.data['agentHost'])
-            mock_request.return_value = mock_response
-            datafeed_id = self.datafeed_client.create_datafeed()
+    def test_create_datafeed(self, mock_request):
+        mock_response, url_call = mocked_response('CREATE_DATAFEED', self.datafeed_client.config.data['agentHost'])
+        mock_request.return_value = mock_response
+        datafeed_id = self.datafeed_client.create_datafeed()
 
         self.assertEqual(mock_response.status_code, 201)
         self.assertEqual(datafeed_id, '21449143d35a86461e254d28697214b4_f')
         mock_request.assert_called_with('POST', url_call)
 
-    def test_list_datafeed(self):
-        with patch('sym_api_client_python.clients.sym_bot_client.requests.sessions.Session.request') as mock_request:
-            mock_response, url_call = mocked_response('LIST_DATAFEED', self.datafeed_client.config.data['agentHost'])
-            mock_request.return_value = mock_response
-            datafeed_ids = self.datafeed_client.list_datafeed_id()
+    def test_list_datafeed(self, mock_request):
+        mock_response, url_call = mocked_response('LIST_DATAFEED', self.datafeed_client.config.data['agentHost'])
+        mock_request.return_value = mock_response
+        datafeed_ids = self.datafeed_client.list_datafeed_id()
 
         self.assertEqual(mock_response.status_code, 200)
         self.assertEqual(datafeed_ids[0]['id'], mock_response.get_json()[0]['id'])
@@ -40,47 +39,44 @@ class TestDataFeedClientV2(unittest.TestCase):
         self.assertEqual(datafeed_ids[2]['id'], mock_response.get_json()[2]['id'])
         mock_request.assert_called_with('GET', url_call)
 
-    def test_read_datafeed_empty_ackid(self):
+    def test_read_datafeed_empty_ackid(self, mock_request):
         """Test Datafeed Read first call conversation
 
         Test of handling of ackId when not provided to read_datafeed and call of the function with the right parameters"""
-        with patch('sym_api_client_python.clients.sym_bot_client.requests.sessions.Session.request') as mock_request:
-            mock_response, url_call = mocked_response('READ_DATAFEED', self.datafeed_client.config.data['agentHost'],
-                                                      'test_datafeed_id')
-            mock_request.return_value = mock_response
-            events = self.datafeed_client.read_datafeed('test_datafeed_id')
-            ack_id = self.datafeed_client.datafeed_client.get_ack_id()
+        mock_response, url_call = mocked_response('READ_DATAFEED', self.datafeed_client.config.data['agentHost'],
+                                                  'test_datafeed_id')
+        mock_request.return_value = mock_response
+        events = self.datafeed_client.read_datafeed('test_datafeed_id')
+        ack_id = self.datafeed_client.datafeed_client.get_ack_id()
 
         self.assertEqual(mock_response.status_code, 200)
         self.assertEqual(ack_id, mock_response.get_json()['ackId'])
         self.assertEqual(events, mock_response.get_json()['events'])
         mock_request.assert_called_with('POST', url_call, json={'ackId': ''})
 
-    def test_read_datafeed(self):
+    def test_read_datafeed(self, mock_request):
         """Test a datafeed read during conversation
 
         Testing the handling of the ackId when provided to read_datafeed() and call of the function with the right parameters """
-        with patch('sym_api_client_python.clients.sym_bot_client.requests.sessions.Session.request') as mock_request:
-            mock_response, url_call = mocked_response('READ_DATAFEED', self.datafeed_client.config.data['agentHost'],
-                                                      'test_datafeed_id')
-            mock_request.return_value = mock_response
-            events = self.datafeed_client.read_datafeed('test_datafeed_id', 'test_ack_id')
-            ack_id = self.datafeed_client.datafeed_client.get_ack_id()
+        mock_response, url_call = mocked_response('READ_DATAFEED', self.datafeed_client.config.data['agentHost'],
+                                                  'test_datafeed_id')
+        mock_request.return_value = mock_response
+        events = self.datafeed_client.read_datafeed('test_datafeed_id', 'test_ack_id')
+        ack_id = self.datafeed_client.datafeed_client.get_ack_id()
 
         self.assertEqual(mock_response.status_code, 200)
         self.assertEqual(ack_id, mock_response.get_json()['ackId'])
         self.assertEqual(events, mock_response.get_json()['events'])
         mock_request.assert_called_with('POST', url_call, json={'ackId': 'test_ack_id'})
 
-    def test_delete_datafeed(self):
+    def test_delete_datafeed(self, mock_request):
         """Test deleting the datafeed
 
         Because it's a no content response, we need to make sure of the call parameters """
-        with patch('sym_api_client_python.clients.sym_bot_client.requests.sessions.Session.request') as mock_request:
-            mock_response, url_call = mocked_response('DELETE_DATAFEED', self.datafeed_client.config.data['agentHost'],
-                                                      'test_datafeed_id')
-            mock_request.return_value = mock_response
-            self.datafeed_client.delete_datafeed('test_datafeed_id')
+        mock_response, url_call = mocked_response('DELETE_DATAFEED', self.datafeed_client.config.data['agentHost'],
+                                                  'test_datafeed_id')
+        mock_request.return_value = mock_response
+        self.datafeed_client.delete_datafeed('test_datafeed_id')
 
         self.assertEqual(mock_response.status_code, 204)
         mock_request.assert_called_with('DELETE', url_call)

--- a/tests/clients/api/test_datafeed_client_v2.py
+++ b/tests/clients/api/test_datafeed_client_v2.py
@@ -1,133 +1,136 @@
-import pytest
-from unittest.mock import patch
 import json
 import os
+import unittest
+from unittest.mock import patch
 
-from sym_api_client_python.clients.sym_bot_client import SymBotClient
 from sym_api_client_python.auth.rsa_auth import SymBotRSAAuth
+from sym_api_client_python.clients.sym_bot_client import SymBotClient
 from sym_api_client_python.configure.configure import SymConfig
 
 
-@pytest.fixture
-def datafeed_client():
-    configure = SymConfig('./tests/resources/bot-config.json', __file__)
-    configure.load_config()
-    configure.data["datafeedVersion"] = "v2"
+class TestDataFeedClientV2(unittest.TestCase):
+    def setUp(self):
+        configure = SymConfig(get_path_relative_to_resources_folder('./bot-config.json'))
+        configure.load_config()
+        configure.data['datafeedVersion'] = 'v2'
 
-    # auth = SymBotRSAAuth(configure)
-    auth = SymBotRSAAuth(configure)
-    auth.session_token = "eyJhbGciOiJSUzUxMiJ9.eyJzdWIiOiJ0ZXN0LWJvdCIsImlzcyI6InN5bXBob255Iiwic2Vzc2lvbklkIjoiZmRiOTAxMmQzOTgwMGE3NzNkMTJjYWFmZGY5MjU4ZjZjOWEyMTE2MmYyZDU1ODQ3M2Y5ZDU5MDUyNjA0Mjg1ZjU0MWM5Yzg0Mzc5YTE0MjZmODNiZmZkZTljYmQ5NjRjMDAwMDAxNmRmMjMyODIwNTAwMDEzZmYwMDAwMDAxZTgiLCJ1c2VySWQiOiIzNTE3NzUwMDE0MTIwNzIifQ.DlQ_-sAqZLlAcVTr7t_PaYt_Muq_P82yYrtbEEZWMpHMl-7qCciwfi3uXns7oRbc1uvOrhQd603VKQJzQxaZBZBVlUPS-2ysH0tBpCS57ocTS6ZwtQwPLCZYdT-EZ70EzQ95kG6P5TrLENH6UveohgeDdmyzSPOEiwyEUjjmzaXFE8Tu0R3xQDwl-BKbsyUAAgd1X7T0cUDC3WIDl9xaTvyxavep4ZJnZJl4qPc1Tan0yU7JrxtXeD8uwNYlKLudT3UVxduFPMQP_2jyj5Laa-YWGKvRtXkcy2d3hzf4ll1l1wVnyJc1e6hW2EnRlff_Nxge-QCJMcZ_ALrpOUtAyQ"
+        bot_client = SymBotClient(SymBotRSAAuth(configure), configure)
 
-    # Initialize SymBotClient with auth and configure objects
-    bot_client = SymBotClient(auth, configure)
+        self.datafeed_client = bot_client.get_datafeed_client()
 
-    # Initialize datafeed service
-    datafeed_client = bot_client.get_datafeed_client()
-    return datafeed_client
+    def test_create_datafeed(self):
+        with patch('sym_api_client_python.clients.sym_bot_client.requests.sessions.Session.request') as mock_request:
+            mock_response, url_call = mocked_response('CREATE_DATAFEED', self.datafeed_client.config.data['agentHost'])
+            mock_request.return_value = mock_response
+            datafeed_id = self.datafeed_client.create_datafeed()
+
+        self.assertEqual(mock_response.status_code, 201)
+        self.assertEqual(datafeed_id, '21449143d35a86461e254d28697214b4_f')
+        mock_request.assert_called_with('POST', url_call)
+
+    def test_list_datafeed(self):
+        with patch('sym_api_client_python.clients.sym_bot_client.requests.sessions.Session.request') as mock_request:
+            mock_response, url_call = mocked_response('LIST_DATAFEED', self.datafeed_client.config.data['agentHost'])
+            mock_request.return_value = mock_response
+            datafeed_ids = self.datafeed_client.list_datafeed_id()
+
+        self.assertEqual(mock_response.status_code, 200)
+        self.assertEqual(datafeed_ids[0]['id'], mock_response.get_json()[0]['id'])
+        self.assertEqual(datafeed_ids[1]['id'], mock_response.get_json()[1]['id'])
+        self.assertEqual(datafeed_ids[2]['id'], mock_response.get_json()[2]['id'])
+        mock_request.assert_called_with('GET', url_call)
+
+    def test_read_datafeed_empty_ackid(self):
+        """Test Datafeed Read first call conversation
+
+        Test of handling of ackId when not provided to read_datafeed and call of the function with the right parameters"""
+        with patch('sym_api_client_python.clients.sym_bot_client.requests.sessions.Session.request') as mock_request:
+            mock_response, url_call = mocked_response('READ_DATAFEED', self.datafeed_client.config.data['agentHost'],
+                                                      'test_datafeed_id')
+            mock_request.return_value = mock_response
+            events = self.datafeed_client.read_datafeed('test_datafeed_id')
+            ack_id = self.datafeed_client.datafeed_client.get_ack_id()
+
+        self.assertEqual(mock_response.status_code, 200)
+        self.assertEqual(ack_id, mock_response.get_json()['ackId'])
+        self.assertEqual(events, mock_response.get_json()['events'])
+        mock_request.assert_called_with('POST', url_call, json={'ackId': ''})
+
+    def test_read_datafeed(self):
+        """Test a datafeed read during conversation
+
+        Testing the handling of the ackId when provided to read_datafeed() and call of the function with the right parameters """
+        with patch('sym_api_client_python.clients.sym_bot_client.requests.sessions.Session.request') as mock_request:
+            mock_response, url_call = mocked_response('READ_DATAFEED', self.datafeed_client.config.data['agentHost'],
+                                                      'test_datafeed_id')
+            mock_request.return_value = mock_response
+            events = self.datafeed_client.read_datafeed('test_datafeed_id', 'test_ack_id')
+            ack_id = self.datafeed_client.datafeed_client.get_ack_id()
+
+        self.assertEqual(mock_response.status_code, 200)
+        self.assertEqual(ack_id, mock_response.get_json()['ackId'])
+        self.assertEqual(events, mock_response.get_json()['events'])
+        mock_request.assert_called_with('POST', url_call, json={'ackId': 'test_ack_id'})
+
+    def test_delete_datafeed(self):
+        """Test deleting the datafeed
+
+        Because it's a no content response, we need to make sure of the call parameters """
+        with patch('sym_api_client_python.clients.sym_bot_client.requests.sessions.Session.request') as mock_request:
+            mock_response, url_call = mocked_response('DELETE_DATAFEED', self.datafeed_client.config.data['agentHost'],
+                                                      'test_datafeed_id')
+            mock_request.return_value = mock_response
+            self.datafeed_client.delete_datafeed('test_datafeed_id')
+
+        self.assertEqual(mock_response.status_code, 204)
+        mock_request.assert_called_with('DELETE', url_call)
 
 
-def test_create_datafeed(datafeed_client):
-    with patch('sym_api_client_python.clients.sym_bot_client.requests.sessions.Session.request') as mock_request:
-        mock_response, url_call = mocked_response('CREATE_DATAFEED', datafeed_client.config.data["agentHost"])
-        mock_request.return_value = mock_response
-        datafeed_id = datafeed_client.create_datafeed()
+def get_path_relative_to_resources_folder(path_relative_to_resources):
+    path_to_resources = os.path.join(os.path.dirname(__file__), '../../resources/', path_relative_to_resources)
+    return os.path.normpath(path_to_resources)
 
-    assert mock_response.status_code == 201
-    assert datafeed_id == "21449143d35a86461e254d28697214b4_f"
-
-    mock_request.assert_called_with("POST", url_call)
-
-
-def test_list_datafeed(datafeed_client):
-    with patch('sym_api_client_python.clients.sym_bot_client.requests.sessions.Session.request') as mock_request:
-        mock_response, url_call = mocked_response('LIST_DATAFEED', datafeed_client.config.data["agentHost"])
-        mock_request.return_value = mock_response
-        datafeed_ids = datafeed_client.list_datafeed_id()
-
-    assert mock_response.status_code == 200
-    assert datafeed_ids[0]["id"] == mock_response.get_json()[0]["id"]
-    assert datafeed_ids[1]["id"] == mock_response.get_json()[1]["id"]
-    assert datafeed_ids[2]["id"] == mock_response.get_json()[2]["id"]
-    mock_request.assert_called_with("GET", url_call)
-
-def test_read_datafeed_empty_ackid(datafeed_client):
-    """Test Datafeed Read first call conversation
-
-    Test of handling of ackId when not provided to read_datafeed and call of the function with the right parameters"""
-    with patch('sym_api_client_python.clients.sym_bot_client.requests.sessions.Session.request') as mock_request:
-        mock_response, url_call = mocked_response('READ_DATAFEED', datafeed_client.config.data["agentHost"], "test_datafeed_id")
-        mock_request.return_value = mock_response
-        events = datafeed_client.read_datafeed("test_datafeed_id")
-        ack_id = datafeed_client.datafeed_client.get_ack_id()
-
-    assert mock_response.status_code == 200
-    assert ack_id == mock_response.get_json()["ackId"]
-    assert events == mock_response.get_json()["events"]
-    mock_request.assert_called_with("POST", url_call, json={'ackId': ''})
-
-def test_read_datafeed(datafeed_client):
-    """Test a datafeed read during conversation
-
-    Testing the handling of the ackId when provided to read_datafeed() and call of the function with the right parameters """
-    with patch('sym_api_client_python.clients.sym_bot_client.requests.sessions.Session.request') as mock_request:
-        mock_response, url_call = mocked_response('READ_DATAFEED', datafeed_client.config.data["agentHost"], "test_datafeed_id")
-        mock_request.return_value = mock_response
-        events = datafeed_client.read_datafeed("test_datafeed_id", "test_ack_id")
-        ack_id = datafeed_client.datafeed_client.get_ack_id()
-
-    assert mock_response.status_code == 200
-    assert ack_id == mock_response.get_json()["ackId"]
-    assert events == mock_response.get_json()["events"]
-    mock_request.assert_called_with("POST", url_call, json={'ackId': 'test_ack_id'})
-
-def test_delete_datafeed(datafeed_client):
-    """Test deleting the datafeed
-
-    Because it's a no content response, we need to make sure of the call parameters """
-    with patch('sym_api_client_python.clients.sym_bot_client.requests.sessions.Session.request') as mock_request:
-        mock_response, url_call = mocked_response('DELETE_DATAFEED', datafeed_client.config.data["agentHost"], "test_datafeed_id")
-        mock_request.return_value = mock_response
-        datafeed_client.delete_datafeed("test_datafeed_id")
-
-    assert mock_response.status_code == 204 # no content
-    mock_request.assert_called_with("DELETE", url_call)
 
 def url_method_builder(base_url, url):
     return base_url + url
 
+
 # This method will be used by the mock to replace Session.request
 def mocked_response(agent_call, agent_host, *datafeed_id):
     if agent_call == 'CREATE_DATAFEED':
-        return MockResponse(201, "./tests/resources/response_content/datafeed_v2/create_datafeed_v2.json"), url_method_builder(agent_host, '/agent/v5/datafeeds')
+        return MockResponse(201, get_path_relative_to_resources_folder('./response_content/datafeed_v2/create_datafeed_v2.json')), \
+               url_method_builder(agent_host, '/agent/v5/datafeeds')
     elif agent_call == 'LIST_DATAFEED':
-        return MockResponse(200, "./tests/resources/response_content/datafeed_v2/list_datafeed_v2.json"), url_method_builder(agent_host, '/agent/v5/datafeeds')
+        return MockResponse(200, get_path_relative_to_resources_folder('./response_content/datafeed_v2/list_datafeed_v2.json')), \
+               url_method_builder(agent_host, '/agent/v5/datafeeds')
     elif agent_call == 'READ_DATAFEED':
         if len(datafeed_id) == 0:
-            raise ValueError("If datafeed id is provided, it should not be empty")
+            raise ValueError('If datafeed id is provided, it should not be empty')
         else:
-            return MockResponse(200, "./tests/resources/response_content/datafeed_v2/read_datafeed_v2.json"), url_method_builder(agent_host, '/agent/v5/datafeeds/{0}/read'.format(datafeed_id[0]))
+            return MockResponse(200, get_path_relative_to_resources_folder('./response_content/datafeed_v2/read_datafeed_v2.json')), \
+                   url_method_builder(agent_host, '/agent/v5/datafeeds/{0}/read'.format(datafeed_id[0]))
     elif agent_call == 'DELETE_DATAFEED':
         if len(datafeed_id) == 0:
-            raise ValueError("If datafeed id is provided, it should not be empty")
+            raise ValueError('If datafeed id is provided, it should not be empty')
         else:
-            return MockResponse(204, ""), url_method_builder(agent_host, '/agent/v5/datafeeds/{0}'.format(datafeed_id[0]))
+            return MockResponse(204, ''), url_method_builder(agent_host,
+                                                             '/agent/v5/datafeeds/{0}'.format(datafeed_id[0]))
     else:
         return MockResponse(None, 404)
-
 
 
 class MockResponse:
     def __init__(self, status_code, path):
         self.status_code = status_code
         if len(path) == 0:
-            self.data = ""
+            self.data = ''
         else:
             with open(os.path.realpath(path)) as json_file:
                 self.data = json.load(json_file)
         self.text = json.dumps(self.data)
+
     def get_json(self):
         return self.data
 
     def get_text(self):
         return json.dumps(self.data)
-

--- a/tests/clients/test_datafeed_client.py
+++ b/tests/clients/test_datafeed_client.py
@@ -1,51 +1,40 @@
-import pytest
+import os
+import unittest
 from unittest.mock import patch
 
-from sym_api_client_python.configure.configure import SymConfig
 from sym_api_client_python.clients.datafeed_client import DataFeedClient
 from sym_api_client_python.clients.datafeed_client_v1 import DataFeedClientV1
 from sym_api_client_python.clients.datafeed_client_v2 import DataFeedClientV2
+from sym_api_client_python.configure.configure import SymConfig
 
 
-@pytest.fixture
-def config():
-    configure = SymConfig('./tests/resources/bot-config.json', __file__)
-    configure.load_config()
-    return configure
+class TestDataFeedClient(unittest.TestCase):
+    def setUp(self):
+        self.config = SymConfig(get_path_relative_to_resources_folder('./bot-config.json'))
+        self.config.load_config()
+
+    @patch('sym_api_client_python.clients.sym_bot_client.SymBotClient', autospec=True)
+    def test_datafeed_client_v1(self, mock_client):
+        self.assert_configured_df_version_leads_to_df_client_type('v1', DataFeedClientV1)
+
+    @patch('sym_api_client_python.clients.sym_bot_client.SymBotClient', autospec=True)
+    def test_datafeed_client_v2(self, mock_client):
+        self.assert_configured_df_version_leads_to_df_client_type('v2', DataFeedClientV2)
+
+    @patch('sym_api_client_python.clients.sym_bot_client.SymBotClient', autospec=True)
+    def test_datafeed_client_wrong_version(self, mock_client):
+        self.assert_configured_df_version_leads_to_df_client_type('25', DataFeedClientV1)
+
+    def assert_configured_df_version_leads_to_df_client_type(self, datafeed_version, expected_class):
+        with patch('sym_api_client_python.clients.sym_bot_client.SymBotClient') as mock_client:
+            self.config.data['datafeedVersion'] = datafeed_version
+            mock_client.get_sym_config.return_value = self.config
+            datafeed_client = DataFeedClient(mock_client)
+
+            self.assertIsInstance(datafeed_client.datafeed_client, expected_class)
 
 
-@patch('sym_api_client_python.clients.sym_bot_client.SymBotClient', autospec=True)
-def test_datafeed_client_v1(mock_client, config):
-    config.data["datafeedVersion"] = "v1"
-
-    mock_client.get_sym_config.return_value = config
-
-    # Initialize datafeed client
-    datafeed_client = DataFeedClient(mock_client)
-
-    assert isinstance(datafeed_client.datafeed_client, DataFeedClientV1) == True
-
-@patch('sym_api_client_python.clients.sym_bot_client.SymBotClient', autospec=True)
-def test_datafeed_client_v2(mock_client, config):
-    config.data["datafeedVersion"] = "v2"
-
-    mock_client.get_sym_config.return_value = config
-
-    # Initialize datafeed client
-    datafeed_client = DataFeedClient(mock_client)
-    print(datafeed_client.datafeed_client)
-    assert isinstance(datafeed_client.datafeed_client, DataFeedClientV2) == True
-
-@patch('sym_api_client_python.clients.sym_bot_client.SymBotClient', autospec=True)
-def test_datafeed_client_wrong_version(mock_client, config):
-    config.data["datafeed_version"] = 25
-
-    mock_client.get_sym_config.return_value = config
-
-    # Initialize datafeed client
-    datafeed_client = DataFeedClient(mock_client)
-
-    assert isinstance(datafeed_client.datafeed_client, DataFeedClientV1) == True
-
-
+def get_path_relative_to_resources_folder(path_relative_to_resources):
+    path_to_resources = os.path.join(os.path.dirname(__file__), '../resources/', path_relative_to_resources)
+    return os.path.normpath(path_to_resources)
 

--- a/tests/clients/test_datafeed_client.py
+++ b/tests/clients/test_datafeed_client.py
@@ -13,16 +13,13 @@ class TestDataFeedClient(unittest.TestCase):
         self.config = SymConfig(get_path_relative_to_resources_folder('./bot-config.json'))
         self.config.load_config()
 
-    @patch('sym_api_client_python.clients.sym_bot_client.SymBotClient', autospec=True)
-    def test_datafeed_client_v1(self, mock_client):
+    def test_datafeed_client_v1(self):
         self.assert_configured_df_version_leads_to_df_client_type('v1', DataFeedClientV1)
 
-    @patch('sym_api_client_python.clients.sym_bot_client.SymBotClient', autospec=True)
-    def test_datafeed_client_v2(self, mock_client):
+    def test_datafeed_client_v2(self):
         self.assert_configured_df_version_leads_to_df_client_type('v2', DataFeedClientV2)
 
-    @patch('sym_api_client_python.clients.sym_bot_client.SymBotClient', autospec=True)
-    def test_datafeed_client_wrong_version(self, mock_client):
+    def test_datafeed_client_wrong_version(self):
         self.assert_configured_df_version_leads_to_df_client_type('25', DataFeedClientV1)
 
     def assert_configured_df_version_leads_to_df_client_type(self, datafeed_version, expected_class):


### PR DESCRIPTION
APP-2935: fixed relative paths in unit tests and made tests use only unittests as it was done so at the beginning.
Tests can now be run from the command line by running `pytest tests` or `python setup.py test` or from the PyCharm UI. 