### PR TITLE
PLAT-10420: proxy support and SSL verification

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,6 +61,9 @@ pod:
 agent:
    host: dev-agent.symphony.com
    port: 5678
+   proxy:
+     host: agent-proxy
+     port: 3396
 
 keyManager:
   host: dev-key.symphony.com

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,6 +38,65 @@ config_3 = BdkConfigLoader.load_from_symphony_dir("config.yaml")  # 3
 ```
 1. Load configuration from a file
 2. Load configuration from a string object
-3. Load configuration from the Symphony directory. The Symphony directory is located under `.symphony` folder in your home directory 
-    . It can be useful when you don't want to share your own Symphony credentials within your project codebase
+3. Load configuration from the Symphony directory. The Symphony directory is located under `.symphony` folder in your
+   home directory. It can be useful when you don't want to share your own Symphony credentials within your project
+   codebase
 
+## Full configuration example
+```yaml
+scheme: https
+host: localhost.symphony.com
+port: 8443
+
+proxy:
+  host: proxy.symphony.com
+  port: 1234
+  username: proxyuser
+  password: proxypassword
+
+pod:
+  host: dev.symphony.com
+  port: 443
+
+agent:
+   host: dev-agent.symphony.com
+   port: 5678
+
+keyManager:
+  host: dev-key.symphony.com
+  port: 8444
+
+sessionAuth:
+  host: dev-session.symphony.com
+  port: 8444
+
+bot:
+  username: bot-name
+  privateKey:
+    path: /path/to/bot/rsa-private-key.pem
+
+app:
+  appId: app-id
+  privateKey:
+    path: path/to/private-key.pem
+```
+
+### Configuration structure
+
+The BDK configuration now includes the following properties:
+- The BDK configuration can contain the global properties for `host`, `port`, `context` and `scheme`.
+These global properties can be used by the client configuration by default or can be overridden if
+user specify the dedicated `host`, `port`, `context`, `scheme` inside the client configuration.
+- `proxy` contains proxy related information. This field is optional.
+If set, it will use the provided `host` (mandatory), `port` (mandatory), `username` and `password`.
+It can be overridden in each of the `pod`, `agent`, `keyManager` and `sessionAuth` fields.
+- `pod` contains information like host, port, scheme, context, proxy... of the pod on which
+the service account using by the bot is created.
+- `agent` contains information like host, port, scheme, context, proxy... of the agent which
+the bot connects to.
+- `keyManager` contains information like host, port, scheme, context, proxy... of the key
+manager which manages the key token of the bot.
+- `bot` contains information about the bot like the username, the private key for authenticating the service account
+  on pod.
+- `app` contains information about the extension app that the bot will use like
+the appId, the private key for authenticating the extension app.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,7 +103,9 @@ the service account using by the bot is created.
 the bot connects to.
 - `keyManager` contains information like host, port, scheme, context, proxy... of the key
 manager which manages the key token of the bot.
-- `ssl` contains the path to the truststore in pem format for SSL verification.
+- `ssl` contains the path to a file of concatenated CA certificates in PEM format. As we are using python SSL library
+  under the hood, you can check
+  [ssl lib documentation on certificates](https://docs.python.org/3/library/ssl.html#certificates) for more information.
 - `bot` contains information about the bot like the username, the private key for authenticating the service account
   on pod.
 - `app` contains information about the extension app that the bot will use like

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,6 +70,10 @@ sessionAuth:
   host: dev-session.symphony.com
   port: 8444
 
+ssl:
+  trustStore:
+    path: /path/to/truststore.pem
+
 bot:
   username: bot-name
   privateKey:
@@ -96,6 +100,7 @@ the service account using by the bot is created.
 the bot connects to.
 - `keyManager` contains information like host, port, scheme, context, proxy... of the key
 manager which manages the key token of the bot.
+- `ssl` contains the path to the truststore in pem format for SSL verification.
 - `bot` contains information about the bot like the username, the private key for authenticating the service account
   on pod.
 - `app` contains information about the extension app that the bot will use like

--- a/symphony/bdk/core/client/api_client_factory.py
+++ b/symphony/bdk/core/client/api_client_factory.py
@@ -66,7 +66,7 @@ class ApiClientFactory:
     def _get_api_client(self, server_config, context) -> ApiClient:
         configuration = Configuration(host=(server_config.get_base_path() + context))
         configuration.verify_ssl = True
-        configuration.ssl_ca_cert = self._config.ssl.trust_store.path
+        configuration.ssl_ca_cert = self._config.ssl.trust_store_path
 
         if server_config.proxy is not None:
             self._configure_proxy(server_config.proxy, configuration)

--- a/symphony/bdk/core/client/api_client_factory.py
+++ b/symphony/bdk/core/client/api_client_factory.py
@@ -63,9 +63,10 @@ class ApiClientFactory:
         await self._agent_client.close()
         await self._session_auth_client.close()
 
-    def _get_api_client(self, server_config, context='') -> ApiClient:
-        path = server_config.get_base_path() + context
-        configuration = Configuration(host=path)
+    def _get_api_client(self, server_config, context) -> ApiClient:
+        configuration = Configuration(host=(server_config.get_base_path() + context))
+        configuration.verify_ssl = True
+        configuration.ssl_ca_cert = self._config.ssl.trust_store.path
 
         if server_config.proxy is not None:
             self._configure_proxy(server_config.proxy, configuration)

--- a/symphony/bdk/core/config/model/bdk_client_config.py
+++ b/symphony/bdk/core/config/model/bdk_client_config.py
@@ -1,4 +1,4 @@
-from symphony.bdk.core.config.model.bdk_server_config import BdkServerConfig
+from symphony.bdk.core.config.model.bdk_server_config import BdkServerConfig, BdkProxyConfig
 
 
 class BdkClientConfig(BdkServerConfig):
@@ -17,17 +17,15 @@ class BdkClientConfig(BdkServerConfig):
         :param parent_config: the parent configuration of type BdkConfig
         :param config: client configuration parameters of type dict
         """
+        if config is None:
+            config = {}
+
+        self._scheme = config.get("scheme")
+        self._port = config.get("port")
+        self._host = config.get("host")
+        self._context = config.get("context")
+        self._proxy = BdkProxyConfig(**config.get("proxy")) if "proxy" in config else None
         self.parent_config = parent_config
-        if config is not None:
-            self._scheme = config.get("scheme")
-            self._port = config.get("port")
-            self._host = config.get("host")
-            self._context = config.get("context")
-        else:
-            self._scheme = None
-            self._port = None
-            self._host = None
-            self._context = None
 
     @property
     def scheme(self):
@@ -60,6 +58,15 @@ class BdkClientConfig(BdkServerConfig):
         :return: the applicable context path
         """
         return self._self_or_parent(self._context, self.parent_config.context)
+
+    @property
+    def proxy(self):
+        """Return the applicable proxy information: either the one configured at child level (e.g. 'pod')
+        or at global level.
+
+        :return: the applicable proxy information
+        """
+        return self._self_or_parent(self._proxy, self.parent_config.proxy)
 
     @staticmethod
     def _self_or_parent(instance_value, parent_value):

--- a/symphony/bdk/core/config/model/bdk_config.py
+++ b/symphony/bdk/core/config/model/bdk_config.py
@@ -16,7 +16,7 @@ class BdkConfig(BdkServerConfig):
         :param config: the dict containing the server configuration parameters.
         """
         super().__init__(scheme=config.get("scheme"), host=config.get("host"), port=config.get("port"),
-                         context=config.get("context"))
+                         context=config.get("context"), proxy=config.get("proxy"))
         self.agent = BdkClientConfig(self, config.get("agent"))
         self.pod = BdkClientConfig(self, config.get("pod"))
         self.key_manager = BdkClientConfig(self, config.get("keyManager"))

--- a/symphony/bdk/core/config/model/bdk_server_config.py
+++ b/symphony/bdk/core/config/model/bdk_server_config.py
@@ -1,14 +1,14 @@
 class BdkServerConfig:
-    """Base class for server and client configurations
-    """
+    """Base class for server and client configurations"""
     DEFAULT_SCHEME: str = "https"
     DEFAULT_HTTPS_PORT: int = 443
 
-    def __init__(self, scheme=None, port=None, context="", host=None):
+    def __init__(self, scheme=None, port=None, context="", host=None, proxy=None):
         self.scheme = scheme if scheme is not None else self.DEFAULT_SCHEME
         self.port = self.port = port if port is not None else self.DEFAULT_HTTPS_PORT
         self.context = context
         self.host = host
+        self.proxy = BdkProxyConfig(**proxy) if proxy is not None else None
 
     def get_base_path(self) -> str:
         """Constructs the base path of the current config
@@ -39,3 +39,41 @@ class BdkServerConfig:
         :return: the port information to be appended to the built URL
         """
         return ":" + str(self.port) if self.port else ""
+
+
+class BdkProxyConfig:
+    """Class to configure a proxy with a host, port and optional proxy credentials"""
+
+    def __init__(self, host, port, username=None, password=None):
+        """
+
+        :param host: host of the proxy (mandatory)
+        :param port: port of the proxy (mandatory)
+        :param username: username for proxy basic authentication (optional)
+        :param password: password for proxy basic authentication (optional, must be not None if username specified)
+        """
+        self.host = host
+        self.port = port
+        self.username = username
+        self.password = password
+
+    def get_url(self):
+        """Builds the proxy URL.
+
+        :return: the URL of the http proxy to target
+        """
+        return f"http://{self.host}:{self.port}"
+
+    def are_credentials_defined(self):
+        """Check if proxy credentials were set
+
+        :return: True if username and password set
+        """
+        return self.username and self.password is not None
+
+    def get_credentials(self):
+        """Builds the credentials information to pass to the proxy-authorization header before base64 encoding.
+
+        :return: username + ":" + password
+        """
+        return f"{self.username}:{self.password}"

--- a/symphony/bdk/core/config/model/bdk_ssl_config.py
+++ b/symphony/bdk/core/config/model/bdk_ssl_config.py
@@ -4,8 +4,7 @@ TRUST_STORE = "trustStore"
 
 
 class BdkSslConfig:
-    """Class containing the SSL configuration.
-    """
+    """Class containing the SSL configuration."""
 
     def __init__(self, config):
         """
@@ -13,8 +12,6 @@ class BdkSslConfig:
         :param config: the dict containing the SSL specific configuration.
         """
         if config is not None and TRUST_STORE in config:
-            truststore_config = config.get(TRUST_STORE)
-            self.trust_store = BdkCertificateConfig(path=truststore_config.get("path"),
-                                                    password=truststore_config.get("password"))
+            self.trust_store = BdkCertificateConfig(path=config[TRUST_STORE].get("path"))
         else:
             self.trust_store = BdkCertificateConfig()

--- a/symphony/bdk/core/config/model/bdk_ssl_config.py
+++ b/symphony/bdk/core/config/model/bdk_ssl_config.py
@@ -1,17 +1,15 @@
-from symphony.bdk.core.config.model.bdk_certificate_config import BdkCertificateConfig
-
 TRUST_STORE = "trustStore"
 
 
 class BdkSslConfig:
-    """Class containing the SSL configuration."""
+    """Class containing the SSL configuration.
+    self.trust_store_path should be the path to a file of concatenated CA certificates in PEM format."""
 
     def __init__(self, config):
         """
 
         :param config: the dict containing the SSL specific configuration.
         """
+        self.trust_store_path = None
         if config is not None and TRUST_STORE in config:
-            self.trust_store = BdkCertificateConfig(path=config[TRUST_STORE].get("path"))
-        else:
-            self.trust_store = BdkCertificateConfig()
+            self.trust_store_path = config[TRUST_STORE].get("path")

--- a/symphony/bdk/gen/rest.py
+++ b/symphony/bdk/gen/rest.py
@@ -49,8 +49,12 @@ class RESTClientObject(object):
             maxsize = configuration.connection_pool_maxsize
 
         ssl_context = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH, cafile=configuration.ssl_ca_cert)
+        ssl_context.verify_mode = ssl.CERT_REQUIRED
+
         if configuration.cert_file:
-            ssl_context.load_verify_locations(configuration.cert_file)
+            ssl_context.load_cert_chain(
+                configuration.cert_file, keyfile=configuration.key_file
+            )
 
         if not configuration.verify_ssl:
             ssl_context.check_hostname = False

--- a/tests/core/client/api_client_factory_test.py
+++ b/tests/core/client/api_client_factory_test.py
@@ -1,8 +1,11 @@
+from unittest.mock import patch
+
 import pytest
 
 from symphony.bdk.core.client.api_client_factory import ApiClientFactory
 from symphony.bdk.core.config.model.bdk_config import BdkConfig
 from symphony.bdk.core.config.model.bdk_server_config import BdkProxyConfig
+from symphony.bdk.core.config.model.bdk_ssl_config import BdkSslConfig
 
 HOST = "acme.symphony.com"
 
@@ -56,6 +59,16 @@ async def test_proxy_credentials_configured(config):
                                                  proxy_port)
     assert_host_and_proxy_credentials_configured(client_factory.get_relay_client().configuration, "/relay", proxy_host,
                                                  proxy_port)
+
+
+def test_trust_store_configured(config):
+    with patch("symphony.bdk.gen.rest.RESTClientObject"):
+        truststore_path = "/path/to/truststore.pem"
+        config.ssl = BdkSslConfig({"trustStore": {"path": truststore_path}})
+
+        client_factory = ApiClientFactory(config)
+
+        assert client_factory.get_pod_client().configuration.ssl_ca_cert == truststore_path
 
 
 def assert_host_configured_only(configuration, url_suffix):

--- a/tests/core/client/api_client_factory_test.py
+++ b/tests/core/client/api_client_factory_test.py
@@ -1,22 +1,76 @@
-from unittest.mock import patch
-
 import pytest
 
 from symphony.bdk.core.client.api_client_factory import ApiClientFactory
-from symphony.bdk.core.config.loader import BdkConfigLoader
-from tests.utils.resource_utils import get_config_resource_filepath
+from symphony.bdk.core.config.model.bdk_config import BdkConfig
+from symphony.bdk.core.config.model.bdk_server_config import BdkProxyConfig
+
+HOST = "acme.symphony.com"
 
 
 @pytest.fixture()
 def config():
-    return BdkConfigLoader.load_from_file(get_config_resource_filepath("config.yaml"))
+    return BdkConfig(host=HOST)
 
 
-def test_get_api_client(config):
-    with patch('symphony.bdk.core.client.api_client_factory.ApiClient', autospec=True):
-        api_client_factory = ApiClientFactory(config)
-        assert api_client_factory.get_pod_client() is not None
-        assert api_client_factory.get_login_client() is not None
-        assert api_client_factory.get_agent_client() is not None
-        assert api_client_factory.get_session_auth_client() is not None
-        assert api_client_factory.get_relay_client() is not None
+@pytest.mark.asyncio
+async def test_host_configured(config):
+    client_factory = ApiClientFactory(config)
+
+    assert_host_configured_only(client_factory.get_pod_client().configuration, "/pod")
+    assert_host_configured_only(client_factory.get_login_client().configuration, "/login")
+    assert_host_configured_only(client_factory.get_agent_client().configuration, "/agent")
+    assert_host_configured_only(client_factory.get_session_auth_client().configuration, "/sessionauth")
+    assert_host_configured_only(client_factory.get_relay_client().configuration, "/relay")
+
+
+@pytest.mark.asyncio
+async def test_proxy_configured(config):
+    proxy_host = "proxy.com"
+    proxy_port = 1234
+    config.proxy = BdkProxyConfig(proxy_host, proxy_port)
+    client_factory = ApiClientFactory(config)
+
+    assert_host_and_proxy_configured(client_factory.get_pod_client().configuration, "/pod", proxy_host, proxy_port)
+    assert_host_and_proxy_configured(client_factory.get_login_client().configuration, "/login", proxy_host, proxy_port)
+    assert_host_and_proxy_configured(client_factory.get_agent_client().configuration, "/agent", proxy_host, proxy_port)
+    assert_host_and_proxy_configured(client_factory.get_session_auth_client().configuration, "/sessionauth", proxy_host,
+                                     proxy_port)
+    assert_host_and_proxy_configured(client_factory.get_relay_client().configuration, "/relay", proxy_host, proxy_port)
+
+
+@pytest.mark.asyncio
+async def test_proxy_credentials_configured(config):
+    proxy_host = "proxy.com"
+    proxy_port = 1234
+    config.proxy = BdkProxyConfig(proxy_host, proxy_port, "user", "pass")
+    client_factory = ApiClientFactory(config)
+
+    assert_host_and_proxy_credentials_configured(client_factory.get_pod_client().configuration, "/pod", proxy_host,
+                                                 proxy_port)
+    assert_host_and_proxy_credentials_configured(client_factory.get_login_client().configuration, "/login", proxy_host,
+                                                 proxy_port)
+    assert_host_and_proxy_credentials_configured(client_factory.get_agent_client().configuration, "/agent", proxy_host,
+                                                 proxy_port)
+    assert_host_and_proxy_credentials_configured(client_factory.get_session_auth_client().configuration, "/sessionauth",
+                                                 proxy_host,
+                                                 proxy_port)
+    assert_host_and_proxy_credentials_configured(client_factory.get_relay_client().configuration, "/relay", proxy_host,
+                                                 proxy_port)
+
+
+def assert_host_configured_only(configuration, url_suffix):
+    assert configuration.host == f"https://{HOST}:443{url_suffix}"
+    assert configuration.proxy is None
+    assert configuration.proxy_headers is None
+
+
+def assert_host_and_proxy_configured(configuration, url_suffix, proxy_host, proxy_port):
+    assert configuration.host == f"https://{HOST}:443{url_suffix}"
+    assert configuration.proxy == f"http://{proxy_host}:{proxy_port}"
+    assert configuration.proxy_headers is None
+
+
+def assert_host_and_proxy_credentials_configured(configuration, url_suffix, proxy_host, proxy_port):
+    assert configuration.host == f"https://{HOST}:443{url_suffix}"
+    assert configuration.proxy == f"http://{proxy_host}:{proxy_port}"
+    assert "proxy-authorization" in configuration.proxy_headers

--- a/tests/core/config/models/test_bdk_server_config.py
+++ b/tests/core/config/models/test_bdk_server_config.py
@@ -1,4 +1,4 @@
-from symphony.bdk.core.config.model.bdk_server_config import BdkServerConfig
+from symphony.bdk.core.config.model.bdk_server_config import BdkServerConfig, BdkProxyConfig
 
 
 def test_get_base_path():
@@ -24,3 +24,18 @@ def test_get_port_as_string():
 
     config.port = None
     assert config.get_port_as_string() == ""
+
+
+def test_proxy_config_no_credentials():
+    proxy = BdkProxyConfig("proxy.symphony.com", 1234)
+
+    assert proxy.get_url() == "http://proxy.symphony.com:1234"
+    assert not proxy.are_credentials_defined()
+
+
+def test_proxy_config_with_credentials():
+    proxy = BdkProxyConfig("proxy.symphony.com", 1234, "user", "password")
+
+    assert proxy.get_url() == "http://proxy.symphony.com:1234"
+    assert proxy.are_credentials_defined()
+    assert proxy.get_credentials() == "user:password"

--- a/tests/core/config/test_bdk_config_loader.py
+++ b/tests/core/config/test_bdk_config_loader.py
@@ -1,3 +1,4 @@
+from symphony.bdk.core.config.model.bdk_server_config import BdkProxyConfig
 from tests.utils.resource_utils import get_config_resource_filepath
 from symphony.bdk.core.config.loader import BdkConfigLoader
 from symphony.bdk.core.config.exception import BdkConfigException
@@ -76,3 +77,49 @@ def test_load_client_global_config(global_config_path):
     assert config.session_auth.host == "devx1.symphony.com"
     assert config.session_auth.port == 8443
     assert config.session_auth.context == "context"
+
+
+def test_load_proxy_defined_at_global_level():
+    config = BdkConfigLoader.load_from_file(get_config_resource_filepath("config_global_proxy.yaml"))
+
+    assert config.proxy.host == "proxy.symphony.com"
+    assert config.proxy.port == 1234
+    assert config.proxy.username == "proxyuser"
+    assert config.proxy.password == "proxypass"
+
+    assert config.agent.proxy == config.proxy
+    assert config.pod.proxy == config.proxy
+    assert config.key_manager.proxy == config.proxy
+    assert config.session_auth.proxy == config.proxy
+
+
+def test_load_proxy_defined_at_global_and_child_level():
+    config = BdkConfigLoader.load_from_file(get_config_resource_filepath("config_proxy_global_child.yaml"))
+
+    assert config.proxy.host == "proxy.symphony.com"
+    assert config.proxy.port == 1234
+    assert config.proxy.username == "proxyuser"
+    assert config.proxy.password == "proxypass"
+
+    assert config.pod.proxy == config.proxy
+    assert config.key_manager.proxy == config.proxy
+    assert config.session_auth.proxy == config.proxy
+
+    assert config.agent.proxy.host == "agent-proxy.symphony.com"
+    assert config.agent.proxy.port == 5678
+    assert config.agent.proxy.username is None
+    assert config.agent.proxy.password is None
+
+
+def test_load_proxy_defined_at_child_level_only():
+    config = BdkConfigLoader.load_from_file(get_config_resource_filepath("config_proxy_child_only.yaml"))
+
+    assert config.proxy is None
+    assert config.pod.proxy is None
+    assert config.key_manager.proxy is None
+    assert config.session_auth.proxy is None
+
+    assert config.agent.proxy.host == "agent-proxy.symphony.com"
+    assert config.agent.proxy.port == 5678
+    assert config.agent.proxy.username is None
+    assert config.agent.proxy.password is None

--- a/tests/resources/config/config_global_proxy.yaml
+++ b/tests/resources/config/config_global_proxy.yaml
@@ -1,0 +1,5 @@
+proxy:
+  host: "proxy.symphony.com"
+  port: 1234
+  username: proxyuser
+  password: proxypass

--- a/tests/resources/config/config_proxy_child_only.yaml
+++ b/tests/resources/config/config_proxy_child_only.yaml
@@ -1,0 +1,4 @@
+agent:
+  proxy:
+    host: "agent-proxy.symphony.com"
+    port: 5678

--- a/tests/resources/config/config_proxy_global_child.yaml
+++ b/tests/resources/config/config_proxy_global_child.yaml
@@ -1,0 +1,10 @@
+proxy:
+  host: "proxy.symphony.com"
+  port: 1234
+  username: proxyuser
+  password: proxypass
+
+agent:
+  proxy:
+    host: "agent-proxy.symphony.com"
+    port: 5678


### PR DESCRIPTION
### Ticket
PLAT-10420

### Description
Proxy support with and without basic authentication.
Enforced SSL verification with a configurable truststore (otherwise it will use the default system CA).

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [x] Docstrings added or updated
- [x] Updated the documentation in [docs folder](../docs)
