### PR TITLE
PLAT-10367: Fixed blast message endpoint

### DIFF
--- a/symphony/bdk/gen/api_client.py
+++ b/symphony/bdk/gen/api_client.py
@@ -245,12 +245,14 @@ class ApiClient(object):
             collection_types = (dict)
         for k, v in params.items() if isinstance(params, dict) else params:  # noqa: E501
             if isinstance(v, collection_types): # v is instance of collection_type, formatting as application/json
-                 v = json.dumps(v, ensure_ascii=False).encode("utf-8")
-                 field = RequestField(k, v)
-                 field.make_multipart(content_type="application/json; charset=utf-8")
-                 new_params.append(field)
+                v = json.dumps(v, ensure_ascii=False).encode("utf-8")
+                field = RequestField(k, v)
+                field.make_multipart(content_type="application/json; charset=utf-8")
+                new_params.append(field)
+            elif isinstance(v, str):
+                params.append((k, (v, "text/plain; charset=utf-8")))
             else:
-                 new_params.append((k, v))
+                new_params.append((k, v))
         return new_params
 
     @classmethod

--- a/symphony/bdk/gen/rest.py
+++ b/symphony/bdk/gen/rest.py
@@ -143,6 +143,8 @@ class RESTClientObject(object):
                                        value=v[1],
                                        filename=v[0],
                                        content_type=v[2])
+                    elif isinstance(v, tuple) and len(v) == 2:
+                        data.add_field(k, v[0], content_type=v[1])
                     else:
                         data.add_field(k, v)
                 args["data"] = data

--- a/templates/api_client.mustache
+++ b/templates/api_client.mustache
@@ -237,12 +237,14 @@ class ApiClient(object):
             collection_types = (dict)
         for k, v in params.items() if isinstance(params, dict) else params:  # noqa: E501
             if isinstance(v, collection_types): # v is instance of collection_type, formatting as application/json
-                 v = json.dumps(v, ensure_ascii=False).encode("utf-8")
-                 field = RequestField(k, v)
-                 field.make_multipart(content_type="application/json; charset=utf-8")
-                 new_params.append(field)
+                v = json.dumps(v, ensure_ascii=False).encode("utf-8")
+                field = RequestField(k, v)
+                field.make_multipart(content_type="application/json; charset=utf-8")
+                new_params.append(field)
+            elif isinstance(v, str):
+                params.append((k, (v, "text/plain; charset=utf-8")))
             else:
-                 new_params.append((k, v))
+                new_params.append((k, v))
         return new_params
 
     @classmethod

--- a/templates/rest.mustache
+++ b/templates/rest.mustache
@@ -137,6 +137,8 @@ class RESTClientObject(object):
                                        value=v[1],
                                        filename=v[0],
                                        content_type=v[2])
+                    elif isinstance(v, tuple) and len(v) == 2:
+                        data.add_field(k, v[0], content_type=v[1])
                     else:
                         data.add_field(k, v)
                 args["data"] = data


### PR DESCRIPTION
Generated api_client.py and rest.py modules were not properly handling text/plain body parts in a multipart/form-data query

### Ticket
PLAT-10367

### Description
Added content type text/plain for string form values.