### PR TITLE
PLAT-10343: Datafeed V2 service implementation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,6 +86,9 @@ app:
   appId: app-id
   privateKey:
     path: path/to/private-key.pem
+
+datafeed:
+  version: v2
 ```
 
 ### Configuration structure
@@ -110,3 +113,6 @@ manager which manages the key token of the bot.
   on pod.
 - `app` contains information about the extension app that the bot will use like
 the appId, the private key for authenticating the extension app.
+- `datafeed` contains information about the datafeed service that the bot will use for the `DatafeedLoop` service.
+If the version field is configured to `v2`, the datafeed service v2 will be used. Otherwise, the datafeed service v1 
+will be used by default.

--- a/symphony/bdk/core/config/model/bdk_datafeed_config.py
+++ b/symphony/bdk/core/config/model/bdk_datafeed_config.py
@@ -15,10 +15,11 @@ class BdkDatafeedConfig:
 
         :param config: the dict containing the datafeed specific confguration.
         """
-        self.version = config.get(VERSION) if VERSION in config else DF_V1
+        self.version = DF_V1
         self.id_file_path = ""
-        if config is not None and DF_ID_FILE_PATH in config:
-            self.id_file_path = Path(config.get(DF_ID_FILE_PATH))
+        if config is not None:
+            self.id_file_path = Path(config.get(DF_ID_FILE_PATH)) if DF_ID_FILE_PATH in config else ""
+            self.version = config.get(VERSION)
 
     def get_id_file_path(self) -> Path:
         """

--- a/symphony/bdk/core/config/model/bdk_datafeed_config.py
+++ b/symphony/bdk/core/config/model/bdk_datafeed_config.py
@@ -15,7 +15,7 @@ class BdkDatafeedConfig:
 
         :param config: the dict containing the datafeed specific confguration.
         """
-        self.version = DF_V1
+        self.version = config.get(VERSION) if VERSION in config else DF_V1
         self.id_file_path = ""
         if config is not None and DF_ID_FILE_PATH in config:
             self.id_file_path = Path(config.get(DF_ID_FILE_PATH))

--- a/symphony/bdk/core/service/datafeed/abstract_datafeed_loop.py
+++ b/symphony/bdk/core/service/datafeed/abstract_datafeed_loop.py
@@ -6,14 +6,20 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import List
 
-from symphony.bdk.core.config.model.bdk_config import BdkConfig
 from symphony.bdk.core.auth.auth_session import AuthSession
-
-from symphony.bdk.gen.agent_api.datafeed_api import DatafeedApi
+from symphony.bdk.core.config.model.bdk_config import BdkConfig
 from symphony.bdk.core.service.datafeed.real_time_event_listener import RealTimeEventListener
+from symphony.bdk.gen.agent_api.datafeed_api import DatafeedApi
 from symphony.bdk.gen.agent_model.v4_event import V4Event
 
 logger = logging.getLogger(__name__)
+
+
+class DatafeedVersion(Enum):
+
+    V1 = "v1"
+    V2 = "v2"
+
 
 class RealTimeEvent(Enum):
     """This enum lists all possible

--- a/symphony/bdk/core/service/datafeed/datafeed_loop_v2.py
+++ b/symphony/bdk/core/service/datafeed/datafeed_loop_v2.py
@@ -1,0 +1,90 @@
+from symphony.bdk.core.auth.auth_session import AuthSession
+from symphony.bdk.core.config.model.bdk_config import BdkConfig
+from symphony.bdk.core.service.datafeed.abstract_datafeed_loop import AbstractDatafeedLoop
+from symphony.bdk.gen import ApiException
+from symphony.bdk.gen.agent_api.datafeed_api import DatafeedApi
+from symphony.bdk.gen.agent_model.ack_id import AckId
+from symphony.bdk.gen.agent_model.v5_datafeed import V5Datafeed
+from typing import Optional
+
+
+class DatafeedLoopV2(AbstractDatafeedLoop):
+    """A class for implementing the datafeed v2 loop service.
+
+        This service will be started by calling :func:`~DatafeedLoopV2.start`.
+
+        On the very first run, the BDK bot will try to retrieve the list of datafeed to which it is listening.
+        Since each bot should only listening to just one datafeed, the first datafeed in the list will be used by
+        the bot to be listened to. If the retrieved list is empty, the BDK bot will create a new datafeed to listen.
+
+        The BDK bot will listen to this datafeed to get all the received real-time events.
+
+        If this datafeed becomes stale or faulty, the BDK bot will create the new one for listening.
+
+        This service will be stopped by calling :func:`~DatafeedLoopV1.stop`
+
+        If the datafeed service is stopped during a read datafeed call, it has to wait until the last read finish to be
+        really stopped
+        """
+
+    def __init__(self, datafeed_api: DatafeedApi, auth_session: AuthSession, config: BdkConfig):
+        super().__init__(datafeed_api, auth_session, config)
+        self._ack_id = ""
+        self.started = False
+        self.datafeed_id = None
+
+    async def start(self):
+        datafeed = await self._retrieve_datafeed()
+        if not datafeed:
+            datafeed = await self._create_datafeed()
+        self.datafeed_id = datafeed.id
+        self.started = True
+        while self.started:
+            try:
+                await self._read_datafeed()
+            except ApiException as e:
+                if e.status == 400:
+                    datafeed = await self._recreate_datafeed()
+                    self.datafeed_id = datafeed.id
+                else:
+                    raise e
+
+    async def stop(self):
+        self.started = False
+
+    async def _retrieve_datafeed(self) -> Optional[V5Datafeed]:
+        session_token = await self.auth_session.session_token
+        key_manager_token = await self.auth_session.key_manager_token
+        datafeeds = await self.datafeed_api.list_datafeed(session_token=session_token,
+                                                          key_manager_token=key_manager_token)
+        if datafeeds:
+            return datafeeds[0]
+        return None
+
+    async def _create_datafeed(self) -> V5Datafeed:
+        session_token = await self.auth_session.session_token
+        key_manager_token = await self.auth_session.key_manager_token
+        return await self.datafeed_api.create_datafeed(session_token=session_token, key_manager_token=key_manager_token)
+
+    async def _read_datafeed(self):
+        params = {
+            'session_token': await self.auth_session.session_token,
+            'key_manager_token': await self.auth_session.key_manager_token,
+            'datafeed_id': self.datafeed_id,
+            'ack_id': AckId(ack_id=self._ack_id)
+        }
+        event_list = await self.datafeed_api.read_datafeed(**params)
+        self._ack_id = event_list.ack_id
+        if event_list.events:
+            await self.handle_v4_event_list(events=event_list.events)
+
+    async def _delete_datafeed(self) -> None:
+        session_token = await self.auth_session.session_token
+        key_manager_token = await self.auth_session.key_manager_token
+        await self.datafeed_api.delete_datafeed(datafeed_id=self.datafeed_id,
+                                                session_token=session_token,
+                                                key_manager_token=key_manager_token)
+
+    async def _recreate_datafeed(self):
+        await self._delete_datafeed()
+        return await self._create_datafeed()

--- a/symphony/bdk/core/service_factory.py
+++ b/symphony/bdk/core/service_factory.py
@@ -2,7 +2,9 @@ from symphony.bdk.core.auth.auth_session import AuthSession
 from symphony.bdk.core.client.api_client_factory import ApiClientFactory
 from symphony.bdk.core.config.model.bdk_config import BdkConfig
 from symphony.bdk.core.service.connection.connection_service import ConnectionService
+from symphony.bdk.core.service.datafeed.abstract_datafeed_loop import DatafeedVersion, AbstractDatafeedLoop
 from symphony.bdk.core.service.datafeed.datafeed_loop_v1 import DatafeedLoopV1
+from symphony.bdk.core.service.datafeed.datafeed_loop_v2 import DatafeedLoopV2
 from symphony.bdk.core.service.message.message_service import MessageService
 from symphony.bdk.core.service.message.multi_attachments_messages_api import MultiAttachmentsMessagesApi
 from symphony.bdk.core.service.stream.stream_service import StreamService
@@ -94,11 +96,18 @@ class ServiceFactory:
             ShareApi(self._agent_client),
             self._auth_session)
 
-    def get_datafeed_loop(self) -> DatafeedLoopV1:
+    def get_datafeed_loop(self) -> AbstractDatafeedLoop:
         """Returns a fully initialized DatafeedLoop
 
         :return: a new DatafeedLoop instance.
         """
+        df_version = self._config.datafeed.version
+        if df_version.lower() == DatafeedVersion.V2.value.lower():
+            return DatafeedLoopV2(
+                DatafeedApi(self._agent_client),
+                self._auth_session,
+                self._config
+            )
         return DatafeedLoopV1(
             DatafeedApi(self._agent_client),
             self._auth_session,

--- a/symphony/bdk/core/symphony_bdk.py
+++ b/symphony/bdk/core/symphony_bdk.py
@@ -3,7 +3,7 @@ from symphony.bdk.core.auth.authenticator_factory import AuthenticatorFactory
 from symphony.bdk.core.auth.exception import AuthInitializationException
 from symphony.bdk.core.client.api_client_factory import ApiClientFactory
 from symphony.bdk.core.service.connection.connection_service import ConnectionService
-from symphony.bdk.core.service.datafeed.datafeed_loop_v1 import DatafeedLoopV1
+from symphony.bdk.core.service.datafeed.abstract_datafeed_loop import AbstractDatafeedLoop
 from symphony.bdk.core.service.message.message_service import MessageService
 from symphony.bdk.core.service.stream.stream_service import StreamService
 from symphony.bdk.core.service.user.user_service import UserService
@@ -73,7 +73,7 @@ class SymphonyBdk:
         """
         return self._stream_service
 
-    def datafeed(self) -> DatafeedLoopV1:
+    def datafeed(self) -> AbstractDatafeedLoop:
         """Get the Datafeed loop from the BDK entry point.
 
         :return: The Datafeed Loop instance.

--- a/tests/core/config/models/test_bdk_datafeed_config.py
+++ b/tests/core/config/models/test_bdk_datafeed_config.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 
-@pytest.fixture(params=["v1", 25, True])
+@pytest.fixture(params=["v1"])
 def datafeed_version(request):
     return request.param
 

--- a/tests/core/service/datafeed/datafeed_loop_v2_test.py
+++ b/tests/core/service/datafeed/datafeed_loop_v2_test.py
@@ -1,0 +1,174 @@
+from unittest.mock import MagicMock, AsyncMock, call
+
+import pytest
+
+from symphony.bdk.core.auth.auth_session import AuthSession
+from symphony.bdk.core.config.loader import BdkConfigLoader
+from symphony.bdk.core.service.datafeed.abstract_datafeed_loop import RealTimeEvent
+from symphony.bdk.core.service.datafeed.datafeed_loop_v2 import DatafeedLoopV2
+from symphony.bdk.core.service.datafeed.real_time_event_listener import RealTimeEventListener
+from symphony.bdk.gen import ApiClient, ApiException
+from symphony.bdk.gen.agent_api.datafeed_api import DatafeedApi
+from symphony.bdk.gen.agent_model.ack_id import AckId
+from symphony.bdk.gen.agent_model.datafeed import Datafeed
+from symphony.bdk.gen.agent_model.v4_event import V4Event
+from symphony.bdk.gen.agent_model.v4_initiator import V4Initiator
+from symphony.bdk.gen.agent_model.v4_message_sent import V4MessageSent
+from symphony.bdk.gen.agent_model.v4_payload import V4Payload
+from symphony.bdk.gen.agent_model.v4_user import V4User
+from tests.utils.resource_utils import get_config_resource_filepath
+
+
+@pytest.fixture()
+def auth_session():
+    auth_session = AuthSession(None)
+    auth_session.session_token = "session_token"
+    auth_session.key_manager_token = "km_token"
+    return auth_session
+
+
+@pytest.fixture()
+def config():
+    config = BdkConfigLoader.load_from_file(get_config_resource_filepath("config.yaml"))
+    config.datafeed.version = "v2"
+    return config
+
+
+@pytest.fixture()
+def datafeed_api():
+    datafeed_api = MagicMock(DatafeedApi)
+    datafeed_api.api_client = MagicMock(ApiClient)
+    datafeed_api.list_datafeed = AsyncMock()
+    datafeed_api.create_datafeed = AsyncMock()
+    datafeed_api.read_datafeed = AsyncMock()
+    datafeed_api.delete_datafeed = AsyncMock()
+    return datafeed_api
+
+
+@pytest.fixture()
+def mock_listener():
+    return AsyncMock(wraps=RealTimeEventListener())
+
+
+@pytest.fixture()
+def initiator():
+    return V4Initiator(user=V4User(username="username"))
+
+
+@pytest.fixture()
+def message_sent_event(initiator):
+    class EventsMock:
+        def __init__(self, individual_event):
+            self.events = [individual_event]
+            self.ack_id = "ack_id"
+
+    v4_event = V4Event(type=RealTimeEvent.MESSAGESENT.name,
+                       payload=V4Payload(message_sent=V4MessageSent()),
+                       initiator=initiator)
+    event = EventsMock(v4_event)
+    return event
+
+
+@pytest.fixture()
+def datafeed_loop(datafeed_api, auth_session, config):
+    datafeed_loop = DatafeedLoopV2(datafeed_api, auth_session, config)
+
+    class RealTimeEventListenerImpl(RealTimeEventListener):
+
+        async def on_message_sent(self, initiator: V4Initiator, event: V4MessageSent):
+            await datafeed_loop.stop()
+
+    datafeed_loop.subscribe(RealTimeEventListenerImpl())
+    return datafeed_loop
+
+
+@pytest.mark.asyncio
+async def test_start(datafeed_loop, datafeed_api, message_sent_event):
+    datafeed_api.list_datafeed.return_value = []
+    datafeed_api.create_datafeed.return_value = Datafeed(id="test_id")
+    datafeed_api.read_datafeed.return_value = message_sent_event
+
+    await datafeed_loop.start()
+
+    datafeed_api.list_datafeed.assert_called_with(
+        session_token="session_token",
+        key_manager_token="km_token"
+    )
+    datafeed_api.create_datafeed.assert_called_with(
+        session_token="session_token",
+        key_manager_token="km_token"
+    )
+    datafeed_api.read_datafeed.assert_called_with(
+        session_token="session_token",
+        key_manager_token="km_token",
+        datafeed_id="test_id",
+        ack_id=AckId(ack_id="")
+    )
+
+    assert datafeed_loop._datafeed_id == "test_id"
+    assert datafeed_loop._ack_id == "ack_id"
+
+
+@pytest.mark.asyncio
+async def test_start_datafeed_exist(datafeed_loop, datafeed_api, message_sent_event):
+    datafeed_api.list_datafeed.return_value = [Datafeed(id="test_id_exist")]
+    datafeed_api.read_datafeed.return_value = message_sent_event
+
+    await datafeed_loop.start()
+
+    datafeed_api.list_datafeed.assert_called_with(
+        session_token="session_token",
+        key_manager_token="km_token"
+    )
+    datafeed_api.read_datafeed.assert_called_with(
+        session_token="session_token",
+        key_manager_token="km_token",
+        datafeed_id="test_id_exist",
+        ack_id=AckId(ack_id="")
+    )
+
+    assert datafeed_loop._datafeed_id == "test_id_exist"
+    assert datafeed_loop._ack_id == "ack_id"
+
+
+@pytest.mark.asyncio
+async def test_start_datafeed_stale_datafeed(datafeed_loop, datafeed_api, message_sent_event):
+    datafeed_api.list_datafeed.return_value = [Datafeed(id="fault_datafeed_id")]
+    datafeed_api.create_datafeed.return_value = Datafeed(id="test_id")
+    datafeed_api.read_datafeed.side_effect = [ApiException(400), message_sent_event]
+
+    await datafeed_loop.start()
+
+    datafeed_api.list_datafeed.assert_called_with(
+        session_token="session_token",
+        key_manager_token="km_token"
+    )
+
+    datafeed_api.delete_datafeed.assert_called_with(
+        session_token="session_token",
+        key_manager_token="km_token",
+        datafeed_id="fault_datafeed_id"
+    )
+
+    datafeed_api.create_datafeed.assert_called_with(
+        session_token="session_token",
+        key_manager_token="km_token"
+    )
+
+    datafeed_api.read_datafeed.assert_has_calls([
+        call(
+            session_token="session_token",
+            key_manager_token="km_token",
+            datafeed_id="fault_datafeed_id",
+            ack_id=AckId(ack_id="")
+        ),
+        call(
+            session_token="session_token",
+            key_manager_token="km_token",
+            datafeed_id="test_id",
+            ack_id=AckId(ack_id="")
+        )
+    ])
+
+    assert datafeed_loop._datafeed_id == "test_id"
+    assert datafeed_loop._ack_id == "ack_id"

--- a/tests/core/service_factory_test.py
+++ b/tests/core/service_factory_test.py
@@ -1,0 +1,82 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from symphony.bdk.core.auth.auth_session import AuthSession
+from symphony.bdk.core.client.api_client_factory import ApiClientFactory
+from symphony.bdk.core.config.loader import BdkConfigLoader
+from symphony.bdk.core.service.connection.connection_service import ConnectionService
+from symphony.bdk.core.service.datafeed.datafeed_loop_v1 import DatafeedLoopV1
+from symphony.bdk.core.service.datafeed.datafeed_loop_v2 import DatafeedLoopV2
+from symphony.bdk.core.service.message.message_service import MessageService
+from symphony.bdk.core.service.stream.stream_service import StreamService
+from symphony.bdk.core.service.user.user_service import UserService
+from symphony.bdk.core.service_factory import ServiceFactory
+from symphony.bdk.gen import ApiClient
+from tests.utils.resource_utils import get_config_resource_filepath
+
+
+@pytest.fixture()
+def api_client_factory():
+    factory = MagicMock(ApiClientFactory)
+    api_client = MagicMock(ApiClient)
+    factory.get_pod_client.return_value = api_client
+    factory.get_agent_client.return_value = api_client
+    return factory
+
+
+@pytest.fixture()
+def config():
+    config = BdkConfigLoader.load_from_file(get_config_resource_filepath("config.yaml"))
+    return config
+
+
+@pytest.fixture()
+def service_factory(api_client_factory, config):
+    factory = ServiceFactory(api_client_factory, AuthSession(None), config)
+    return factory
+
+
+def test_get_user_service(service_factory):
+    user_service = service_factory.get_user_service()
+    assert user_service is not None
+    assert type(user_service) == UserService
+
+
+def test_get_message_service(service_factory):
+    message_service = service_factory.get_message_service()
+    assert message_service is not None
+    assert type(message_service) == MessageService
+
+
+def test_get_connection_service(service_factory):
+    connection_service = service_factory.get_connection_service()
+    assert connection_service is not None
+    assert type(connection_service) == ConnectionService
+
+
+def test_get_stream_service(service_factory):
+    stream_service = service_factory.get_stream_service()
+    assert stream_service is not None
+    assert type(stream_service) == StreamService
+
+
+def test_get_datafeed_loop(config, service_factory):
+    datafeed_loop = service_factory.get_datafeed_loop()
+    assert datafeed_loop is not None
+    assert type(datafeed_loop) == DatafeedLoopV1
+
+    config.datafeed.version = "v1"
+    datafeed_loop = service_factory.get_datafeed_loop()
+    assert datafeed_loop is not None
+    assert type(datafeed_loop) == DatafeedLoopV1
+
+    config.datafeed.version = "something"
+    datafeed_loop = service_factory.get_datafeed_loop()
+    assert datafeed_loop is not None
+    assert type(datafeed_loop) == DatafeedLoopV1
+
+    config.datafeed.version = "v2"
+    datafeed_loop = service_factory.get_datafeed_loop()
+    assert datafeed_loop is not None
+    assert type(datafeed_loop) == DatafeedLoopV2


### PR DESCRIPTION
**Draft PR for early review without unittest yet**

### Ticket
[PLAT-10343](https://perzoinc.atlassian.net/browse/PLAT-10343)

### Description
Datafeed V2 service implementation.

In the BdkDatafeedConfig class, check if the `datafeed.version` configuration is
specified. If not, the datafeed version equals `v1`

In the ServiceFactory class, check if the datafeed version is configured as `v2`, return
the DatafeedLoopV2 instance. Otherwise, the DatafeedLoopV1 will be used by default.

Implementation the datafeed v2 loop service in DatafeedLoopV2 class

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [x] Docstrings added or updated
- [ ] Updated the documentation in [docs folder](../docs)
