### PR TITLE
APP-3161: Removed logging of datafeed event content

### DIFF
--- a/sym_api_client_python/services/abstract_datafeed_event_service.py
+++ b/sym_api_client_python/services/abstract_datafeed_event_service.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 
 class AbstractDatafeedEventService(ABC):
 
-    def __init__(self, sym_bot_client, log_events=True, error_timeout_sec=None, maximum_timeout_sec=None):
+    def __init__(self, sym_bot_client, error_timeout_sec=None, maximum_timeout_sec=None):
         self.datafeed_events = []
         self.room_listeners = []
         self.im_listeners = []
@@ -26,7 +26,6 @@ class AbstractDatafeedEventService(ABC):
 
         self.bot_client = sym_bot_client
         self.datafeed_client = self.bot_client.get_datafeed_client()
-        self.log_events = log_events
         self.stop = False
 
         config = sym_bot_client.get_sym_config()
@@ -154,20 +153,12 @@ class AbstractDatafeedEventService(ABC):
         """
         log.debug('DataFeedEventService/handle_events()')
         for event in events:
-            if self.log_events:
-                log.info(
-                    'DataFeedEventService/read_datafeed() --> '
-                    'Incoming event: {}'.
-                        format(json.dumps(event, indent=4)))
+            log.info(
+                'DataFeedEventService/read_datafeed() --> '
+                'Incoming event with id: {}'.format(event['id'])
+            )
 
-            else:
-                log.info(
-                    'DataFeedEventService/read_datafeed() --> '
-                    'Incoming event with id: {}'
-                        .format(event['id'])
-                )
-
-            if event == None or event['initiator']['user']['userId'] == self.bot_client.get_bot_user_info()['id']:
+            if event is None or event['initiator']['user']['userId'] == self.bot_client.get_bot_user_info()['id']:
                 continue
             else:
                 self.handle_event(event)

--- a/sym_api_client_python/services/datafeed_event_service_v1.py
+++ b/sym_api_client_python/services/datafeed_event_service_v1.py
@@ -63,21 +63,15 @@ class DataFeedEventServiceV1(AbstractDatafeedEventService):
         try:
             raise thrown_exception
         except UnauthorizedException:
-            log.error(
-                'DataFeedEventService - caught unauthorized exception'
-            )
+            log.error('DataFeedEventService - caught unauthorized exception')
         except MaxRetryException as e:
             log.error('DataFeedEventService - Bot has tried to authenticate more than 5 times ')
             raise
 
         except (DatafeedExpiredException, APIClientErrorException, ServerErrorException) as exc:
-            log.error(
-                'DataFeedEventService - ' + str(exc)
-            )
+            log.error('DataFeedEventService - ' + str(exc))
         except Exception as exc:
-            log.exception(
-                'DataFeedEventService - Unknown exception: ' + str(exc)
-            )
+            log.exception('DataFeedEventService - Unknown exception: ' + str(exc))
         sleep_for = self.get_and_increase_timeout(thrown_exception)
         log.info('DataFeedEventService/handle_event() --> Sleeping for {:.4g}s'.format(sleep_for))
         time.sleep(sleep_for)

--- a/sym_api_client_python/services/datafeed_event_service_v2.py
+++ b/sym_api_client_python/services/datafeed_event_service_v2.py
@@ -71,21 +71,15 @@ class DataFeedEventServiceV2(AbstractDatafeedEventService):
         try:
             raise thrown_exception
         except UnauthorizedException:
-            log.error(
-                'DataFeedEventService - caught unauthorized exception'
-            )
+            log.error('DataFeedEventService - caught unauthorized exception')
         except MaxRetryException as e:
             log.error('DataFeedEventService - Bot has tried to authenticate more than 5 times ')
             raise
 
         except (DatafeedExpiredException, APIClientErrorException, ServerErrorException) as exc:
-            log.error(
-                'DataFeedEventService - ' + str(exc)
-            )
+            log.error('DataFeedEventService - ' + str(exc))
         except Exception as exc:
-            log.exception(
-                'DataFeedEventService - Unknown exception: ' + str(exc)
-            )
+            log.exception('DataFeedEventService - Unknown exception: ' + str(exc))
         sleep_for = self.get_and_increase_timeout(thrown_exception)
         log.info('DataFeedEventService/handle_event() --> Sleeping for {:.4g}s'.format(sleep_for))
         time.sleep(sleep_for)


### PR DESCRIPTION
### Ticket
[APP-3161](https://perzoinc.atlassian.net/browse/APP-3161)

### Description
Removed logging of datafeed event content. Removed the `log_events` field in `DataFeedEventService` class.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
