### PR TITLE
PLAT-10466 - Handle Null Events gracefully

### DIFF
--- a/sym_api_client_python/services/abstract_datafeed_event_service.py
+++ b/sym_api_client_python/services/abstract_datafeed_event_service.py
@@ -154,12 +154,15 @@ class AbstractDatafeedEventService(ABC):
         """
         log.debug('DataFeedEventService/handle_events()')
         for event in events:
+            if event is None:
+                continue
+            
             log.debug(
                 'DataFeedEventService/read_datafeed() --> '
                 'Incoming event with id: {}'.format(event.get('id'))
             )
-
-            if event is None or event['initiator']['user']['userId'] == self.bot_client.get_bot_user_info()['id']:
+            
+            if event['initiator']['user']['userId'] == self.bot_client.get_bot_user_info()['id']:
                 continue
             else:
                 self.handle_event(event)


### PR DESCRIPTION
### Ticket
PLAT-10466

### Description
In certain cases a null event can be passed to the bot in the Datafeed v5 endpoint and we try to log all event ids where a null will not have one and crash the bot.
