### PR TITLE
PLAT-10646: Unknown event breaks DF loop

### DIFF
--- a/sym_api_client_python/datafeed_event_service.py
+++ b/sym_api_client_python/datafeed_event_service.py
@@ -378,9 +378,9 @@ class AsyncDataFeedEventService(AbstractDatafeedEventService):
                 try:
                     route = self.routing_dict[event_type]
                 except KeyError:
-                    log.debug('no event detected')
+                    log.debug('Event with unsupported type ' + event_type + ' detected')
                     self.queue.task_done()
-                    return
+                    continue
 
                 future = asyncio.ensure_future(route(event))
                 future.add_done_callback(partial(self._check_result, e_id))


### PR DESCRIPTION
### Ticket
[PLAT-10646](https://perzoinc.atlassian.net/browse/PLAT-10646)

### Description
An unknown event was causing the handle_events part of the DF loop to
exit (i.e return instead of continuing the loop).

Also print the event type in the log to have it with context.

### Dependencies
N/A

### Checklist
- [X] Referenced a ticket in the PR title and in the corresponding section
- [X] Filled properly the description and dependencies, if any
- [X] Unit tests updated or added
- [-] Docstrings added or updated
- [-] Updated the documentation in [docs folder](../docs)
