### PR TITLE
PLAT-10279 Fix async calls not using truststorePath

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,18 @@ responses
 
 * Successfully employing this strategy can make your bot handle far higher loads than would be possible in the synchronous case, without having to resort to threading or complex callbacks.
 
+---
+**NOTE**
+
+There is an outstanding issue with aiohttp and Python 3.8+ on Windows. This affects our client when you specify a proxy on Windows with Python 3.8+.
+
+If you are using a proxy, you may need to implement the following workaround before you start the async datafeed or make any async calls with aiohttp:
+```
+if sys.version_info[0] == 3 and sys.version_info[1] >= 8 and sys.platform.startswith('win'):
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+```
+---
+
 Blocking listeners will however still block the datafeed. Listeners that need to make HTTP requests however can make them with aiohttp,
 instead of requests for example. aiohttp is already a dependency of this module. These can be awaited to release the thread.
 ```

--- a/sym_api_client_python/clients/sym_bot_client.py
+++ b/sym_api_client_python/clients/sym_bot_client.py
@@ -3,8 +3,6 @@ import logging
 from json.decoder import JSONDecodeError
 
 import aiohttp
-import asyncio
-import sys
 import requests
 import ssl
 
@@ -54,17 +52,7 @@ class SymBotClient(APIClient):
         self.async_agent_session = None
         self.bot_user_info = None
         self.health_check_client = None
-        #Required for aiohttp to use truststore
-        if self.config.data[_TRUSTSTORE_PATH]:
-            logging.debug("Setting truststorePath for async calls to {}".format(config.data[_TRUSTSTORE_PATH]))
-            self.async_ssl_context = ssl.create_default_context(cafile=self.config.data[_TRUSTSTORE_PATH])
-        else: 
-            logging.debug("Setting truststore for async calls to system truststore")
-            self.async_ssl_context = ssl.create_default_context()
-        #Required to work around a bug in Python 3.8+ on Windows. Can be removed once fixed in aiohttp
-        if sys.version_info[0] == 3 and sys.version_info[1] >= 8 and sys.platform.startswith('win'):
-            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-
+        self.async_ssl_context = None
 
 
     def get_datafeed_event_service(self, *args, **kwargs):
@@ -230,6 +218,8 @@ class SymBotClient(APIClient):
             # For aiohttp proxies and truststore are handled when the request is made
         return self.async_agent_session
 
+    # Known issue on this function when using a proxy due to an outstanding issue with aiohttp
+    # To workaround this please check README.md
     async def execute_rest_call_async(self, method, path, **kwargs):
         """This is the asynchronous method to hit the rest api, it should be awaited"""
         results = None
@@ -274,7 +264,7 @@ class SymBotClient(APIClient):
 
 
         try:
-            response = await session.request(method, url, proxy=http_proxy, ssl=self.async_ssl_context, data=data, **kwargs)
+            response = await session.request(method, url, proxy=http_proxy, ssl=self.get_async_ssl_context(), data=data, **kwargs)
         except aiohttp.ClientConnectionError as err:
             logging.debug(err)
             logging.debug(type(err))
@@ -345,6 +335,16 @@ class SymBotClient(APIClient):
         if self.health_check_client is None:
             self.health_check_client = HealthCheckClient(self)
         return self.health_check_client
+
+    #Required for aiohttp to use truststore
+    def get_async_ssl_context(self):
+        if self.async_ssl_context is None:
+            if self.config.data[_TRUSTSTORE_PATH]:
+                logging.debug("Setting truststorePath for async calls to {}".format(self.config.data[_TRUSTSTORE_PATH]))
+                self.async_ssl_context = ssl.create_default_context(cafile=self.config.data[_TRUSTSTORE_PATH])
+            else:
+                self.async_ssl_context = ssl.create_default_context()
+        return self.async_ssl_context
 
     async def close_async_sessions(self):
         """Close the open aiohttp.ClientSession objects

--- a/sym_api_client_python/datafeed_event_service.py
+++ b/sym_api_client_python/datafeed_event_service.py
@@ -177,6 +177,17 @@ class AsyncDataFeedEventService(AbstractDatafeedEventService):
     Potential improvements:
         * Provide a timeout to allow handlers to be cancelled after a certain period
         * Allow exception handling around listeners to be customised
+
+    Known Issues:
+        On Windows with Python 3.8+ there is a known issue with aiohttp and setting a proxy
+        that can be found at https://github.com/aio-libs/aiohttp/issues/4536
+
+        To work around this we must specify the event loop to use WindowsSelectorEventLoopPolicy with:
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
+        If cross-platform code is needed you can use a check:
+        if sys.version_info[0] == 3 and sys.version_info[1] >= 8 and sys.platform.startswith('win'):
+            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     """
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
### Ticket
PLAT-10279

### Description
Datafeed and other async calls that used aiohttp did not use the defined truststore in the config.json

### Dependencies
No additional dependencies
