### PR TITLE
PLAT-10459: Logging configuration example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,7 @@ sym_api_client_python/resources/bot_private_key.pem
 
 # Datafeed V1
 datafeed.id
+
+# Log files created by examples
+bdk.log*
+examples/bdk.log*

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,16 @@
+# Getting started
+
+## Logging
+
+The Symphony BDK uses
+the [standard Python logging module](https://docs.python.org/3/howto/logging.html). To troubleshoot
+your bot you might want to enable the DEBUG level to get the full logs from the BDK.
+The [Datafeed example](../examples/datafeed_example.py) uses
+a [sample logging configuration](../examples/logging.conf)
+and illustrates how you can configure logging as a bot developer.
+
+If you are logging to a file we recommend that you use
+a [rotating file handler](https://docs.python.org/3/library/logging.handlers.html#logging.handlers.RotatingFileHandler)
+to avoid filling the disk.
+
+**Beware of logging sensitive or personal data such as message content, user details,...**

--- a/examples/datafeed_example.py
+++ b/examples/datafeed_example.py
@@ -1,0 +1,36 @@
+import asyncio
+import logging
+import logging.config
+import os
+
+from symphony.bdk.core.config.loader import BdkConfigLoader
+from symphony.bdk.core.service.datafeed.real_time_event_listener import RealTimeEventListener
+from symphony.bdk.core.symphony_bdk import SymphonyBdk
+from symphony.bdk.gen.agent_model.v4_initiator import V4Initiator
+from symphony.bdk.gen.agent_model.v4_message_sent import V4MessageSent
+
+
+async def run():
+    config = BdkConfigLoader.load_from_symphony_dir("config.yaml")
+
+    async with SymphonyBdk(config) as bdk:
+        datafeed_loop = bdk.datafeed()
+        datafeed_loop.subscribe(RealTimeEventListenerImpl())
+        await datafeed_loop.start()
+
+
+class RealTimeEventListenerImpl(RealTimeEventListener):
+
+    async def on_message_sent(self, initiator: V4Initiator, event: V4MessageSent):
+        # We do not recommend logging full events in production as it could expose sensitive data
+        logging.debug("Received event: %s", event)
+
+
+logging.config.fileConfig(os.path.dirname(os.path.abspath(__file__)) + '/logging.conf',
+                          disable_existing_loggers=False)
+
+try:
+    logging.info("Running datafeed example...")
+    asyncio.run(run())
+except KeyboardInterrupt:
+    logging.info("Ending datafeed example")

--- a/examples/logging.conf
+++ b/examples/logging.conf
@@ -1,0 +1,31 @@
+# Sample configuration for logging, prints to the console
+# See https://docs.python.org/3/library/logging.config.html#logging-config-fileformat
+
+[loggers]
+keys=root
+
+[handlers]
+keys=consoleHandler,fileHandler
+
+[formatters]
+keys=simpleFormatter
+
+[logger_root]
+level=DEBUG
+handlers=consoleHandler,fileHandler
+
+[handler_consoleHandler]
+class=StreamHandler
+level=DEBUG
+formatter=simpleFormatter
+args=(sys.stdout,)
+
+[formatter_simpleFormatter]
+format=%(asctime)s - %(name)s - %(levelname)s - %(message)s
+
+[handler_fileHandler]
+# Rotating log file if size exceeds 10MB
+class=logging.handlers.RotatingFileHandler
+level=DEBUG
+formatter=simpleFormatter
+args=('bdk.log', 'w', 10000000, 10)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,12 @@
 [tool.poetry]
-name = "symphony-bdk"
+name = "sym_api_client_python"
 version = "2.0.dev0"
 description = "Symphony Bot Development Kit for Python"
 authors = ["Symphony Platform Solutions <platformsolutions@symphony.com>"]
+
+packages = [
+    { include = "symphony" }
+]
 
 [tool.poetry.dependencies]
 python = "^3.8"

--- a/symphony/bdk/core/service/datafeed/abstract_datafeed_loop.py
+++ b/symphony/bdk/core/service/datafeed/abstract_datafeed_loop.py
@@ -13,6 +13,7 @@ from symphony.bdk.gen.agent_api.datafeed_api import DatafeedApi
 from symphony.bdk.core.service.datafeed.real_time_event_listener import RealTimeEventListener
 from symphony.bdk.gen.agent_model.v4_event import V4Event
 
+logger = logging.getLogger(__name__)
 
 class RealTimeEvent(Enum):
     """This enum lists all possible
@@ -98,7 +99,7 @@ class AbstractDatafeedLoop(ABC):
         try:
             listener_method_name, payload_field_name = RealTimeEvent[event.type].value
         except KeyError:
-            logging.info("Received event with an unknown type: %s", event.type)
+            logger.info("Received event with an unknown type: %s", event.type)
             return
 
         listener_method = getattr(listener, listener_method_name)

--- a/symphony/bdk/core/service/datafeed/on_disk_datafeed_id_repository.py
+++ b/symphony/bdk/core/service/datafeed/on_disk_datafeed_id_repository.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from symphony.bdk.core.config.model.bdk_config import BdkConfig
 
+logger = logging.getLogger(__name__)
 
 class DatafeedIdRepository(ABC):
     """A repository interface for storing a datafeed id.
@@ -38,9 +39,9 @@ class OnDiskDatafeedIdRepository(DatafeedIdRepository):
         self.datafeed_id_file_path.write_text(f"{datafeed_id}@{agent_base_path}")
 
     def read(self) -> str:
-        logging.debug("Retrieving datafeed id from file %s", self.datafeed_id_file_path.absolute())
+        logger.debug("Retrieving datafeed id from file %s", self.datafeed_id_file_path.absolute())
         if not os.path.exists(self.datafeed_id_file_path):
-            logging.debug("Could not retrieve datafeed id from file %s: file not found",
+            logger.debug("Could not retrieve datafeed id from file %s: file not found",
                           self.datafeed_id_file_path.absolute())
             return None
 
@@ -54,11 +55,11 @@ class OnDiskDatafeedIdRepository(DatafeedIdRepository):
     def _read_in_line(self, line):
         index = line.find("@")
         if index == -1:
-            logging.debug("Could not retrieve datafeed id from file %s: file without datafeed id information",
+            logger.debug("Could not retrieve datafeed id from file %s: file without datafeed id information",
                           self.datafeed_id_file_path.absolute())
             return None
         datafeed_id = line[0:index]
-        logging.debug("Retrieved datafeed id: %s", datafeed_id)
+        logger.debug("Retrieved datafeed id: %s", datafeed_id)
         return datafeed_id
 
     def _get_datafeed_id_file(self) -> Path:


### PR DESCRIPTION
### Ticket
PLAT-10459

### Description
As part of the datafeed example a sample logging configuration is
provided, sending logs to the console and to rotating files. This is
mostly here to illustrate how logging can be used in a bot.

Also handled KeyboardInterruptException in the example to avoid the
stacktrace when we quit the application.

**The example has been rewritten as a script, if you are ok with that I'll
move other examples as well. It is shorter and easier to understand.**

poetry build was failing so the package has been configured properly and
the package's name changed to what is actually published on pypi (might
change later).

### Dependencies
N/A

### Checklist
- [X] Referenced a ticket in the PR title and in the corresponding section
- [X] Filled properly the description and dependencies, if any
- [N/A] Unit tests updated or added
- [N/A] Docstrings added or updated
- [X] Updated the documentation in [docs folder](../docs)
