### PR TITLE
PLAT-10225: Fix datafeed loop crash for events without id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,5 @@ venv.bak/
 sym_api_client_python/resources/certificates/*
 sym_api_client_python/resources/bot_private_key.pem
 *.log
+
+.DS_Store

--- a/examples/main_async.py
+++ b/examples/main_async.py
@@ -11,7 +11,7 @@ from sym_api_client_python.listeners.im_listener_test_imp import (
     AsyncIMListenerImp, IMListenerTestImp)
 from sym_api_client_python.listeners.room_listener_test_imp import (
     AsyncRoomListenerImp, RoomListenerTestImp)
-from sym_api_client_python.listeners.elements_listener_test_imp import AsyncElementsListenerImp
+from sym_api_client_python.listeners.elements_listener_test_imp import AsyncElementsListenerTestImp
 
 
 def configure_logging():

--- a/sym_api_client_python/services/abstract_datafeed_event_service.py
+++ b/sym_api_client_python/services/abstract_datafeed_event_service.py
@@ -156,7 +156,7 @@ class AbstractDatafeedEventService(ABC):
         for event in events:
             log.debug(
                 'DataFeedEventService/read_datafeed() --> '
-                'Incoming event with id: {}'.format(event['id'])
+                'Incoming event with id: {}'.format(event.get('id'))
             )
 
             if event is None or event['initiator']['user']['userId'] == self.bot_client.get_bot_user_info()['id']:

--- a/tests/test_datafeed_event_service.py
+++ b/tests/test_datafeed_event_service.py
@@ -1,0 +1,67 @@
+import asyncio
+from unittest import TestCase, mock, IsolatedAsyncioTestCase
+from unittest.mock import MagicMock, AsyncMock
+
+import pytest
+
+from sym_api_client_python.clients.sym_bot_client import SymBotClient
+from sym_api_client_python.configure.configure import SymConfig
+from sym_api_client_python.datafeed_event_service import AsyncDataFeedEventService
+from sym_api_client_python.listeners.im_listener import IMListener
+from tests.clients.test_datafeed_client import get_path_relative_to_resources_folder
+
+
+class TestDataFeedEventService(IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        self.config = SymConfig(get_path_relative_to_resources_folder('./bot-config.json'))
+        self.config.load_config()
+        self.client = SymBotClient(None, self.config)
+        self.ran = False
+
+    @mock.patch(
+        'sym_api_client_python.clients.datafeed_client.DataFeedClient',
+        new_callable=AsyncMock)
+    async def test_read_datafeed_event_no_id(self, datafeed_client_mock):
+        self.service = AsyncDataFeedEventService(self.client)
+        self.client.get_bot_user_info = MagicMock(return_value={'id': 456})
+
+        self.service.datafeed_client = datafeed_client_mock
+        datafeed_client_mock.read_datafeed_async.side_effect = self.return_event_no_id_first_time
+
+        listener = IMListenerRecorder(self.service)
+        self.service.add_im_listener(listener)
+
+        # Simulate start_datafeed
+        await asyncio.gather(self.service.read_datafeed(), self.service.handle_events())
+
+        self.assertIsNotNone(listener.last_message)
+
+    async def return_event_no_id_first_time(self, _arg):
+        if self.ran:
+            # Give control back to handle_event coroutine
+            await asyncio.sleep(0)
+            return []
+
+        else:
+            self.ran = True
+            event = {'type': 'MESSAGESENT', 'timestamp': 0,
+                     'payload': {'messageSent': {'message': {'stream': {'streamType': 'IM'}}}},
+                     'initiator': {'user': {'userId': 123}}}
+            return [event]
+
+
+class IMListenerRecorder(IMListener):
+
+    def __init__(self, service) -> None:
+        super().__init__()
+        self.service = service
+        self.last_message = None
+
+    async def on_im_message(self, message):
+        self.last_message = message
+        # Stop datafeed loop
+        await self.service.deactivate_datafeed(False)
+
+    def on_im_created(self, stream):
+        pass  # Not used


### PR DESCRIPTION
### Ticket
[PLAT-10225](https://perzoinc.atlassian.net/browse/PLAT-10225)

### Description
Fix datafeed loop crash for events without id

A datafeed event does not always have an id (for instance when external
users join a room) therefore we must handle that. The access to the id
is replaced with .get() to avoid the runtime error and if the id is
missing a random one is set for tracing purpose.

Added a unit test for that using IsolatedAsyncioTestCase, it is a bit
complex due to the async nature of the code but it does run part of the
datafeed loop.

### Dependencies
N/A
### Checklist
- [X] Referenced a ticket in the PR title and in the corresponding section
- [X] Filled properly the description and dependencies, if any
- [X] Unit tests updated or added
- [-] Docstrings added or updated
- [-] Updated the documentation in [docs folder](../docs)
