### PR TITLE
PLAT-10245: Support CircleCI build for master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+version: 2.1
+
+jobs:
+  build:
+    docker:
+      - image: cimg/python:3.9
+    steps:
+      - checkout
+
+      - run:
+          name: Install Python dependencies
+          command: pip3 install -e .
+
+      - run:
+          name: Build
+          command: python3 setup.py test

--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,9 @@ setuptools.setup(
     ],
     tests_require=['pytest'],
     include_package_data=True,
-    classifiers=(
+    classifiers=[
         "Programming Language :: Python :: 3.6",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
-    ),
+    ],
 )


### PR DESCRIPTION
### Ticket
PLAT-10245

### Description

In the 2.0 branch we introduced CircleCI and PR builders, just to make
it work with the master branch, here we add a simple build file just
running the tests (the bare minimum, the 2.0 branch supports Snyk, test
coverage and reports).

3.6 cannot be used because we use unittest.async_case.
Caching with pyenv was not working (dependencies problem) so it is not
implemented (we do not expect a lot of executions).
