### PR TITLE
APP-3283: Implemented datafeed id reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,16 @@ An example of json has been provided below.  (The "botPrivateKeyPath" ends with 
       "keyManagerProxyUsername": "proxy-username",
       "keyManagerProxyPassword": "proxy-password",
 
-
       // Required: If a truststore is required to access on-prem components, provide a path to the python truststore. Needs to be .pem file.  Instructions below for converting JKS to python pem truststore. If truststore is not needed, set value as empty string ("").
-      "truststorePath": "/path/to/truststore.pem"
+      "truststorePath": "/path/to/truststore.pem",
+
+      // Optional: if set to true, the datafeed id will be stored on the filesystem and subsequently reused.
+      // Applies for DFv1 only. Default value is true.
+      "reuseDatafeedID": true,
+
+      // Optional: path to the folder where to store the datafeed id. Applies for DFv1 and if reuseDatafeedID set to true.
+      // Default value is os.getcwd().
+      "datafeedIdFilePath": "/some/folder/"
     }
 
 

--- a/sym_api_client_python/clients/datafeed_client.py
+++ b/sym_api_client_python/clients/datafeed_client.py
@@ -1,9 +1,9 @@
 import logging
 
 from .api_client import APIClient
-from .constants.DatafeedVersion import DatafeedVersion
 from .datafeed_client_v1 import DataFeedClientV1
 from .datafeed_client_v2 import DataFeedClientV2
+
 
 # child class of APIClient --> Extends error handling functionality
 class DataFeedClient(APIClient):
@@ -11,10 +11,10 @@ class DataFeedClient(APIClient):
     def __init__(self, bot_client):
         self.config = bot_client.get_sym_config()
 
-        if DatafeedVersion.version_of(self.config.data.get("datafeedVersion")) == DatafeedVersion.V2:
-            self.datafeed_client = DataFeedClientV2(bot_client)
-        else:
+        if self.config.is_datafeed_v1():
             self.datafeed_client = DataFeedClientV1(bot_client)
+        else:
+            self.datafeed_client = DataFeedClientV2(bot_client)
 
     # raw api call to create_datafeed --> returns datafeed_id
     def create_datafeed(self):

--- a/sym_api_client_python/configure/configure.py
+++ b/sym_api_client_python/configure/configure.py
@@ -198,4 +198,4 @@ class SymConfig:
         datafeed_id_file_path = self.data.get("datafeedIdFilePath")
         if datafeed_id_file_path:
             return datafeed_id_file_path
-        return "./"
+        return os.getcwd()

--- a/sym_api_client_python/configure/configure.py
+++ b/sym_api_client_python/configure/configure.py
@@ -2,6 +2,8 @@ import json
 import logging
 import os
 
+from sym_api_client_python.clients.constants.DatafeedVersion import DatafeedVersion
+
 
 class SymConfig:
     # initialize object by passing in path to config file
@@ -178,3 +180,22 @@ class SymConfig:
             contextPath = contextPath[:-1]
 
         return 'https://' + host + ':' + str(port) + contextPath
+
+    def get_agent_url(self):
+        return self.data.get('agentUrl')
+
+    def should_store_datafeed_id(self):
+        return self.is_datafeed_v1() and self.is_datafeed_id_reused()
+
+    def is_datafeed_v1(self):
+        return DatafeedVersion.version_of(self.data.get("datafeedVersion")) != DatafeedVersion.V2
+
+    def is_datafeed_id_reused(self):
+        reuse_datafeed_id = self.data.get("reuseDatafeedID")
+        return reuse_datafeed_id is None or reuse_datafeed_id
+
+    def get_datafeed_id_folder_path(self):
+        datafeed_id_file_path = self.data.get("datafeedIdFilePath")
+        if datafeed_id_file_path:
+            return datafeed_id_file_path
+        return "./"

--- a/sym_api_client_python/services/datafeed_event_service_v1.py
+++ b/sym_api_client_python/services/datafeed_event_service_v1.py
@@ -11,16 +11,16 @@ from ..exceptions.MaxRetryException import MaxRetryException
 
 log = logging.getLogger(__name__)
 
+
 class DataFeedEventServiceV1(AbstractDatafeedEventService):
 
     def __init__(self, *args, **kwargs):
-        self.datafeed_id = None
         super().__init__(*args, **kwargs)
-
+        self.datafeed_id = None
 
     def start_datafeed(self):
         log.debug('DataFeedEventService/startDataFeed()')
-        self.datafeed_id = self.datafeed_client.create_datafeed()
+        self.datafeed_id = self._get_from_file_or_create_datafeed_id()
         self.read_datafeed()
 
     def activate_datafeed(self):
@@ -78,7 +78,7 @@ class DataFeedEventServiceV1(AbstractDatafeedEventService):
 
         try:
             log.debug('DataFeedEventService/handle_event() --> Restarting Datafeed')
-            self.datafeed_id = self.datafeed_client.create_datafeed()
+            self.datafeed_id = self._create_datafeed_and_persist()
 
         except Exception as exc:
             self.handle_datafeed_errors(exc)

--- a/sym_api_client_python/services/datafeed_id_repository.py
+++ b/sym_api_client_python/services/datafeed_id_repository.py
@@ -1,0 +1,38 @@
+import logging
+import os
+
+DATAFEED_ID_FILE = 'datafeed.id'
+
+log = logging.getLogger(__name__)
+
+
+class OnDiskDatafeedIdRepository:
+    def __init__(self, datafeed_id_folder):
+        self.datafeed_id_file_path = OnDiskDatafeedIdRepository._get_datafeed_id_file_path(datafeed_id_folder)
+
+    def read_datafeed_id_from_file(self):
+        log.debug(f'Retrieving datafeed id from file {self.datafeed_id_file_path}')
+        if os.path.exists(self.datafeed_id_file_path):
+            with open(self.datafeed_id_file_path, 'r') as datafeed_id_file:
+                line = datafeed_id_file.readline()
+                if line:
+                    index = line.find("@")
+                    if index != -1:
+                        datafeed_id = line[0:index]
+                        log.debug(f'Retrieved datafeed id: {datafeed_id}')
+                        return datafeed_id
+        log.debug(f'Could not retrieve datafeed id from file {self.datafeed_id_file_path}')
+        return None
+
+    def store_datafeed_id_to_file(self, datafeed_id, agent_url):
+        with open(self._get_datafeed_id_file_path(), 'w') as datafeed_id_file:
+            line = f'{datafeed_id}@{agent_url}'
+            log.debug(f'Writing {line} to {self.datafeed_id_file_path}')
+            datafeed_id_file.write(line)
+
+    @staticmethod
+    def _get_datafeed_id_file_path(datafeed_id_folder):
+        datafeed_id_file_path = datafeed_id_folder + "/" + DATAFEED_ID_FILE
+        if os.path.exists(datafeed_id_file_path) and os.path.isdir(datafeed_id_file_path):
+            datafeed_id_file_path = datafeed_id_file_path + "/" + DATAFEED_ID_FILE
+        return os.path.abspath(datafeed_id_file_path)

--- a/sym_api_client_python/services/datafeed_id_repository.py
+++ b/sym_api_client_python/services/datafeed_id_repository.py
@@ -8,7 +8,7 @@ log = logging.getLogger(__name__)
 
 class OnDiskDatafeedIdRepository:
     def __init__(self, datafeed_id_folder):
-        self.datafeed_id_file_path = OnDiskDatafeedIdRepository._get_datafeed_id_file_path(datafeed_id_folder)
+        self.datafeed_id_file_path = self._get_datafeed_id_file_path(datafeed_id_folder)
 
     def read_datafeed_id_from_file(self):
         log.debug(f'Retrieving datafeed id from file {self.datafeed_id_file_path}')
@@ -30,8 +30,7 @@ class OnDiskDatafeedIdRepository:
             log.debug(f'Writing {line} to {self.datafeed_id_file_path}')
             datafeed_id_file.write(line)
 
-    @staticmethod
-    def _get_datafeed_id_file_path(datafeed_id_folder):
+    def _get_datafeed_id_file_path(self, datafeed_id_folder):
         datafeed_id_file_path = os.path.join(datafeed_id_folder, DATAFEED_ID_FILE)
         if os.path.exists(datafeed_id_file_path) and os.path.isdir(datafeed_id_file_path):
             datafeed_id_file_path = os.path.join(datafeed_id_file_path, DATAFEED_ID_FILE)

--- a/sym_api_client_python/services/datafeed_id_repository.py
+++ b/sym_api_client_python/services/datafeed_id_repository.py
@@ -25,14 +25,14 @@ class OnDiskDatafeedIdRepository:
         return None
 
     def store_datafeed_id_to_file(self, datafeed_id, agent_url):
-        with open(self._get_datafeed_id_file_path(), 'w') as datafeed_id_file:
+        with open(self.datafeed_id_file_path, 'w') as datafeed_id_file:
             line = f'{datafeed_id}@{agent_url}'
             log.debug(f'Writing {line} to {self.datafeed_id_file_path}')
             datafeed_id_file.write(line)
 
     @staticmethod
     def _get_datafeed_id_file_path(datafeed_id_folder):
-        datafeed_id_file_path = datafeed_id_folder + "/" + DATAFEED_ID_FILE
+        datafeed_id_file_path = os.path.join(datafeed_id_folder, DATAFEED_ID_FILE)
         if os.path.exists(datafeed_id_file_path) and os.path.isdir(datafeed_id_file_path):
-            datafeed_id_file_path = datafeed_id_file_path + "/" + DATAFEED_ID_FILE
+            datafeed_id_file_path = os.path.join(datafeed_id_file_path, DATAFEED_ID_FILE)
         return os.path.abspath(datafeed_id_file_path)


### PR DESCRIPTION
### Ticket
[APP-3283](https://perzoinc.atlassian.net/browse/APP-3283)

### Description
Implementing reuse and persistence of datafeed id when using DFv1

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [ ] Unit tests updated or added
- [ ] Docstrings added or updated
- [ ] Updated the documentation in [docs folder](../docs)
