### PR TITLE
PLAT-10652: regenerated all models to enable autocomplete

### DIFF
--- a/docsrc/markdown/tech/generated_api.md
+++ b/docsrc/markdown/tech/generated_api.md
@@ -9,8 +9,11 @@ from [swagger specifications](https://github.com/symphonyoss/symphony-api-spec) 
 * [login/login-api-public.yaml](https://github.com/symphonyoss/symphony-api-spec/blob/master/login/login-api-public.yaml)
 * [pod/pod-api-public-deprecated.yaml](https://github.com/symphonyoss/symphony-api-spec/blob/master/pod/pod-api-public-deprecated.yaml)
 
-In order to re-generate these files:
-* download the [openapi-generator-cli jar](https://search.maven.org/artifact/org.openapitools/openapi-generator-cli/5.0.0/jar)
-  from Maven Central
-* download the swagger specs from [symphony-api-spec repo](https://github.com/symphonyoss/symphony-api-spec)
-* run ` java -jar openapi-generator-cli-5.0.0.jar generate -g python -i path/to/spec.yaml -t templates --package-name symphony.bdk.gen -o output`
+In order to re-generate model and api files, run
+```shell
+cd project_root/templates
+./generate_client_api.sh
+```
+
+The file templates/open-api-generator-cli.jar used to generated model and api files was created from sources
+[here](https://github.com/symphony-elias/openapi-generator/tree/PLAT-10652) to accommodate for type hinting.

--- a/symphony/bdk/core/client/api_client_factory.py
+++ b/symphony/bdk/core/client/api_client_factory.py
@@ -69,7 +69,7 @@ class ApiClientFactory:
         await self._session_auth_client.close()
 
     def _get_api_client(self, server_config, context) -> ApiClient:
-        configuration = Configuration(host=(server_config.get_base_path() + context))
+        configuration = Configuration(host=(server_config.get_base_path() + context), discard_unknown_keys=True)
         configuration.verify_ssl = True
         configuration.ssl_ca_cert = self._config.ssl.trust_store_path
 

--- a/symphony/bdk/gen/agent_api/attachments_api.py
+++ b/symphony/bdk/gen/agent_api/attachments_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -118,7 +118,7 @@ class AttachmentsApi(object):
                 key_manager_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_stream_sid_attachment_get = Endpoint(
+        self.v1_stream_sid_attachment_get = _Endpoint(
             settings={
                 'response_type': (str,),
                 'auth': [],

--- a/symphony/bdk/gen/agent_api/audit_trail_api.py
+++ b/symphony/bdk/gen/agent_api/audit_trail_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -117,7 +117,7 @@ class AuditTrailApi(object):
                 start_timestamp
             return self.call_with_http_info(**kwargs)
 
-        self.v1_audittrail_privilegeduser_get = Endpoint(
+        self.v1_audittrail_privilegeduser_get = _Endpoint(
             settings={
                 'response_type': (V1AuditTrailInitiatorList,),
                 'auth': [],

--- a/symphony/bdk/gen/agent_api/datafeed_api.py
+++ b/symphony/bdk/gen/agent_api/datafeed_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -111,7 +111,7 @@ class DatafeedApi(object):
                 key_manager_token
             return self.call_with_http_info(**kwargs)
 
-        self.create_datafeed = Endpoint(
+        self.create_datafeed = _Endpoint(
             settings={
                 'response_type': (V5Datafeed,),
                 'auth': [],
@@ -242,7 +242,7 @@ class DatafeedApi(object):
                 key_manager_token
             return self.call_with_http_info(**kwargs)
 
-        self.delete_datafeed = Endpoint(
+        self.delete_datafeed = _Endpoint(
             settings={
                 'response_type': (V2Error,),
                 'auth': [],
@@ -375,7 +375,7 @@ class DatafeedApi(object):
                 key_manager_token
             return self.call_with_http_info(**kwargs)
 
-        self.list_datafeed = Endpoint(
+        self.list_datafeed = _Endpoint(
             settings={
                 'response_type': ([V5Datafeed],),
                 'auth': [],
@@ -508,7 +508,7 @@ class DatafeedApi(object):
                 key_manager_token
             return self.call_with_http_info(**kwargs)
 
-        self.read_datafeed = Endpoint(
+        self.read_datafeed = _Endpoint(
             settings={
                 'response_type': (V5EventList,),
                 'auth': [],
@@ -647,7 +647,7 @@ class DatafeedApi(object):
                 key_manager_token
             return self.call_with_http_info(**kwargs)
 
-        self.v4_datafeed_create_post = Endpoint(
+        self.v4_datafeed_create_post = _Endpoint(
             settings={
                 'response_type': (Datafeed,),
                 'auth': [],
@@ -779,7 +779,7 @@ class DatafeedApi(object):
                 key_manager_token
             return self.call_with_http_info(**kwargs)
 
-        self.v4_datafeed_id_read_get = Endpoint(
+        self.v4_datafeed_id_read_get = _Endpoint(
             settings={
                 'response_type': (V4EventList,),
                 'auth': [],

--- a/symphony/bdk/gen/agent_api/dlp_policies_and_dictionary_management_api.py
+++ b/symphony/bdk/gen/agent_api/dlp_policies_and_dictionary_management_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -121,7 +121,7 @@ class DLPPoliciesAndDictionaryManagementApi(object):
                 dict_id
             return self.call_with_http_info(**kwargs)
 
-        self.v1_dlp_dictionaries_dict_id_data_download_get = Endpoint(
+        self.v1_dlp_dictionaries_dict_id_data_download_get = _Endpoint(
             settings={
                 'response_type': (str,),
                 'auth': [],
@@ -267,7 +267,7 @@ class DLPPoliciesAndDictionaryManagementApi(object):
                 data
             return self.call_with_http_info(**kwargs)
 
-        self.v1_dlp_dictionaries_dict_id_data_upload_post = Endpoint(
+        self.v1_dlp_dictionaries_dict_id_data_upload_post = _Endpoint(
             settings={
                 'response_type': (V1DLPDictionaryMetadataResponse,),
                 'auth': [],
@@ -412,7 +412,7 @@ class DLPPoliciesAndDictionaryManagementApi(object):
                 dict_id
             return self.call_with_http_info(**kwargs)
 
-        self.v1_dlp_dictionaries_dict_id_delete = Endpoint(
+        self.v1_dlp_dictionaries_dict_id_delete = _Endpoint(
             settings={
                 'response_type': (V1DLPDictionaryMetadataResponse,),
                 'auth': [],
@@ -550,7 +550,7 @@ class DLPPoliciesAndDictionaryManagementApi(object):
                 dict_id
             return self.call_with_http_info(**kwargs)
 
-        self.v1_dlp_dictionaries_dict_id_get = Endpoint(
+        self.v1_dlp_dictionaries_dict_id_get = _Endpoint(
             settings={
                 'response_type': (V1DLPDictionaryMetadataResponse,),
                 'auth': [],
@@ -696,7 +696,7 @@ class DLPPoliciesAndDictionaryManagementApi(object):
                 body
             return self.call_with_http_info(**kwargs)
 
-        self.v1_dlp_dictionaries_dict_id_put = Endpoint(
+        self.v1_dlp_dictionaries_dict_id_put = _Endpoint(
             settings={
                 'response_type': (V1DLPDictionaryMetadataResponse,),
                 'auth': [],
@@ -838,7 +838,7 @@ class DLPPoliciesAndDictionaryManagementApi(object):
                 key_manager_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_dlp_dictionaries_get = Endpoint(
+        self.v1_dlp_dictionaries_get = _Endpoint(
             settings={
                 'response_type': (V1DLPDictionaryMetadataCollectionResponse,),
                 'auth': [],
@@ -979,7 +979,7 @@ class DLPPoliciesAndDictionaryManagementApi(object):
                 body
             return self.call_with_http_info(**kwargs)
 
-        self.v1_dlp_dictionaries_post = Endpoint(
+        self.v1_dlp_dictionaries_post = _Endpoint(
             settings={
                 'response_type': (V1DLPDictionaryMetadataResponse,),
                 'auth': [],
@@ -1115,7 +1115,7 @@ class DLPPoliciesAndDictionaryManagementApi(object):
                 key_manager_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_dlp_policies_get = Endpoint(
+        self.v1_dlp_policies_get = _Endpoint(
             settings={
                 'response_type': (V1DLPPoliciesCollectionResponse,),
                 'auth': [],
@@ -1256,7 +1256,7 @@ class DLPPoliciesAndDictionaryManagementApi(object):
                 policy_id
             return self.call_with_http_info(**kwargs)
 
-        self.v1_dlp_policies_policy_id_delete = Endpoint(
+        self.v1_dlp_policies_policy_id_delete = _Endpoint(
             settings={
                 'response_type': (V1DLPPolicyResponse,),
                 'auth': [],
@@ -1393,7 +1393,7 @@ class DLPPoliciesAndDictionaryManagementApi(object):
                 policy_id
             return self.call_with_http_info(**kwargs)
 
-        self.v1_dlp_policies_policy_id_disable_post = Endpoint(
+        self.v1_dlp_policies_policy_id_disable_post = _Endpoint(
             settings={
                 'response_type': (V1DLPPolicyResponse,),
                 'auth': [],
@@ -1530,7 +1530,7 @@ class DLPPoliciesAndDictionaryManagementApi(object):
                 policy_id
             return self.call_with_http_info(**kwargs)
 
-        self.v1_dlp_policies_policy_id_enable_post = Endpoint(
+        self.v1_dlp_policies_policy_id_enable_post = _Endpoint(
             settings={
                 'response_type': (V1DLPPolicyResponse,),
                 'auth': [],
@@ -1668,7 +1668,7 @@ class DLPPoliciesAndDictionaryManagementApi(object):
                 policy_id
             return self.call_with_http_info(**kwargs)
 
-        self.v1_dlp_policies_policy_id_get = Endpoint(
+        self.v1_dlp_policies_policy_id_get = _Endpoint(
             settings={
                 'response_type': (V1DLPPolicyResponse,),
                 'auth': [],
@@ -1814,7 +1814,7 @@ class DLPPoliciesAndDictionaryManagementApi(object):
                 body
             return self.call_with_http_info(**kwargs)
 
-        self.v1_dlp_policies_policy_id_put = Endpoint(
+        self.v1_dlp_policies_policy_id_put = _Endpoint(
             settings={
                 'response_type': (V1DLPPolicyResponse,),
                 'auth': [],
@@ -1958,7 +1958,7 @@ class DLPPoliciesAndDictionaryManagementApi(object):
                 body
             return self.call_with_http_info(**kwargs)
 
-        self.v1_dlp_policies_post = Endpoint(
+        self.v1_dlp_policies_post = _Endpoint(
             settings={
                 'response_type': (V1DLPPolicyResponse,),
                 'auth': [],
@@ -2094,7 +2094,7 @@ class DLPPoliciesAndDictionaryManagementApi(object):
                 key_manager_token
             return self.call_with_http_info(**kwargs)
 
-        self.v3_dlp_policies_get = Endpoint(
+        self.v3_dlp_policies_get = _Endpoint(
             settings={
                 'response_type': (V3DLPPoliciesCollectionResponse,),
                 'auth': [],
@@ -2235,7 +2235,7 @@ class DLPPoliciesAndDictionaryManagementApi(object):
                 policy_id
             return self.call_with_http_info(**kwargs)
 
-        self.v3_dlp_policies_policy_id_delete_post = Endpoint(
+        self.v3_dlp_policies_policy_id_delete_post = _Endpoint(
             settings={
                 'response_type': (V3DLPPolicyResponse,),
                 'auth': [],
@@ -2372,7 +2372,7 @@ class DLPPoliciesAndDictionaryManagementApi(object):
                 policy_id
             return self.call_with_http_info(**kwargs)
 
-        self.v3_dlp_policies_policy_id_disable_post = Endpoint(
+        self.v3_dlp_policies_policy_id_disable_post = _Endpoint(
             settings={
                 'response_type': (V3DLPPolicyResponse,),
                 'auth': [],
@@ -2509,7 +2509,7 @@ class DLPPoliciesAndDictionaryManagementApi(object):
                 policy_id
             return self.call_with_http_info(**kwargs)
 
-        self.v3_dlp_policies_policy_id_enable_post = Endpoint(
+        self.v3_dlp_policies_policy_id_enable_post = _Endpoint(
             settings={
                 'response_type': (V3DLPPolicyResponse,),
                 'auth': [],
@@ -2647,7 +2647,7 @@ class DLPPoliciesAndDictionaryManagementApi(object):
                 policy_id
             return self.call_with_http_info(**kwargs)
 
-        self.v3_dlp_policies_policy_id_get = Endpoint(
+        self.v3_dlp_policies_policy_id_get = _Endpoint(
             settings={
                 'response_type': (V3DLPPolicyResponse,),
                 'auth': [],
@@ -2793,7 +2793,7 @@ class DLPPoliciesAndDictionaryManagementApi(object):
                 body
             return self.call_with_http_info(**kwargs)
 
-        self.v3_dlp_policies_policy_id_update_post = Endpoint(
+        self.v3_dlp_policies_policy_id_update_post = _Endpoint(
             settings={
                 'response_type': (V3DLPPolicyResponse,),
                 'auth': [],
@@ -2937,7 +2937,7 @@ class DLPPoliciesAndDictionaryManagementApi(object):
                 body
             return self.call_with_http_info(**kwargs)
 
-        self.v3_dlp_policies_post = Endpoint(
+        self.v3_dlp_policies_post = _Endpoint(
             settings={
                 'response_type': (V3DLPPolicyResponse,),
                 'auth': [],

--- a/symphony/bdk/gen/agent_api/messages_api.py
+++ b/symphony/bdk/gen/agent_api/messages_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -115,7 +115,7 @@ class MessagesApi(object):
                 id
             return self.call_with_http_info(**kwargs)
 
-        self.v1_message_id_get = Endpoint(
+        self.v1_message_id_get = _Endpoint(
             settings={
                 'response_type': (V4Message,),
                 'auth': [],
@@ -256,7 +256,7 @@ class MessagesApi(object):
                 key_manager_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_message_search_get = Endpoint(
+        self.v1_message_search_get = _Endpoint(
             settings={
                 'response_type': (V4MessageList,),
                 'auth': [],
@@ -417,7 +417,7 @@ class MessagesApi(object):
                 query
             return self.call_with_http_info(**kwargs)
 
-        self.v1_message_search_post = Endpoint(
+        self.v1_message_search_post = _Endpoint(
             settings={
                 'response_type': (V4MessageList,),
                 'auth': [],
@@ -577,7 +577,7 @@ class MessagesApi(object):
                 sids
             return self.call_with_http_info(**kwargs)
 
-        self.v4_message_blast_post = Endpoint(
+        self.v4_message_blast_post = _Endpoint(
             settings={
                 'response_type': (V4MessageBlastResponse,),
                 'auth': [],
@@ -741,7 +741,7 @@ class MessagesApi(object):
                 message_list
             return self.call_with_http_info(**kwargs)
 
-        self.v4_message_import_post = Endpoint(
+        self.v4_message_import_post = _Endpoint(
             settings={
                 'response_type': (V4ImportResponseList,),
                 'auth': [],
@@ -881,7 +881,7 @@ class MessagesApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v4_stream_sid_message_create_post = Endpoint(
+        self.v4_stream_sid_message_create_post = _Endpoint(
             settings={
                 'response_type': (V4Message,),
                 'auth': [],
@@ -1050,7 +1050,7 @@ class MessagesApi(object):
                 key_manager_token
             return self.call_with_http_info(**kwargs)
 
-        self.v4_stream_sid_message_get = Endpoint(
+        self.v4_stream_sid_message_get = _Endpoint(
             settings={
                 'response_type': (V4MessageList,),
                 'auth': [],

--- a/symphony/bdk/gen/agent_api/share_api.py
+++ b/symphony/bdk/gen/agent_api/share_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -113,7 +113,7 @@ class ShareApi(object):
                 share_content
             return self.call_with_http_info(**kwargs)
 
-        self.v3_stream_sid_share_post = Endpoint(
+        self.v3_stream_sid_share_post = _Endpoint(
             settings={
                 'response_type': (V2Message,),
                 'auth': [],

--- a/symphony/bdk/gen/agent_api/signals_api.py
+++ b/symphony/bdk/gen/agent_api/signals_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -103,7 +103,7 @@ class SignalsApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             return self.call_with_http_info(**kwargs)
 
-        self.v1_info_get = Endpoint(
+        self.v1_info_get = _Endpoint(
             settings={
                 'response_type': (AgentInfo,),
                 'auth': [],
@@ -217,7 +217,7 @@ class SignalsApi(object):
                 signal
             return self.call_with_http_info(**kwargs)
 
-        self.v1_signals_create_post = Endpoint(
+        self.v1_signals_create_post = _Endpoint(
             settings={
                 'response_type': (Signal,),
                 'auth': [],
@@ -350,7 +350,7 @@ class SignalsApi(object):
                 id
             return self.call_with_http_info(**kwargs)
 
-        self.v1_signals_id_delete_post = Endpoint(
+        self.v1_signals_id_delete_post = _Endpoint(
             settings={
                 'response_type': (SuccessResponse,),
                 'auth': [],
@@ -482,7 +482,7 @@ class SignalsApi(object):
                 id
             return self.call_with_http_info(**kwargs)
 
-        self.v1_signals_id_get_get = Endpoint(
+        self.v1_signals_id_get_get = _Endpoint(
             settings={
                 'response_type': (Signal,),
                 'auth': [],
@@ -616,7 +616,7 @@ class SignalsApi(object):
                 id
             return self.call_with_http_info(**kwargs)
 
-        self.v1_signals_id_subscribe_post = Endpoint(
+        self.v1_signals_id_subscribe_post = _Endpoint(
             settings={
                 'response_type': (ChannelSubscriptionResponse,),
                 'auth': [],
@@ -761,7 +761,7 @@ class SignalsApi(object):
                 id
             return self.call_with_http_info(**kwargs)
 
-        self.v1_signals_id_subscribers_get = Endpoint(
+        self.v1_signals_id_subscribers_get = _Endpoint(
             settings={
                 'response_type': (ChannelSubscriberResponse,),
                 'auth': [],
@@ -904,7 +904,7 @@ class SignalsApi(object):
                 id
             return self.call_with_http_info(**kwargs)
 
-        self.v1_signals_id_unsubscribe_post = Endpoint(
+        self.v1_signals_id_unsubscribe_post = _Endpoint(
             settings={
                 'response_type': (ChannelSubscriptionResponse,),
                 'auth': [],
@@ -1046,7 +1046,7 @@ class SignalsApi(object):
                 signal
             return self.call_with_http_info(**kwargs)
 
-        self.v1_signals_id_update_post = Endpoint(
+        self.v1_signals_id_update_post = _Endpoint(
             settings={
                 'response_type': (Signal,),
                 'auth': [],
@@ -1183,7 +1183,7 @@ class SignalsApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_signals_list_get = Endpoint(
+        self.v1_signals_list_get = _Endpoint(
             settings={
                 'response_type': (SignalList,),
                 'auth': [],

--- a/symphony/bdk/gen/agent_api/system_api.py
+++ b/symphony/bdk/gen/agent_api/system_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -108,7 +108,7 @@ class SystemApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             return self.call_with_http_info(**kwargs)
 
-        self.v2_health_check_get = Endpoint(
+        self.v2_health_check_get = _Endpoint(
             settings={
                 'response_type': (V2HealthCheckResponse,),
                 'auth': [],
@@ -263,7 +263,7 @@ class SystemApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             return self.call_with_http_info(**kwargs)
 
-        self.v3_extended_health = Endpoint(
+        self.v3_extended_health = _Endpoint(
             settings={
                 'response_type': (V3Health,),
                 'auth': [],
@@ -368,7 +368,7 @@ class SystemApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             return self.call_with_http_info(**kwargs)
 
-        self.v3_health = Endpoint(
+        self.v3_health = _Endpoint(
             settings={
                 'response_type': (V3Health,),
                 'auth': [],

--- a/symphony/bdk/gen/agent_api/util_api.py
+++ b/symphony/bdk/gen/agent_api/util_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -110,7 +110,7 @@ class UtilApi(object):
                 echo_input
             return self.call_with_http_info(**kwargs)
 
-        self.v1_util_echo_post = Endpoint(
+        self.v1_util_echo_post = _Endpoint(
             settings={
                 'response_type': (SimpleMessage,),
                 'auth': [],

--- a/symphony/bdk/gen/agent_api/violations_api.py
+++ b/symphony/bdk/gen/agent_api/violations_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -119,7 +119,7 @@ class ViolationsApi(object):
                 key_manager_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_dlp_violations_message_get = Endpoint(
+        self.v1_dlp_violations_message_get = _Endpoint(
             settings={
                 'response_type': (V1DLPViolationMessageResponse,),
                 'auth': [],
@@ -274,7 +274,7 @@ class ViolationsApi(object):
                 key_manager_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_dlp_violations_signal_get = Endpoint(
+        self.v1_dlp_violations_signal_get = _Endpoint(
             settings={
                 'response_type': (V1DLPViolationSignalResponse,),
                 'auth': [],
@@ -429,7 +429,7 @@ class ViolationsApi(object):
                 key_manager_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_dlp_violations_stream_get = Endpoint(
+        self.v1_dlp_violations_stream_get = _Endpoint(
             settings={
                 'response_type': (V1DLPViolationStreamResponse,),
                 'auth': [],
@@ -585,7 +585,7 @@ class ViolationsApi(object):
                 key_manager_token
             return self.call_with_http_info(**kwargs)
 
-        self.v3_dlp_violation_attachment_get = Endpoint(
+        self.v3_dlp_violation_attachment_get = _Endpoint(
             settings={
                 'response_type': (str,),
                 'auth': [],
@@ -731,7 +731,7 @@ class ViolationsApi(object):
                 key_manager_token
             return self.call_with_http_info(**kwargs)
 
-        self.v3_dlp_violations_message_get = Endpoint(
+        self.v3_dlp_violations_message_get = _Endpoint(
             settings={
                 'response_type': (V3DLPViolationMessageResponse,),
                 'auth': [],
@@ -886,7 +886,7 @@ class ViolationsApi(object):
                 key_manager_token
             return self.call_with_http_info(**kwargs)
 
-        self.v3_dlp_violations_signal_get = Endpoint(
+        self.v3_dlp_violations_signal_get = _Endpoint(
             settings={
                 'response_type': (V3DLPViolationSignalResponse,),
                 'auth': [],
@@ -1041,7 +1041,7 @@ class ViolationsApi(object):
                 key_manager_token
             return self.call_with_http_info(**kwargs)
 
-        self.v3_dlp_violations_stream_get = Endpoint(
+        self.v3_dlp_violations_stream_get = _Endpoint(
             settings={
                 'response_type': (V3DLPViolationStreamResponse,),
                 'auth': [],

--- a/symphony/bdk/gen/agent_model/ack_id.py
+++ b/symphony/bdk/gen/agent_model/ack_id.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,7 +73,7 @@ class AckId(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'ack_id': (str,),  # noqa: E501
+            'ack_id': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -157,7 +156,7 @@ class AckId(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.ack_id: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/agent_info.py
+++ b/symphony/bdk/gen/agent_model/agent_info.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,13 +73,13 @@ class AgentInfo(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'ip_address': (str,),  # noqa: E501
-            'hostname': (str,),  # noqa: E501
-            'server_fqdn': (str,),  # noqa: E501
-            'version': (str,),  # noqa: E501
-            'url': (str,),  # noqa: E501
-            'on_prem': (bool,),  # noqa: E501
-            'commit_id': (str,),  # noqa: E501
+            'ip_address': (str, none_type),  # noqa: E501
+            'hostname': (str, none_type),  # noqa: E501
+            'server_fqdn': (str, none_type),  # noqa: E501
+            'version': (str, none_type),  # noqa: E501
+            'url': (str, none_type),  # noqa: E501
+            'on_prem': (bool, none_type),  # noqa: E501
+            'commit_id': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -175,7 +174,13 @@ class AgentInfo(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.ip_address: str = None
+        self.hostname: str = None
+        self.server_fqdn: str = None
+        self.version: str = None
+        self.url: str = None
+        self.on_prem: bool = None
+        self.commit_id: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/attachment_info.py
+++ b/symphony/bdk/gen/agent_model/attachment_info.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -165,10 +164,9 @@ class AttachmentInfo(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.id = id
-        self.name = name
-        self.size = size
+        self.id: str = id
+        self.name: str = name
+        self.size: int = size
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/base_signal.py
+++ b/symphony/bdk/gen/agent_model/base_signal.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,10 +73,10 @@ class BaseSignal(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'name': (str,),  # noqa: E501
-            'query': (str,),  # noqa: E501
-            'visible_on_profile': (bool,),  # noqa: E501
-            'company_wide': (bool,),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
+            'query': (str, none_type),  # noqa: E501
+            'visible_on_profile': (bool, none_type),  # noqa: E501
+            'company_wide': (bool, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -166,7 +165,10 @@ class BaseSignal(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.name: str = None
+        self.query: str = None
+        self.visible_on_profile: bool = None
+        self.company_wide: bool = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/channel_subscriber.py
+++ b/symphony/bdk/gen/agent_model/channel_subscriber.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,12 +73,12 @@ class ChannelSubscriber(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'subscription_id': (str,),  # noqa: E501
-            'pushed': (bool,),  # noqa: E501
-            'owner': (bool,),  # noqa: E501
-            'subscriber_name': (str,),  # noqa: E501
-            'user_id': (int,),  # noqa: E501
-            'timestamp': (int,),  # noqa: E501
+            'subscription_id': (str, none_type),  # noqa: E501
+            'pushed': (bool, none_type),  # noqa: E501
+            'owner': (bool, none_type),  # noqa: E501
+            'subscriber_name': (str, none_type),  # noqa: E501
+            'user_id': (int, none_type),  # noqa: E501
+            'timestamp': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -172,7 +171,12 @@ class ChannelSubscriber(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.subscription_id: str = None
+        self.pushed: bool = None
+        self.owner: bool = None
+        self.subscriber_name: str = None
+        self.user_id: int = None
+        self.timestamp: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/channel_subscriber_response.py
+++ b/symphony/bdk/gen/agent_model/channel_subscriber_response.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.channel_subscriber import ChannelSubscriber
-    globals()['ChannelSubscriber'] = ChannelSubscriber
+from symphony.bdk.gen.agent_model.channel_subscriber import ChannelSubscriber
+globals()['ChannelSubscriber'] = ChannelSubscriber
 
 
 class ChannelSubscriberResponse(ModelNormal):
@@ -77,12 +75,11 @@ class ChannelSubscriberResponse(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'offset': (int,),  # noqa: E501
-            'has_more': (bool,),  # noqa: E501
-            'total': (int,),  # noqa: E501
-            'data': ([ChannelSubscriber],),  # noqa: E501
+            'offset': (int, none_type),  # noqa: E501
+            'has_more': (bool, none_type),  # noqa: E501
+            'total': (int, none_type),  # noqa: E501
+            'data': ([ChannelSubscriber], none_type),  # noqa: E501
         }
 
     @cached_property
@@ -171,7 +168,10 @@ class ChannelSubscriberResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.offset: int = None
+        self.has_more: bool = None
+        self.total: int = None
+        self.data: List[ChannelSubscriber] = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/channel_subscription_error.py
+++ b/symphony/bdk/gen/agent_model/channel_subscription_error.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,9 +73,9 @@ class ChannelSubscriptionError(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'user_id': (int,),  # noqa: E501
-            'code': (str,),  # noqa: E501
-            'message': (str,),  # noqa: E501
+            'user_id': (int, none_type),  # noqa: E501
+            'code': (str, none_type),  # noqa: E501
+            'message': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -163,7 +162,9 @@ class ChannelSubscriptionError(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.user_id: int = None
+        self.code: str = None
+        self.message: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/channel_subscription_response.py
+++ b/symphony/bdk/gen/agent_model/channel_subscription_response.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.channel_subscription_error import ChannelSubscriptionError
-    globals()['ChannelSubscriptionError'] = ChannelSubscriptionError
+from symphony.bdk.gen.agent_model.channel_subscription_error import ChannelSubscriptionError
+globals()['ChannelSubscriptionError'] = ChannelSubscriptionError
 
 
 class ChannelSubscriptionResponse(ModelNormal):
@@ -77,12 +75,11 @@ class ChannelSubscriptionResponse(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'requested_subscription': (int,),  # noqa: E501
-            'successful_subscription': (int,),  # noqa: E501
-            'failed_subscription': (int,),  # noqa: E501
-            'subscription_errors': ([ChannelSubscriptionError],),  # noqa: E501
+            'requested_subscription': (int, none_type),  # noqa: E501
+            'successful_subscription': (int, none_type),  # noqa: E501
+            'failed_subscription': (int, none_type),  # noqa: E501
+            'subscription_errors': ([ChannelSubscriptionError], none_type),  # noqa: E501
         }
 
     @cached_property
@@ -171,7 +168,10 @@ class ChannelSubscriptionResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.requested_subscription: int = None
+        self.successful_subscription: int = None
+        self.failed_subscription: int = None
+        self.subscription_errors: List[ChannelSubscriptionError] = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/connection_request_message.py
+++ b/symphony/bdk/gen/agent_model/connection_request_message.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.connection_request_message_all_of import ConnectionRequestMessageAllOf
-    from symphony.bdk.gen.agent_model.v2_base_message import V2BaseMessage
-    globals()['ConnectionRequestMessageAllOf'] = ConnectionRequestMessageAllOf
-    globals()['V2BaseMessage'] = V2BaseMessage
+from symphony.bdk.gen.agent_model.connection_request_message_all_of import ConnectionRequestMessageAllOf
+from symphony.bdk.gen.agent_model.v2_base_message import V2BaseMessage
+globals()['ConnectionRequestMessageAllOf'] = ConnectionRequestMessageAllOf
+globals()['V2BaseMessage'] = V2BaseMessage
 
 
 class ConnectionRequestMessage(ModelComposed):
@@ -71,7 +69,6 @@ class ConnectionRequestMessage(ModelComposed):
         This must be a method because a agent_model may have properties that are
         of type self, this must run after the class is loaded
         """
-        lazy_import()
         return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
 
     _nullable = False
@@ -86,18 +83,17 @@ class ConnectionRequestMessage(ModelComposed):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'timestamp': (str,),  # noqa: E501
             'v2message_type': (str,),  # noqa: E501
             'stream_id': (str,),  # noqa: E501
-            'requesting_user_id': (int,),  # noqa: E501
-            'target_user_id': (int,),  # noqa: E501
-            'first_requested_at': (int,),  # noqa: E501
-            'updated_at': (int,),  # noqa: E501
-            'request_counter': (int,),  # noqa: E501
-            'status': (str,),  # noqa: E501
-            'id': (str,),  # noqa: E501
+            'requesting_user_id': (int, none_type),  # noqa: E501
+            'target_user_id': (int, none_type),  # noqa: E501
+            'first_requested_at': (int, none_type),  # noqa: E501
+            'updated_at': (int, none_type),  # noqa: E501
+            'request_counter': (int, none_type),  # noqa: E501
+            'status': (str, none_type),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -217,11 +213,6 @@ class ConnectionRequestMessage(ModelComposed):
             'v2message_type': v2message_type,
             'stream_id': stream_id,
         }
-        # remove args whose value is Null because they are unset
-        required_arg_names = list(required_args.keys())
-        for required_arg_name in required_arg_names:
-            if required_args[required_arg_name] is nulltype.Null:
-                del required_args[required_arg_name]
         model_args = {}
         model_args.update(required_args)
         model_args.update(kwargs)
@@ -231,9 +222,16 @@ class ConnectionRequestMessage(ModelComposed):
         self._var_name_to_model_instances = composed_info[1]
         self._additional_properties_model_instances = composed_info[2]
         unused_args = composed_info[3]
-
-        for var_name, var_value in required_args.items():
-            setattr(self, var_name, var_value)
+        self.timestamp: str = timestamp
+        self.v2message_type: str = v2message_type
+        self.stream_id: str = stream_id
+        self.requesting_user_id: int = None
+        self.target_user_id: int = None
+        self.first_requested_at: int = None
+        self.updated_at: int = None
+        self.request_counter: int = None
+        self.status: str = None
+        self.id: str = None
         for var_name, var_value in kwargs.items():
             if var_name in unused_args and \
                         self._configuration is not None and \
@@ -252,7 +250,6 @@ class ConnectionRequestMessage(ModelComposed):
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        lazy_import()
         return {
           'anyOf': [
           ],

--- a/symphony/bdk/gen/agent_model/connection_request_message_all_of.py
+++ b/symphony/bdk/gen/agent_model/connection_request_message_all_of.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,12 +73,12 @@ class ConnectionRequestMessageAllOf(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'requesting_user_id': (int,),  # noqa: E501
-            'target_user_id': (int,),  # noqa: E501
-            'first_requested_at': (int,),  # noqa: E501
-            'updated_at': (int,),  # noqa: E501
-            'request_counter': (int,),  # noqa: E501
-            'status': (str,),  # noqa: E501
+            'requesting_user_id': (int, none_type),  # noqa: E501
+            'target_user_id': (int, none_type),  # noqa: E501
+            'first_requested_at': (int, none_type),  # noqa: E501
+            'updated_at': (int, none_type),  # noqa: E501
+            'request_counter': (int, none_type),  # noqa: E501
+            'status': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -172,7 +171,12 @@ class ConnectionRequestMessageAllOf(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.requesting_user_id: int = None
+        self.target_user_id: int = None
+        self.first_requested_at: int = None
+        self.updated_at: int = None
+        self.request_counter: int = None
+        self.status: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/datafeed.py
+++ b/symphony/bdk/gen/agent_model/datafeed.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,7 +73,7 @@ class Datafeed(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'id': (str,),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -157,7 +156,7 @@ class Datafeed(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/error.py
+++ b/symphony/bdk/gen/agent_model/error.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,8 +73,8 @@ class Error(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'code': (int,),  # noqa: E501
-            'message': (str,),  # noqa: E501
+            'code': (int, none_type),  # noqa: E501
+            'message': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -160,7 +159,8 @@ class Error(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.code: int = None
+        self.message: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/message_search_query.py
+++ b/symphony/bdk/gen/agent_model/message_search_query.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,16 +73,16 @@ class MessageSearchQuery(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'text': (str,),  # noqa: E501
-            'stream_id': (str,),  # noqa: E501
-            'stream_type': (str,),  # noqa: E501
-            'author': (int,),  # noqa: E501
-            'hashtag': (str,),  # noqa: E501
-            'cashtag': (str,),  # noqa: E501
-            'mention': (int,),  # noqa: E501
-            'signal': (str,),  # noqa: E501
-            'from_date': (int,),  # noqa: E501
-            'to_date': (int,),  # noqa: E501
+            'text': (str, none_type),  # noqa: E501
+            'stream_id': (str, none_type),  # noqa: E501
+            'stream_type': (str, none_type),  # noqa: E501
+            'author': (int, none_type),  # noqa: E501
+            'hashtag': (str, none_type),  # noqa: E501
+            'cashtag': (str, none_type),  # noqa: E501
+            'mention': (int, none_type),  # noqa: E501
+            'signal': (str, none_type),  # noqa: E501
+            'from_date': (int, none_type),  # noqa: E501
+            'to_date': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -184,7 +183,16 @@ class MessageSearchQuery(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.text: str = None
+        self.stream_id: str = None
+        self.stream_type: str = None
+        self.author: int = None
+        self.hashtag: str = None
+        self.cashtag: str = None
+        self.mention: int = None
+        self.signal: str = None
+        self.from_date: int = None
+        self.to_date: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/pagination.py
+++ b/symphony/bdk/gen/agent_model/pagination.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.pagination_cursors import PaginationCursors
-    globals()['PaginationCursors'] = PaginationCursors
+from symphony.bdk.gen.agent_model.pagination_cursors import PaginationCursors
+globals()['PaginationCursors'] = PaginationCursors
 
 
 class Pagination(ModelNormal):
@@ -77,11 +75,10 @@ class Pagination(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'cursors': (PaginationCursors,),  # noqa: E501
-            'previous': (str,),  # noqa: E501
-            'next': (str,),  # noqa: E501
+            'previous': (str, none_type),  # noqa: E501
+            'next': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -170,8 +167,9 @@ class Pagination(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.cursors = cursors
+        self.cursors: PaginationCursors = cursors
+        self.previous: str = None
+        self.next: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/pagination_cursors.py
+++ b/symphony/bdk/gen/agent_model/pagination_cursors.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -162,9 +161,8 @@ class PaginationCursors(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.before = before
-        self.after = after
+        self.before: str = before
+        self.after: str = after
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/room_created_message.py
+++ b/symphony/bdk/gen/agent_model/room_created_message.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,13 +27,12 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.room_created_message_all_of import RoomCreatedMessageAllOf
-    from symphony.bdk.gen.agent_model.room_tag import RoomTag
-    from symphony.bdk.gen.agent_model.v2_base_message import V2BaseMessage
-    globals()['RoomCreatedMessageAllOf'] = RoomCreatedMessageAllOf
-    globals()['RoomTag'] = RoomTag
-    globals()['V2BaseMessage'] = V2BaseMessage
+from symphony.bdk.gen.agent_model.room_created_message_all_of import RoomCreatedMessageAllOf
+from symphony.bdk.gen.agent_model.room_tag import RoomTag
+from symphony.bdk.gen.agent_model.v2_base_message import V2BaseMessage
+globals()['RoomCreatedMessageAllOf'] = RoomCreatedMessageAllOf
+globals()['RoomTag'] = RoomTag
+globals()['V2BaseMessage'] = V2BaseMessage
 
 
 class RoomCreatedMessage(ModelComposed):
@@ -73,7 +71,6 @@ class RoomCreatedMessage(ModelComposed):
         This must be a method because a agent_model may have properties that are
         of type self, this must run after the class is loaded
         """
-        lazy_import()
         return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
 
     _nullable = False
@@ -88,22 +85,21 @@ class RoomCreatedMessage(ModelComposed):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'timestamp': (str,),  # noqa: E501
             'v2message_type': (str,),  # noqa: E501
             'stream_id': (str,),  # noqa: E501
-            'creation_date': (int,),  # noqa: E501
-            'name': (str,),  # noqa: E501
-            'keywords': ([RoomTag],),  # noqa: E501
-            'description': (str,),  # noqa: E501
-            'created_by_user_id': (int,),  # noqa: E501
-            'read_only': (bool,),  # noqa: E501
-            'discoverable': (bool,),  # noqa: E501
-            'public': (bool,),  # noqa: E501
-            'members_can_invite': (bool,),  # noqa: E501
-            'copy_protected': (bool,),  # noqa: E501
-            'id': (str,),  # noqa: E501
+            'creation_date': (int, none_type),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
+            'keywords': ([RoomTag], none_type),  # noqa: E501
+            'description': (str, none_type),  # noqa: E501
+            'created_by_user_id': (int, none_type),  # noqa: E501
+            'read_only': (bool, none_type),  # noqa: E501
+            'discoverable': (bool, none_type),  # noqa: E501
+            'public': (bool, none_type),  # noqa: E501
+            'members_can_invite': (bool, none_type),  # noqa: E501
+            'copy_protected': (bool, none_type),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -231,11 +227,6 @@ class RoomCreatedMessage(ModelComposed):
             'v2message_type': v2message_type,
             'stream_id': stream_id,
         }
-        # remove args whose value is Null because they are unset
-        required_arg_names = list(required_args.keys())
-        for required_arg_name in required_arg_names:
-            if required_args[required_arg_name] is nulltype.Null:
-                del required_args[required_arg_name]
         model_args = {}
         model_args.update(required_args)
         model_args.update(kwargs)
@@ -245,9 +236,20 @@ class RoomCreatedMessage(ModelComposed):
         self._var_name_to_model_instances = composed_info[1]
         self._additional_properties_model_instances = composed_info[2]
         unused_args = composed_info[3]
-
-        for var_name, var_value in required_args.items():
-            setattr(self, var_name, var_value)
+        self.timestamp: str = timestamp
+        self.v2message_type: str = v2message_type
+        self.stream_id: str = stream_id
+        self.creation_date: int = None
+        self.name: str = None
+        self.keywords: List[RoomTag] = None
+        self.description: str = None
+        self.created_by_user_id: int = None
+        self.read_only: bool = None
+        self.discoverable: bool = None
+        self.public: bool = None
+        self.members_can_invite: bool = None
+        self.copy_protected: bool = None
+        self.id: str = None
         for var_name, var_value in kwargs.items():
             if var_name in unused_args and \
                         self._configuration is not None and \
@@ -266,7 +268,6 @@ class RoomCreatedMessage(ModelComposed):
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        lazy_import()
         return {
           'anyOf': [
           ],

--- a/symphony/bdk/gen/agent_model/room_created_message_all_of.py
+++ b/symphony/bdk/gen/agent_model/room_created_message_all_of.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.room_tag import RoomTag
-    globals()['RoomTag'] = RoomTag
+from symphony.bdk.gen.agent_model.room_tag import RoomTag
+globals()['RoomTag'] = RoomTag
 
 
 class RoomCreatedMessageAllOf(ModelNormal):
@@ -77,18 +75,17 @@ class RoomCreatedMessageAllOf(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'creation_date': (int,),  # noqa: E501
-            'name': (str,),  # noqa: E501
-            'keywords': ([RoomTag],),  # noqa: E501
-            'description': (str,),  # noqa: E501
-            'created_by_user_id': (int,),  # noqa: E501
-            'read_only': (bool,),  # noqa: E501
-            'discoverable': (bool,),  # noqa: E501
-            'public': (bool,),  # noqa: E501
-            'members_can_invite': (bool,),  # noqa: E501
-            'copy_protected': (bool,),  # noqa: E501
+            'creation_date': (int, none_type),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
+            'keywords': ([RoomTag], none_type),  # noqa: E501
+            'description': (str, none_type),  # noqa: E501
+            'created_by_user_id': (int, none_type),  # noqa: E501
+            'read_only': (bool, none_type),  # noqa: E501
+            'discoverable': (bool, none_type),  # noqa: E501
+            'public': (bool, none_type),  # noqa: E501
+            'members_can_invite': (bool, none_type),  # noqa: E501
+            'copy_protected': (bool, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -189,7 +186,16 @@ class RoomCreatedMessageAllOf(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.creation_date: int = None
+        self.name: str = None
+        self.keywords: List[RoomTag] = None
+        self.description: str = None
+        self.created_by_user_id: int = None
+        self.read_only: bool = None
+        self.discoverable: bool = None
+        self.public: bool = None
+        self.members_can_invite: bool = None
+        self.copy_protected: bool = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/room_deactivated_message.py
+++ b/symphony/bdk/gen/agent_model/room_deactivated_message.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.room_deactivated_message_all_of import RoomDeactivatedMessageAllOf
-    from symphony.bdk.gen.agent_model.v2_base_message import V2BaseMessage
-    globals()['RoomDeactivatedMessageAllOf'] = RoomDeactivatedMessageAllOf
-    globals()['V2BaseMessage'] = V2BaseMessage
+from symphony.bdk.gen.agent_model.room_deactivated_message_all_of import RoomDeactivatedMessageAllOf
+from symphony.bdk.gen.agent_model.v2_base_message import V2BaseMessage
+globals()['RoomDeactivatedMessageAllOf'] = RoomDeactivatedMessageAllOf
+globals()['V2BaseMessage'] = V2BaseMessage
 
 
 class RoomDeactivatedMessage(ModelComposed):
@@ -71,7 +69,6 @@ class RoomDeactivatedMessage(ModelComposed):
         This must be a method because a agent_model may have properties that are
         of type self, this must run after the class is loaded
         """
-        lazy_import()
         return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
 
     _nullable = False
@@ -86,13 +83,12 @@ class RoomDeactivatedMessage(ModelComposed):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'timestamp': (str,),  # noqa: E501
             'v2message_type': (str,),  # noqa: E501
             'stream_id': (str,),  # noqa: E501
-            'deactivated_by_user_id': (int,),  # noqa: E501
-            'id': (str,),  # noqa: E501
+            'deactivated_by_user_id': (int, none_type),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -202,11 +198,6 @@ class RoomDeactivatedMessage(ModelComposed):
             'v2message_type': v2message_type,
             'stream_id': stream_id,
         }
-        # remove args whose value is Null because they are unset
-        required_arg_names = list(required_args.keys())
-        for required_arg_name in required_arg_names:
-            if required_args[required_arg_name] is nulltype.Null:
-                del required_args[required_arg_name]
         model_args = {}
         model_args.update(required_args)
         model_args.update(kwargs)
@@ -216,9 +207,11 @@ class RoomDeactivatedMessage(ModelComposed):
         self._var_name_to_model_instances = composed_info[1]
         self._additional_properties_model_instances = composed_info[2]
         unused_args = composed_info[3]
-
-        for var_name, var_value in required_args.items():
-            setattr(self, var_name, var_value)
+        self.timestamp: str = timestamp
+        self.v2message_type: str = v2message_type
+        self.stream_id: str = stream_id
+        self.deactivated_by_user_id: int = None
+        self.id: str = None
         for var_name, var_value in kwargs.items():
             if var_name in unused_args and \
                         self._configuration is not None and \
@@ -237,7 +230,6 @@ class RoomDeactivatedMessage(ModelComposed):
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        lazy_import()
         return {
           'anyOf': [
           ],

--- a/symphony/bdk/gen/agent_model/room_deactivated_message_all_of.py
+++ b/symphony/bdk/gen/agent_model/room_deactivated_message_all_of.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,7 +73,7 @@ class RoomDeactivatedMessageAllOf(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'deactivated_by_user_id': (int,),  # noqa: E501
+            'deactivated_by_user_id': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -157,7 +156,7 @@ class RoomDeactivatedMessageAllOf(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.deactivated_by_user_id: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/room_member_demoted_from_owner_message.py
+++ b/symphony/bdk/gen/agent_model/room_member_demoted_from_owner_message.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.room_member_demoted_from_owner_message_all_of import RoomMemberDemotedFromOwnerMessageAllOf
-    from symphony.bdk.gen.agent_model.v2_base_message import V2BaseMessage
-    globals()['RoomMemberDemotedFromOwnerMessageAllOf'] = RoomMemberDemotedFromOwnerMessageAllOf
-    globals()['V2BaseMessage'] = V2BaseMessage
+from symphony.bdk.gen.agent_model.room_member_demoted_from_owner_message_all_of import RoomMemberDemotedFromOwnerMessageAllOf
+from symphony.bdk.gen.agent_model.v2_base_message import V2BaseMessage
+globals()['RoomMemberDemotedFromOwnerMessageAllOf'] = RoomMemberDemotedFromOwnerMessageAllOf
+globals()['V2BaseMessage'] = V2BaseMessage
 
 
 class RoomMemberDemotedFromOwnerMessage(ModelComposed):
@@ -71,7 +69,6 @@ class RoomMemberDemotedFromOwnerMessage(ModelComposed):
         This must be a method because a agent_model may have properties that are
         of type self, this must run after the class is loaded
         """
-        lazy_import()
         return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
 
     _nullable = False
@@ -86,14 +83,13 @@ class RoomMemberDemotedFromOwnerMessage(ModelComposed):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'timestamp': (str,),  # noqa: E501
             'v2message_type': (str,),  # noqa: E501
             'stream_id': (str,),  # noqa: E501
-            'demoted_by_user_id': (int,),  # noqa: E501
-            'demoted_user_id': (int,),  # noqa: E501
-            'id': (str,),  # noqa: E501
+            'demoted_by_user_id': (int, none_type),  # noqa: E501
+            'demoted_user_id': (int, none_type),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -205,11 +201,6 @@ class RoomMemberDemotedFromOwnerMessage(ModelComposed):
             'v2message_type': v2message_type,
             'stream_id': stream_id,
         }
-        # remove args whose value is Null because they are unset
-        required_arg_names = list(required_args.keys())
-        for required_arg_name in required_arg_names:
-            if required_args[required_arg_name] is nulltype.Null:
-                del required_args[required_arg_name]
         model_args = {}
         model_args.update(required_args)
         model_args.update(kwargs)
@@ -219,9 +210,12 @@ class RoomMemberDemotedFromOwnerMessage(ModelComposed):
         self._var_name_to_model_instances = composed_info[1]
         self._additional_properties_model_instances = composed_info[2]
         unused_args = composed_info[3]
-
-        for var_name, var_value in required_args.items():
-            setattr(self, var_name, var_value)
+        self.timestamp: str = timestamp
+        self.v2message_type: str = v2message_type
+        self.stream_id: str = stream_id
+        self.demoted_by_user_id: int = None
+        self.demoted_user_id: int = None
+        self.id: str = None
         for var_name, var_value in kwargs.items():
             if var_name in unused_args and \
                         self._configuration is not None and \
@@ -240,7 +234,6 @@ class RoomMemberDemotedFromOwnerMessage(ModelComposed):
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        lazy_import()
         return {
           'anyOf': [
           ],

--- a/symphony/bdk/gen/agent_model/room_member_demoted_from_owner_message_all_of.py
+++ b/symphony/bdk/gen/agent_model/room_member_demoted_from_owner_message_all_of.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,8 +73,8 @@ class RoomMemberDemotedFromOwnerMessageAllOf(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'demoted_by_user_id': (int,),  # noqa: E501
-            'demoted_user_id': (int,),  # noqa: E501
+            'demoted_by_user_id': (int, none_type),  # noqa: E501
+            'demoted_user_id': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -160,7 +159,8 @@ class RoomMemberDemotedFromOwnerMessageAllOf(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.demoted_by_user_id: int = None
+        self.demoted_user_id: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/room_member_promoted_to_owner_message.py
+++ b/symphony/bdk/gen/agent_model/room_member_promoted_to_owner_message.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.room_member_promoted_to_owner_message_all_of import RoomMemberPromotedToOwnerMessageAllOf
-    from symphony.bdk.gen.agent_model.v2_base_message import V2BaseMessage
-    globals()['RoomMemberPromotedToOwnerMessageAllOf'] = RoomMemberPromotedToOwnerMessageAllOf
-    globals()['V2BaseMessage'] = V2BaseMessage
+from symphony.bdk.gen.agent_model.room_member_promoted_to_owner_message_all_of import RoomMemberPromotedToOwnerMessageAllOf
+from symphony.bdk.gen.agent_model.v2_base_message import V2BaseMessage
+globals()['RoomMemberPromotedToOwnerMessageAllOf'] = RoomMemberPromotedToOwnerMessageAllOf
+globals()['V2BaseMessage'] = V2BaseMessage
 
 
 class RoomMemberPromotedToOwnerMessage(ModelComposed):
@@ -71,7 +69,6 @@ class RoomMemberPromotedToOwnerMessage(ModelComposed):
         This must be a method because a agent_model may have properties that are
         of type self, this must run after the class is loaded
         """
-        lazy_import()
         return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
 
     _nullable = False
@@ -86,14 +83,13 @@ class RoomMemberPromotedToOwnerMessage(ModelComposed):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'timestamp': (str,),  # noqa: E501
             'v2message_type': (str,),  # noqa: E501
             'stream_id': (str,),  # noqa: E501
-            'promoted_by_user_id': (int,),  # noqa: E501
-            'promoted_user_id': (int,),  # noqa: E501
-            'id': (str,),  # noqa: E501
+            'promoted_by_user_id': (int, none_type),  # noqa: E501
+            'promoted_user_id': (int, none_type),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -205,11 +201,6 @@ class RoomMemberPromotedToOwnerMessage(ModelComposed):
             'v2message_type': v2message_type,
             'stream_id': stream_id,
         }
-        # remove args whose value is Null because they are unset
-        required_arg_names = list(required_args.keys())
-        for required_arg_name in required_arg_names:
-            if required_args[required_arg_name] is nulltype.Null:
-                del required_args[required_arg_name]
         model_args = {}
         model_args.update(required_args)
         model_args.update(kwargs)
@@ -219,9 +210,12 @@ class RoomMemberPromotedToOwnerMessage(ModelComposed):
         self._var_name_to_model_instances = composed_info[1]
         self._additional_properties_model_instances = composed_info[2]
         unused_args = composed_info[3]
-
-        for var_name, var_value in required_args.items():
-            setattr(self, var_name, var_value)
+        self.timestamp: str = timestamp
+        self.v2message_type: str = v2message_type
+        self.stream_id: str = stream_id
+        self.promoted_by_user_id: int = None
+        self.promoted_user_id: int = None
+        self.id: str = None
         for var_name, var_value in kwargs.items():
             if var_name in unused_args and \
                         self._configuration is not None and \
@@ -240,7 +234,6 @@ class RoomMemberPromotedToOwnerMessage(ModelComposed):
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        lazy_import()
         return {
           'anyOf': [
           ],

--- a/symphony/bdk/gen/agent_model/room_member_promoted_to_owner_message_all_of.py
+++ b/symphony/bdk/gen/agent_model/room_member_promoted_to_owner_message_all_of.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,8 +73,8 @@ class RoomMemberPromotedToOwnerMessageAllOf(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'promoted_by_user_id': (int,),  # noqa: E501
-            'promoted_user_id': (int,),  # noqa: E501
+            'promoted_by_user_id': (int, none_type),  # noqa: E501
+            'promoted_user_id': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -160,7 +159,8 @@ class RoomMemberPromotedToOwnerMessageAllOf(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.promoted_by_user_id: int = None
+        self.promoted_user_id: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/room_reactivated_message.py
+++ b/symphony/bdk/gen/agent_model/room_reactivated_message.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.room_reactivated_message_all_of import RoomReactivatedMessageAllOf
-    from symphony.bdk.gen.agent_model.v2_base_message import V2BaseMessage
-    globals()['RoomReactivatedMessageAllOf'] = RoomReactivatedMessageAllOf
-    globals()['V2BaseMessage'] = V2BaseMessage
+from symphony.bdk.gen.agent_model.room_reactivated_message_all_of import RoomReactivatedMessageAllOf
+from symphony.bdk.gen.agent_model.v2_base_message import V2BaseMessage
+globals()['RoomReactivatedMessageAllOf'] = RoomReactivatedMessageAllOf
+globals()['V2BaseMessage'] = V2BaseMessage
 
 
 class RoomReactivatedMessage(ModelComposed):
@@ -71,7 +69,6 @@ class RoomReactivatedMessage(ModelComposed):
         This must be a method because a agent_model may have properties that are
         of type self, this must run after the class is loaded
         """
-        lazy_import()
         return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
 
     _nullable = False
@@ -86,13 +83,12 @@ class RoomReactivatedMessage(ModelComposed):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'timestamp': (str,),  # noqa: E501
             'v2message_type': (str,),  # noqa: E501
             'stream_id': (str,),  # noqa: E501
-            'reactivated_by_user_id': (int,),  # noqa: E501
-            'id': (str,),  # noqa: E501
+            'reactivated_by_user_id': (int, none_type),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -202,11 +198,6 @@ class RoomReactivatedMessage(ModelComposed):
             'v2message_type': v2message_type,
             'stream_id': stream_id,
         }
-        # remove args whose value is Null because they are unset
-        required_arg_names = list(required_args.keys())
-        for required_arg_name in required_arg_names:
-            if required_args[required_arg_name] is nulltype.Null:
-                del required_args[required_arg_name]
         model_args = {}
         model_args.update(required_args)
         model_args.update(kwargs)
@@ -216,9 +207,11 @@ class RoomReactivatedMessage(ModelComposed):
         self._var_name_to_model_instances = composed_info[1]
         self._additional_properties_model_instances = composed_info[2]
         unused_args = composed_info[3]
-
-        for var_name, var_value in required_args.items():
-            setattr(self, var_name, var_value)
+        self.timestamp: str = timestamp
+        self.v2message_type: str = v2message_type
+        self.stream_id: str = stream_id
+        self.reactivated_by_user_id: int = None
+        self.id: str = None
         for var_name, var_value in kwargs.items():
             if var_name in unused_args and \
                         self._configuration is not None and \
@@ -237,7 +230,6 @@ class RoomReactivatedMessage(ModelComposed):
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        lazy_import()
         return {
           'anyOf': [
           ],

--- a/symphony/bdk/gen/agent_model/room_reactivated_message_all_of.py
+++ b/symphony/bdk/gen/agent_model/room_reactivated_message_all_of.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,7 +73,7 @@ class RoomReactivatedMessageAllOf(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'reactivated_by_user_id': (int,),  # noqa: E501
+            'reactivated_by_user_id': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -157,7 +156,7 @@ class RoomReactivatedMessageAllOf(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.reactivated_by_user_id: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/room_tag.py
+++ b/symphony/bdk/gen/agent_model/room_tag.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -162,9 +161,8 @@ class RoomTag(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.key = key
-        self.value = value
+        self.key: str = key
+        self.value: str = value
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/room_updated_message.py
+++ b/symphony/bdk/gen/agent_model/room_updated_message.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,13 +27,12 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.room_tag import RoomTag
-    from symphony.bdk.gen.agent_model.room_updated_message_all_of import RoomUpdatedMessageAllOf
-    from symphony.bdk.gen.agent_model.v2_base_message import V2BaseMessage
-    globals()['RoomTag'] = RoomTag
-    globals()['RoomUpdatedMessageAllOf'] = RoomUpdatedMessageAllOf
-    globals()['V2BaseMessage'] = V2BaseMessage
+from symphony.bdk.gen.agent_model.room_tag import RoomTag
+from symphony.bdk.gen.agent_model.room_updated_message_all_of import RoomUpdatedMessageAllOf
+from symphony.bdk.gen.agent_model.v2_base_message import V2BaseMessage
+globals()['RoomTag'] = RoomTag
+globals()['RoomUpdatedMessageAllOf'] = RoomUpdatedMessageAllOf
+globals()['V2BaseMessage'] = V2BaseMessage
 
 
 class RoomUpdatedMessage(ModelComposed):
@@ -73,7 +71,6 @@ class RoomUpdatedMessage(ModelComposed):
         This must be a method because a agent_model may have properties that are
         of type self, this must run after the class is loaded
         """
-        lazy_import()
         return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
 
     _nullable = False
@@ -88,21 +85,20 @@ class RoomUpdatedMessage(ModelComposed):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'timestamp': (str,),  # noqa: E501
             'v2message_type': (str,),  # noqa: E501
             'stream_id': (str,),  # noqa: E501
-            'old_name': (str,),  # noqa: E501
-            'new_name': (str,),  # noqa: E501
-            'keywords': ([RoomTag],),  # noqa: E501
-            'old_description': (str,),  # noqa: E501
-            'new_description': (str,),  # noqa: E501
-            'members_can_invite': (bool,),  # noqa: E501
-            'discoverable': (bool,),  # noqa: E501
-            'read_only': (bool,),  # noqa: E501
-            'copy_protected': (bool,),  # noqa: E501
-            'id': (str,),  # noqa: E501
+            'old_name': (str, none_type),  # noqa: E501
+            'new_name': (str, none_type),  # noqa: E501
+            'keywords': ([RoomTag], none_type),  # noqa: E501
+            'old_description': (str, none_type),  # noqa: E501
+            'new_description': (str, none_type),  # noqa: E501
+            'members_can_invite': (bool, none_type),  # noqa: E501
+            'discoverable': (bool, none_type),  # noqa: E501
+            'read_only': (bool, none_type),  # noqa: E501
+            'copy_protected': (bool, none_type),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -228,11 +224,6 @@ class RoomUpdatedMessage(ModelComposed):
             'v2message_type': v2message_type,
             'stream_id': stream_id,
         }
-        # remove args whose value is Null because they are unset
-        required_arg_names = list(required_args.keys())
-        for required_arg_name in required_arg_names:
-            if required_args[required_arg_name] is nulltype.Null:
-                del required_args[required_arg_name]
         model_args = {}
         model_args.update(required_args)
         model_args.update(kwargs)
@@ -242,9 +233,19 @@ class RoomUpdatedMessage(ModelComposed):
         self._var_name_to_model_instances = composed_info[1]
         self._additional_properties_model_instances = composed_info[2]
         unused_args = composed_info[3]
-
-        for var_name, var_value in required_args.items():
-            setattr(self, var_name, var_value)
+        self.timestamp: str = timestamp
+        self.v2message_type: str = v2message_type
+        self.stream_id: str = stream_id
+        self.old_name: str = None
+        self.new_name: str = None
+        self.keywords: List[RoomTag] = None
+        self.old_description: str = None
+        self.new_description: str = None
+        self.members_can_invite: bool = None
+        self.discoverable: bool = None
+        self.read_only: bool = None
+        self.copy_protected: bool = None
+        self.id: str = None
         for var_name, var_value in kwargs.items():
             if var_name in unused_args and \
                         self._configuration is not None and \
@@ -263,7 +264,6 @@ class RoomUpdatedMessage(ModelComposed):
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        lazy_import()
         return {
           'anyOf': [
           ],

--- a/symphony/bdk/gen/agent_model/room_updated_message_all_of.py
+++ b/symphony/bdk/gen/agent_model/room_updated_message_all_of.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.room_tag import RoomTag
-    globals()['RoomTag'] = RoomTag
+from symphony.bdk.gen.agent_model.room_tag import RoomTag
+globals()['RoomTag'] = RoomTag
 
 
 class RoomUpdatedMessageAllOf(ModelNormal):
@@ -77,17 +75,16 @@ class RoomUpdatedMessageAllOf(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'old_name': (str,),  # noqa: E501
-            'new_name': (str,),  # noqa: E501
-            'keywords': ([RoomTag],),  # noqa: E501
-            'old_description': (str,),  # noqa: E501
-            'new_description': (str,),  # noqa: E501
-            'members_can_invite': (bool,),  # noqa: E501
-            'discoverable': (bool,),  # noqa: E501
-            'read_only': (bool,),  # noqa: E501
-            'copy_protected': (bool,),  # noqa: E501
+            'old_name': (str, none_type),  # noqa: E501
+            'new_name': (str, none_type),  # noqa: E501
+            'keywords': ([RoomTag], none_type),  # noqa: E501
+            'old_description': (str, none_type),  # noqa: E501
+            'new_description': (str, none_type),  # noqa: E501
+            'members_can_invite': (bool, none_type),  # noqa: E501
+            'discoverable': (bool, none_type),  # noqa: E501
+            'read_only': (bool, none_type),  # noqa: E501
+            'copy_protected': (bool, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -186,7 +183,15 @@ class RoomUpdatedMessageAllOf(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.old_name: str = None
+        self.new_name: str = None
+        self.keywords: List[RoomTag] = None
+        self.old_description: str = None
+        self.new_description: str = None
+        self.members_can_invite: bool = None
+        self.discoverable: bool = None
+        self.read_only: bool = None
+        self.copy_protected: bool = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/share_article.py
+++ b/symphony/bdk/gen/agent_model/share_article.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -78,15 +77,15 @@ class ShareArticle(ModelNormal):
             'publisher': (str,),  # noqa: E501
             'author': (str,),  # noqa: E501
             'app_id': (str,),  # noqa: E501
-            'article_id': (str,),  # noqa: E501
-            'sub_title': (str,),  # noqa: E501
-            'message': (str,),  # noqa: E501
-            'publish_date': (int,),  # noqa: E501
-            'thumbnail_url': (str,),  # noqa: E501
-            'article_url': (str,),  # noqa: E501
-            'summary': (str,),  # noqa: E501
-            'app_name': (str,),  # noqa: E501
-            'app_icon_url': (str,),  # noqa: E501
+            'article_id': (str, none_type),  # noqa: E501
+            'sub_title': (str, none_type),  # noqa: E501
+            'message': (str, none_type),  # noqa: E501
+            'publish_date': (int, none_type),  # noqa: E501
+            'thumbnail_url': (str, none_type),  # noqa: E501
+            'article_url': (str, none_type),  # noqa: E501
+            'summary': (str, none_type),  # noqa: E501
+            'app_name': (str, none_type),  # noqa: E501
+            'app_icon_url': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -195,11 +194,19 @@ class ShareArticle(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.title = title
-        self.publisher = publisher
-        self.author = author
-        self.app_id = app_id
+        self.title: str = title
+        self.publisher: str = publisher
+        self.author: str = author
+        self.app_id: str = app_id
+        self.article_id: str = None
+        self.sub_title: str = None
+        self.message: str = None
+        self.publish_date: int = None
+        self.thumbnail_url: str = None
+        self.article_url: str = None
+        self.summary: str = None
+        self.app_name: str = None
+        self.app_icon_url: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/share_content.py
+++ b/symphony/bdk/gen/agent_model/share_content.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.share_article import ShareArticle
-    globals()['ShareArticle'] = ShareArticle
+from symphony.bdk.gen.agent_model.share_article import ShareArticle
+globals()['ShareArticle'] = ShareArticle
 
 
 class ShareContent(ModelNormal):
@@ -77,10 +75,9 @@ class ShareContent(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'type': (str,),  # noqa: E501
-            'content': (ShareArticle,),  # noqa: E501
+            'type': (str, none_type),  # noqa: E501
+            'content': (ShareArticle, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -165,7 +162,8 @@ class ShareContent(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.type: str = None
+        self.content: ShareArticle = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/signal.py
+++ b/symphony/bdk/gen/agent_model/signal.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.base_signal import BaseSignal
-    from symphony.bdk.gen.agent_model.signal_all_of import SignalAllOf
-    globals()['BaseSignal'] = BaseSignal
-    globals()['SignalAllOf'] = SignalAllOf
+from symphony.bdk.gen.agent_model.base_signal import BaseSignal
+from symphony.bdk.gen.agent_model.signal_all_of import SignalAllOf
+globals()['BaseSignal'] = BaseSignal
+globals()['SignalAllOf'] = SignalAllOf
 
 
 class Signal(ModelComposed):
@@ -71,7 +69,6 @@ class Signal(ModelComposed):
         This must be a method because a agent_model may have properties that are
         of type self, this must run after the class is loaded
         """
-        lazy_import()
         return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
 
     _nullable = False
@@ -86,14 +83,13 @@ class Signal(ModelComposed):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'name': (str,),  # noqa: E501
-            'query': (str,),  # noqa: E501
-            'visible_on_profile': (bool,),  # noqa: E501
-            'company_wide': (bool,),  # noqa: E501
-            'id': (str,),  # noqa: E501
-            'timestamp': (int,),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
+            'query': (str, none_type),  # noqa: E501
+            'visible_on_profile': (bool, none_type),  # noqa: E501
+            'company_wide': (bool, none_type),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
+            'timestamp': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -197,11 +193,6 @@ class Signal(ModelComposed):
         }
         required_args = {
         }
-        # remove args whose value is Null because they are unset
-        required_arg_names = list(required_args.keys())
-        for required_arg_name in required_arg_names:
-            if required_args[required_arg_name] is nulltype.Null:
-                del required_args[required_arg_name]
         model_args = {}
         model_args.update(required_args)
         model_args.update(kwargs)
@@ -211,9 +202,12 @@ class Signal(ModelComposed):
         self._var_name_to_model_instances = composed_info[1]
         self._additional_properties_model_instances = composed_info[2]
         unused_args = composed_info[3]
-
-        for var_name, var_value in required_args.items():
-            setattr(self, var_name, var_value)
+        self.name: str = None
+        self.query: str = None
+        self.visible_on_profile: bool = None
+        self.company_wide: bool = None
+        self.id: str = None
+        self.timestamp: int = None
         for var_name, var_value in kwargs.items():
             if var_name in unused_args and \
                         self._configuration is not None and \
@@ -232,7 +226,6 @@ class Signal(ModelComposed):
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        lazy_import()
         return {
           'anyOf': [
           ],

--- a/symphony/bdk/gen/agent_model/signal_all_of.py
+++ b/symphony/bdk/gen/agent_model/signal_all_of.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,9 +73,9 @@ class SignalAllOf(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'id': (str,),  # noqa: E501
-            'timestamp': (int,),  # noqa: E501
-            'company_wide': (bool,),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
+            'timestamp': (int, none_type),  # noqa: E501
+            'company_wide': (bool, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -163,7 +162,9 @@ class SignalAllOf(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: str = None
+        self.timestamp: int = None
+        self.company_wide: bool = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/signal_list.py
+++ b/symphony/bdk/gen/agent_model/signal_list.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.signal import Signal
-    globals()['Signal'] = Signal
+from symphony.bdk.gen.agent_model.signal import Signal
+globals()['Signal'] = Signal
 
 
 class SignalList(ModelSimple):
@@ -73,7 +71,6 @@ class SignalList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([Signal],),
         }
@@ -138,6 +135,8 @@ class SignalList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -153,7 +152,6 @@ class SignalList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -173,7 +171,7 @@ class SignalList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[Signal] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/agent_model/simple_message.py
+++ b/symphony/bdk/gen/agent_model/simple_message.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,7 +73,7 @@ class SimpleMessage(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'message': (str,),  # noqa: E501
+            'message': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -157,7 +156,7 @@ class SimpleMessage(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.message: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/success_response.py
+++ b/symphony/bdk/gen/agent_model/success_response.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -78,8 +77,8 @@ class SuccessResponse(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'format': (str,),  # noqa: E501
-            'message': (str,),  # noqa: E501
+            'format': (str, none_type),  # noqa: E501
+            'message': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -164,7 +163,8 @@ class SuccessResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.format: str = None
+        self.message: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/user_joined_room_message.py
+++ b/symphony/bdk/gen/agent_model/user_joined_room_message.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.user_joined_room_message_all_of import UserJoinedRoomMessageAllOf
-    from symphony.bdk.gen.agent_model.v2_base_message import V2BaseMessage
-    globals()['UserJoinedRoomMessageAllOf'] = UserJoinedRoomMessageAllOf
-    globals()['V2BaseMessage'] = V2BaseMessage
+from symphony.bdk.gen.agent_model.user_joined_room_message_all_of import UserJoinedRoomMessageAllOf
+from symphony.bdk.gen.agent_model.v2_base_message import V2BaseMessage
+globals()['UserJoinedRoomMessageAllOf'] = UserJoinedRoomMessageAllOf
+globals()['V2BaseMessage'] = V2BaseMessage
 
 
 class UserJoinedRoomMessage(ModelComposed):
@@ -71,7 +69,6 @@ class UserJoinedRoomMessage(ModelComposed):
         This must be a method because a agent_model may have properties that are
         of type self, this must run after the class is loaded
         """
-        lazy_import()
         return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
 
     _nullable = False
@@ -86,14 +83,13 @@ class UserJoinedRoomMessage(ModelComposed):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'timestamp': (str,),  # noqa: E501
             'v2message_type': (str,),  # noqa: E501
             'stream_id': (str,),  # noqa: E501
-            'added_by_user_id': (int,),  # noqa: E501
-            'member_added_user_id': (int,),  # noqa: E501
-            'id': (str,),  # noqa: E501
+            'added_by_user_id': (int, none_type),  # noqa: E501
+            'member_added_user_id': (int, none_type),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -205,11 +201,6 @@ class UserJoinedRoomMessage(ModelComposed):
             'v2message_type': v2message_type,
             'stream_id': stream_id,
         }
-        # remove args whose value is Null because they are unset
-        required_arg_names = list(required_args.keys())
-        for required_arg_name in required_arg_names:
-            if required_args[required_arg_name] is nulltype.Null:
-                del required_args[required_arg_name]
         model_args = {}
         model_args.update(required_args)
         model_args.update(kwargs)
@@ -219,9 +210,12 @@ class UserJoinedRoomMessage(ModelComposed):
         self._var_name_to_model_instances = composed_info[1]
         self._additional_properties_model_instances = composed_info[2]
         unused_args = composed_info[3]
-
-        for var_name, var_value in required_args.items():
-            setattr(self, var_name, var_value)
+        self.timestamp: str = timestamp
+        self.v2message_type: str = v2message_type
+        self.stream_id: str = stream_id
+        self.added_by_user_id: int = None
+        self.member_added_user_id: int = None
+        self.id: str = None
         for var_name, var_value in kwargs.items():
             if var_name in unused_args and \
                         self._configuration is not None and \
@@ -240,7 +234,6 @@ class UserJoinedRoomMessage(ModelComposed):
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        lazy_import()
         return {
           'anyOf': [
           ],

--- a/symphony/bdk/gen/agent_model/user_joined_room_message_all_of.py
+++ b/symphony/bdk/gen/agent_model/user_joined_room_message_all_of.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,8 +73,8 @@ class UserJoinedRoomMessageAllOf(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'added_by_user_id': (int,),  # noqa: E501
-            'member_added_user_id': (int,),  # noqa: E501
+            'added_by_user_id': (int, none_type),  # noqa: E501
+            'member_added_user_id': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -160,7 +159,8 @@ class UserJoinedRoomMessageAllOf(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.added_by_user_id: int = None
+        self.member_added_user_id: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/user_left_room_message.py
+++ b/symphony/bdk/gen/agent_model/user_left_room_message.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.user_left_room_message_all_of import UserLeftRoomMessageAllOf
-    from symphony.bdk.gen.agent_model.v2_base_message import V2BaseMessage
-    globals()['UserLeftRoomMessageAllOf'] = UserLeftRoomMessageAllOf
-    globals()['V2BaseMessage'] = V2BaseMessage
+from symphony.bdk.gen.agent_model.user_left_room_message_all_of import UserLeftRoomMessageAllOf
+from symphony.bdk.gen.agent_model.v2_base_message import V2BaseMessage
+globals()['UserLeftRoomMessageAllOf'] = UserLeftRoomMessageAllOf
+globals()['V2BaseMessage'] = V2BaseMessage
 
 
 class UserLeftRoomMessage(ModelComposed):
@@ -71,7 +69,6 @@ class UserLeftRoomMessage(ModelComposed):
         This must be a method because a agent_model may have properties that are
         of type self, this must run after the class is loaded
         """
-        lazy_import()
         return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
 
     _nullable = False
@@ -86,15 +83,14 @@ class UserLeftRoomMessage(ModelComposed):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'timestamp': (str,),  # noqa: E501
             'v2message_type': (str,),  # noqa: E501
             'stream_id': (str,),  # noqa: E501
-            'removed_by_user_id': (int,),  # noqa: E501
-            'member_left_user_id': (int,),  # noqa: E501
-            'information_barrier_remediation': (bool,),  # noqa: E501
-            'id': (str,),  # noqa: E501
+            'removed_by_user_id': (int, none_type),  # noqa: E501
+            'member_left_user_id': (int, none_type),  # noqa: E501
+            'information_barrier_remediation': (bool, none_type),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -208,11 +204,6 @@ class UserLeftRoomMessage(ModelComposed):
             'v2message_type': v2message_type,
             'stream_id': stream_id,
         }
-        # remove args whose value is Null because they are unset
-        required_arg_names = list(required_args.keys())
-        for required_arg_name in required_arg_names:
-            if required_args[required_arg_name] is nulltype.Null:
-                del required_args[required_arg_name]
         model_args = {}
         model_args.update(required_args)
         model_args.update(kwargs)
@@ -222,9 +213,13 @@ class UserLeftRoomMessage(ModelComposed):
         self._var_name_to_model_instances = composed_info[1]
         self._additional_properties_model_instances = composed_info[2]
         unused_args = composed_info[3]
-
-        for var_name, var_value in required_args.items():
-            setattr(self, var_name, var_value)
+        self.timestamp: str = timestamp
+        self.v2message_type: str = v2message_type
+        self.stream_id: str = stream_id
+        self.removed_by_user_id: int = None
+        self.member_left_user_id: int = None
+        self.information_barrier_remediation: bool = None
+        self.id: str = None
         for var_name, var_value in kwargs.items():
             if var_name in unused_args and \
                         self._configuration is not None and \
@@ -243,7 +238,6 @@ class UserLeftRoomMessage(ModelComposed):
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        lazy_import()
         return {
           'anyOf': [
           ],

--- a/symphony/bdk/gen/agent_model/user_left_room_message_all_of.py
+++ b/symphony/bdk/gen/agent_model/user_left_room_message_all_of.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,9 +73,9 @@ class UserLeftRoomMessageAllOf(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'removed_by_user_id': (int,),  # noqa: E501
-            'member_left_user_id': (int,),  # noqa: E501
-            'information_barrier_remediation': (bool,),  # noqa: E501
+            'removed_by_user_id': (int, none_type),  # noqa: E501
+            'member_left_user_id': (int, none_type),  # noqa: E501
+            'information_barrier_remediation': (bool, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -163,7 +162,9 @@ class UserLeftRoomMessageAllOf(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.removed_by_user_id: int = None
+        self.member_left_user_id: int = None
+        self.information_barrier_remediation: bool = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v1_audit_trail_initiator_list.py
+++ b/symphony/bdk/gen/agent_model/v1_audit_trail_initiator_list.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.pagination import Pagination
-    from symphony.bdk.gen.agent_model.v1_audit_trail_initiator_response import V1AuditTrailInitiatorResponse
-    globals()['Pagination'] = Pagination
-    globals()['V1AuditTrailInitiatorResponse'] = V1AuditTrailInitiatorResponse
+from symphony.bdk.gen.agent_model.pagination import Pagination
+from symphony.bdk.gen.agent_model.v1_audit_trail_initiator_response import V1AuditTrailInitiatorResponse
+globals()['Pagination'] = Pagination
+globals()['V1AuditTrailInitiatorResponse'] = V1AuditTrailInitiatorResponse
 
 
 class V1AuditTrailInitiatorList(ModelNormal):
@@ -79,10 +77,9 @@ class V1AuditTrailInitiatorList(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'items': ([V1AuditTrailInitiatorResponse],),  # noqa: E501
-            'pagination': (Pagination,),  # noqa: E501
+            'items': ([V1AuditTrailInitiatorResponse], none_type),  # noqa: E501
+            'pagination': (Pagination, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -167,7 +164,8 @@ class V1AuditTrailInitiatorList(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.items: List[V1AuditTrailInitiatorResponse] = None
+        self.pagination: Pagination = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v1_audit_trail_initiator_response.py
+++ b/symphony/bdk/gen/agent_model/v1_audit_trail_initiator_response.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,12 +73,12 @@ class V1AuditTrailInitiatorResponse(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'action': (str,),  # noqa: E501
-            'action_name': (str,),  # noqa: E501
-            'timestamp': (str,),  # noqa: E501
-            'initiator_id': (str,),  # noqa: E501
-            'initiator_username': (str,),  # noqa: E501
-            'initiator_email_address': (str,),  # noqa: E501
+            'action': (str, none_type),  # noqa: E501
+            'action_name': (str, none_type),  # noqa: E501
+            'timestamp': (str, none_type),  # noqa: E501
+            'initiator_id': (str, none_type),  # noqa: E501
+            'initiator_username': (str, none_type),  # noqa: E501
+            'initiator_email_address': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -172,7 +171,12 @@ class V1AuditTrailInitiatorResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.action: str = None
+        self.action_name: str = None
+        self.timestamp: str = None
+        self.initiator_id: str = None
+        self.initiator_username: str = None
+        self.initiator_email_address: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v1_dlp_content_type.py
+++ b/symphony/bdk/gen/agent_model/v1_dlp_content_type.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,7 +73,7 @@ class V1DLPContentType(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'type': (str,),  # noqa: E501
+            'type': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -157,7 +156,7 @@ class V1DLPContentType(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.type: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v1_dlp_dictionary.py
+++ b/symphony/bdk/gen/agent_model/v1_dlp_dictionary.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v1_dlp_dictionary_content import V1DLPDictionaryContent
-    from symphony.bdk.gen.agent_model.v1_dlp_dictionary_metadata import V1DLPDictionaryMetadata
-    globals()['V1DLPDictionaryContent'] = V1DLPDictionaryContent
-    globals()['V1DLPDictionaryMetadata'] = V1DLPDictionaryMetadata
+from symphony.bdk.gen.agent_model.v1_dlp_dictionary_content import V1DLPDictionaryContent
+from symphony.bdk.gen.agent_model.v1_dlp_dictionary_metadata import V1DLPDictionaryMetadata
+globals()['V1DLPDictionaryContent'] = V1DLPDictionaryContent
+globals()['V1DLPDictionaryMetadata'] = V1DLPDictionaryMetadata
 
 
 class V1DLPDictionary(ModelNormal):
@@ -79,10 +77,9 @@ class V1DLPDictionary(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'dictionary_metadata': (V1DLPDictionaryMetadata,),  # noqa: E501
-            'content': (V1DLPDictionaryContent,),  # noqa: E501
+            'content': (V1DLPDictionaryContent, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -169,8 +166,8 @@ class V1DLPDictionary(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.dictionary_metadata = dictionary_metadata
+        self.dictionary_metadata: V1DLPDictionaryMetadata = dictionary_metadata
+        self.content: V1DLPDictionaryContent = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v1_dlp_dictionary_content.py
+++ b/symphony/bdk/gen/agent_model/v1_dlp_dictionary_content.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,9 +73,9 @@ class V1DLPDictionaryContent(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'data': (str,),  # noqa: E501
-            'num_keywords': (int,),  # noqa: E501
-            'md5': (str,),  # noqa: E501
+            'data': (str, none_type),  # noqa: E501
+            'num_keywords': (int, none_type),  # noqa: E501
+            'md5': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -163,7 +162,9 @@ class V1DLPDictionaryContent(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.data: str = None
+        self.num_keywords: int = None
+        self.md5: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v1_dlp_dictionary_metadata.py
+++ b/symphony/bdk/gen/agent_model/v1_dlp_dictionary_metadata.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v1_dlp_dictionary_ref import V1DLPDictionaryRef
-    globals()['V1DLPDictionaryRef'] = V1DLPDictionaryRef
+from symphony.bdk.gen.agent_model.v1_dlp_dictionary_ref import V1DLPDictionaryRef
+globals()['V1DLPDictionaryRef'] = V1DLPDictionaryRef
 
 
 class V1DLPDictionaryMetadata(ModelNormal):
@@ -77,13 +75,12 @@ class V1DLPDictionaryMetadata(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'dict_ref': (V1DLPDictionaryRef,),  # noqa: E501
             'type': (str,),  # noqa: E501
-            'creation_date': (int,),  # noqa: E501
-            'creator_id': (str,),  # noqa: E501
-            'last_updated_date': (int,),  # noqa: E501
+            'creation_date': (int, none_type),  # noqa: E501
+            'creator_id': (str, none_type),  # noqa: E501
+            'last_updated_date': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -176,9 +173,11 @@ class V1DLPDictionaryMetadata(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.dict_ref = dict_ref
-        self.type = type
+        self.dict_ref: V1DLPDictionaryRef = dict_ref
+        self.type: str = type
+        self.creation_date: int = None
+        self.creator_id: str = None
+        self.last_updated_date: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v1_dlp_dictionary_metadata_collection_response.py
+++ b/symphony/bdk/gen/agent_model/v1_dlp_dictionary_metadata_collection_response.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v1_dlp_dictionary_metadata import V1DLPDictionaryMetadata
-    globals()['V1DLPDictionaryMetadata'] = V1DLPDictionaryMetadata
+from symphony.bdk.gen.agent_model.v1_dlp_dictionary_metadata import V1DLPDictionaryMetadata
+globals()['V1DLPDictionaryMetadata'] = V1DLPDictionaryMetadata
 
 
 class V1DLPDictionaryMetadataCollectionResponse(ModelNormal):
@@ -77,11 +75,10 @@ class V1DLPDictionaryMetadataCollectionResponse(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'items': ([V1DLPDictionaryMetadata],),  # noqa: E501
-            'page': (int,),  # noqa: E501
-            'page_count': (int,),  # noqa: E501
+            'items': ([V1DLPDictionaryMetadata], none_type),  # noqa: E501
+            'page': (int, none_type),  # noqa: E501
+            'page_count': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -168,7 +165,9 @@ class V1DLPDictionaryMetadataCollectionResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.items: List[V1DLPDictionaryMetadata] = None
+        self.page: int = None
+        self.page_count: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v1_dlp_dictionary_metadata_create_request.py
+++ b/symphony/bdk/gen/agent_model/v1_dlp_dictionary_metadata_create_request.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -162,9 +161,8 @@ class V1DLPDictionaryMetadataCreateRequest(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.name = name
-        self.type = type
+        self.name: str = name
+        self.type: str = type
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v1_dlp_dictionary_metadata_response.py
+++ b/symphony/bdk/gen/agent_model/v1_dlp_dictionary_metadata_response.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v1_dlp_dictionary_metadata import V1DLPDictionaryMetadata
-    globals()['V1DLPDictionaryMetadata'] = V1DLPDictionaryMetadata
+from symphony.bdk.gen.agent_model.v1_dlp_dictionary_metadata import V1DLPDictionaryMetadata
+globals()['V1DLPDictionaryMetadata'] = V1DLPDictionaryMetadata
 
 
 class V1DLPDictionaryMetadataResponse(ModelNormal):
@@ -77,7 +75,6 @@ class V1DLPDictionaryMetadataResponse(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'data': (V1DLPDictionaryMetadata,),  # noqa: E501
         }
@@ -164,8 +161,7 @@ class V1DLPDictionaryMetadataResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.data = data
+        self.data: V1DLPDictionaryMetadata = data
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v1_dlp_dictionary_metadata_update_request.py
+++ b/symphony/bdk/gen/agent_model/v1_dlp_dictionary_metadata_update_request.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -159,8 +158,7 @@ class V1DLPDictionaryMetadataUpdateRequest(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.name = name
+        self.name: str = name
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v1_dlp_dictionary_ref.py
+++ b/symphony/bdk/gen/agent_model/v1_dlp_dictionary_ref.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -75,8 +74,8 @@ class V1DLPDictionaryRef(ModelNormal):
         """
         return {
             'name': (str,),  # noqa: E501
-            'dict_id': (str,),  # noqa: E501
-            'version': (str,),  # noqa: E501
+            'dict_id': (str, none_type),  # noqa: E501
+            'version': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -165,8 +164,9 @@ class V1DLPDictionaryRef(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.name = name
+        self.name: str = name
+        self.dict_id: str = None
+        self.version: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v1_dlp_matched_policy.py
+++ b/symphony/bdk/gen/agent_model/v1_dlp_matched_policy.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,12 +73,12 @@ class V1DLPMatchedPolicy(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'id': (str,),  # noqa: E501
-            'version': (str,),  # noqa: E501
-            'policy_name': (str,),  # noqa: E501
-            'type': (str,),  # noqa: E501
-            'terms': (str,),  # noqa: E501
-            'diagnostic': (str,),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
+            'version': (str, none_type),  # noqa: E501
+            'policy_name': (str, none_type),  # noqa: E501
+            'type': (str, none_type),  # noqa: E501
+            'terms': (str, none_type),  # noqa: E501
+            'diagnostic': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -172,7 +171,12 @@ class V1DLPMatchedPolicy(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: str = None
+        self.version: str = None
+        self.policy_name: str = None
+        self.type: str = None
+        self.terms: str = None
+        self.diagnostic: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v1_dlp_matched_policy_list.py
+++ b/symphony/bdk/gen/agent_model/v1_dlp_matched_policy_list.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v1_dlp_matched_policy import V1DLPMatchedPolicy
-    globals()['V1DLPMatchedPolicy'] = V1DLPMatchedPolicy
+from symphony.bdk.gen.agent_model.v1_dlp_matched_policy import V1DLPMatchedPolicy
+globals()['V1DLPMatchedPolicy'] = V1DLPMatchedPolicy
 
 
 class V1DLPMatchedPolicyList(ModelSimple):
@@ -73,7 +71,6 @@ class V1DLPMatchedPolicyList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([V1DLPMatchedPolicy],),
         }
@@ -138,6 +135,8 @@ class V1DLPMatchedPolicyList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -153,7 +152,6 @@ class V1DLPMatchedPolicyList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -173,7 +171,7 @@ class V1DLPMatchedPolicyList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[V1DLPMatchedPolicy] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/agent_model/v1_dlp_outcome.py
+++ b/symphony/bdk/gen/agent_model/v1_dlp_outcome.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,7 +73,7 @@ class V1DLPOutcome(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'type': (str,),  # noqa: E501
+            'type': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -157,7 +156,7 @@ class V1DLPOutcome(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.type: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v1_dlp_policies_collection_response.py
+++ b/symphony/bdk/gen/agent_model/v1_dlp_policies_collection_response.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v1_dlp_policy import V1DLPPolicy
-    globals()['V1DLPPolicy'] = V1DLPPolicy
+from symphony.bdk.gen.agent_model.v1_dlp_policy import V1DLPPolicy
+globals()['V1DLPPolicy'] = V1DLPPolicy
 
 
 class V1DLPPoliciesCollectionResponse(ModelNormal):
@@ -77,11 +75,10 @@ class V1DLPPoliciesCollectionResponse(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'policies': ([V1DLPPolicy],),  # noqa: E501
-            'page': (int,),  # noqa: E501
-            'page_count': (int,),  # noqa: E501
+            'policies': ([V1DLPPolicy], none_type),  # noqa: E501
+            'page': (int, none_type),  # noqa: E501
+            'page_count': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -168,7 +165,9 @@ class V1DLPPoliciesCollectionResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.policies: List[V1DLPPolicy] = None
+        self.page: int = None
+        self.page_count: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v1_dlp_policy.py
+++ b/symphony/bdk/gen/agent_model/v1_dlp_policy.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v1_dlp_dictionary_ref import V1DLPDictionaryRef
-    globals()['V1DLPDictionaryRef'] = V1DLPDictionaryRef
+from symphony.bdk.gen.agent_model.v1_dlp_dictionary_ref import V1DLPDictionaryRef
+globals()['V1DLPDictionaryRef'] = V1DLPDictionaryRef
 
 
 class V1DLPPolicy(ModelNormal):
@@ -77,20 +75,19 @@ class V1DLPPolicy(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'content_types': ([str],),  # noqa: E501
             'name': (str,),  # noqa: E501
             'scopes': ([str],),  # noqa: E501
             'type': (str,),  # noqa: E501
-            'active': (bool,),  # noqa: E501
-            'creation_date': (int,),  # noqa: E501
-            'creator_id': (str,),  # noqa: E501
-            'dictionary_refs': ([V1DLPDictionaryRef],),  # noqa: E501
-            'last_disabled_date': (int,),  # noqa: E501
-            'last_updated_date': (int,),  # noqa: E501
-            'policy_id': (str,),  # noqa: E501
-            'version': (str,),  # noqa: E501
+            'active': (bool, none_type),  # noqa: E501
+            'creation_date': (int, none_type),  # noqa: E501
+            'creator_id': (str, none_type),  # noqa: E501
+            'dictionary_refs': ([V1DLPDictionaryRef], none_type),  # noqa: E501
+            'last_disabled_date': (int, none_type),  # noqa: E501
+            'last_updated_date': (int, none_type),  # noqa: E501
+            'policy_id': (str, none_type),  # noqa: E501
+            'version': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -197,11 +194,18 @@ class V1DLPPolicy(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.content_types = content_types
-        self.name = name
-        self.scopes = scopes
-        self.type = type
+        self.content_types: List[str] = content_types
+        self.name: str = name
+        self.scopes: List[str] = scopes
+        self.type: str = type
+        self.active: bool = None
+        self.creation_date: int = None
+        self.creator_id: str = None
+        self.dictionary_refs: List[V1DLPDictionaryRef] = None
+        self.last_disabled_date: int = None
+        self.last_updated_date: int = None
+        self.policy_id: str = None
+        self.version: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v1_dlp_policy_request.py
+++ b/symphony/bdk/gen/agent_model/v1_dlp_policy_request.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -78,7 +77,7 @@ class V1DLPPolicyRequest(ModelNormal):
             'name': (str,),  # noqa: E501
             'scopes': ([str],),  # noqa: E501
             'type': (str,),  # noqa: E501
-            'dictionary_ids': ([str],),  # noqa: E501
+            'dictionary_ids': ([str], none_type),  # noqa: E501
         }
 
     @cached_property
@@ -171,11 +170,11 @@ class V1DLPPolicyRequest(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.content_types = content_types
-        self.name = name
-        self.scopes = scopes
-        self.type = type
+        self.content_types: List[str] = content_types
+        self.name: str = name
+        self.scopes: List[str] = scopes
+        self.type: str = type
+        self.dictionary_ids: List[str] = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v1_dlp_policy_response.py
+++ b/symphony/bdk/gen/agent_model/v1_dlp_policy_response.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v1_dlp_policy import V1DLPPolicy
-    globals()['V1DLPPolicy'] = V1DLPPolicy
+from symphony.bdk.gen.agent_model.v1_dlp_policy import V1DLPPolicy
+globals()['V1DLPPolicy'] = V1DLPPolicy
 
 
 class V1DLPPolicyResponse(ModelNormal):
@@ -77,9 +75,8 @@ class V1DLPPolicyResponse(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'data': (V1DLPPolicy,),  # noqa: E501
+            'data': (V1DLPPolicy, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -162,7 +159,7 @@ class V1DLPPolicyResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.data: V1DLPPolicy = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v1_dlp_signal.py
+++ b/symphony/bdk/gen/agent_model/v1_dlp_signal.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,9 +73,9 @@ class V1DLPSignal(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'name': (str,),  # noqa: E501
-            'rules': (str,),  # noqa: E501
-            'diagnostic': (str,),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
+            'rules': (str, none_type),  # noqa: E501
+            'diagnostic': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -163,7 +162,9 @@ class V1DLPSignal(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.name: str = None
+        self.rules: str = None
+        self.diagnostic: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v1_dlp_stream.py
+++ b/symphony/bdk/gen/agent_model/v1_dlp_stream.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,27 +73,27 @@ class V1DLPStream(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'name': (str,),  # noqa: E501
-            'creator_pretty_name': (str,),  # noqa: E501
-            'public_room': (bool,),  # noqa: E501
-            'cross_pod': (bool,),  # noqa: E501
-            'allow_external': (bool,),  # noqa: E501
-            'creator_id': (str,),  # noqa: E501
-            'room_description': (str,),  # noqa: E501
-            'stream_id': (str,),  # noqa: E501
-            'state': (str,),  # noqa: E501
-            'type': (str,),  # noqa: E501
-            'last_disabled': (int,),  # noqa: E501
-            'member_add_user_enabled': (bool,),  # noqa: E501
-            'active': (bool,),  # noqa: E501
-            'discoverable': (bool,),  # noqa: E501
-            'read_only': (bool,),  # noqa: E501
-            'copy_disabled': (bool,),  # noqa: E501
-            'external_owned': (bool,),  # noqa: E501
-            'send_message_disabled': (bool,),  # noqa: E501
-            'moderated': (bool,),  # noqa: E501
-            'share_history_enabled': (bool,),  # noqa: E501
-            'diagnostic': (str,),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
+            'creator_pretty_name': (str, none_type),  # noqa: E501
+            'public_room': (bool, none_type),  # noqa: E501
+            'cross_pod': (bool, none_type),  # noqa: E501
+            'allow_external': (bool, none_type),  # noqa: E501
+            'creator_id': (str, none_type),  # noqa: E501
+            'room_description': (str, none_type),  # noqa: E501
+            'stream_id': (str, none_type),  # noqa: E501
+            'state': (str, none_type),  # noqa: E501
+            'type': (str, none_type),  # noqa: E501
+            'last_disabled': (int, none_type),  # noqa: E501
+            'member_add_user_enabled': (bool, none_type),  # noqa: E501
+            'active': (bool, none_type),  # noqa: E501
+            'discoverable': (bool, none_type),  # noqa: E501
+            'read_only': (bool, none_type),  # noqa: E501
+            'copy_disabled': (bool, none_type),  # noqa: E501
+            'external_owned': (bool, none_type),  # noqa: E501
+            'send_message_disabled': (bool, none_type),  # noqa: E501
+            'moderated': (bool, none_type),  # noqa: E501
+            'share_history_enabled': (bool, none_type),  # noqa: E501
+            'diagnostic': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -217,7 +216,27 @@ class V1DLPStream(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.name: str = None
+        self.creator_pretty_name: str = None
+        self.public_room: bool = None
+        self.cross_pod: bool = None
+        self.allow_external: bool = None
+        self.creator_id: str = None
+        self.room_description: str = None
+        self.stream_id: str = None
+        self.state: str = None
+        self.type: str = None
+        self.last_disabled: int = None
+        self.member_add_user_enabled: bool = None
+        self.active: bool = None
+        self.discoverable: bool = None
+        self.read_only: bool = None
+        self.copy_disabled: bool = None
+        self.external_owned: bool = None
+        self.send_message_disabled: bool = None
+        self.moderated: bool = None
+        self.share_history_enabled: bool = None
+        self.diagnostic: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v1_dlp_violation.py
+++ b/symphony/bdk/gen/agent_model/v1_dlp_violation.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v1_dlp_matched_policy_list import V1DLPMatchedPolicyList
-    from symphony.bdk.gen.agent_model.v1_dlp_outcome import V1DLPOutcome
-    globals()['V1DLPMatchedPolicyList'] = V1DLPMatchedPolicyList
-    globals()['V1DLPOutcome'] = V1DLPOutcome
+from symphony.bdk.gen.agent_model.v1_dlp_matched_policy_list import V1DLPMatchedPolicyList
+from symphony.bdk.gen.agent_model.v1_dlp_outcome import V1DLPOutcome
+globals()['V1DLPMatchedPolicyList'] = V1DLPMatchedPolicyList
+globals()['V1DLPOutcome'] = V1DLPOutcome
 
 
 class V1DLPViolation(ModelNormal):
@@ -79,18 +77,17 @@ class V1DLPViolation(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'enforcement_event_id': (str,),  # noqa: E501
-            'entity_id': (str,),  # noqa: E501
-            'create_time': (int,),  # noqa: E501
-            'last_modified': (int,),  # noqa: E501
-            'requester_id': (int,),  # noqa: E501
-            'matched_policies': (V1DLPMatchedPolicyList,),  # noqa: E501
-            'action': (str,),  # noqa: E501
-            'outcome': (V1DLPOutcome,),  # noqa: E501
-            'version': (str,),  # noqa: E501
-            'ignore_dl_pwarning': (bool,),  # noqa: E501
+            'enforcement_event_id': (str, none_type),  # noqa: E501
+            'entity_id': (str, none_type),  # noqa: E501
+            'create_time': (int, none_type),  # noqa: E501
+            'last_modified': (int, none_type),  # noqa: E501
+            'requester_id': (int, none_type),  # noqa: E501
+            'matched_policies': (V1DLPMatchedPolicyList, none_type),  # noqa: E501
+            'action': (str, none_type),  # noqa: E501
+            'outcome': (V1DLPOutcome, none_type),  # noqa: E501
+            'version': (str, none_type),  # noqa: E501
+            'ignore_dl_pwarning': (bool, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -191,7 +188,16 @@ class V1DLPViolation(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.enforcement_event_id: str = None
+        self.entity_id: str = None
+        self.create_time: int = None
+        self.last_modified: int = None
+        self.requester_id: int = None
+        self.matched_policies: V1DLPMatchedPolicyList = None
+        self.action: str = None
+        self.outcome: V1DLPOutcome = None
+        self.version: str = None
+        self.ignore_dl_pwarning: bool = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v1_dlp_violation_message.py
+++ b/symphony/bdk/gen/agent_model/v1_dlp_violation_message.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v1_dlp_violation import V1DLPViolation
-    from symphony.bdk.gen.agent_model.v4_message import V4Message
-    globals()['V1DLPViolation'] = V1DLPViolation
-    globals()['V4Message'] = V4Message
+from symphony.bdk.gen.agent_model.v1_dlp_violation import V1DLPViolation
+from symphony.bdk.gen.agent_model.v4_message import V4Message
+globals()['V1DLPViolation'] = V1DLPViolation
+globals()['V4Message'] = V4Message
 
 
 class V1DLPViolationMessage(ModelNormal):
@@ -79,11 +77,10 @@ class V1DLPViolationMessage(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'violation': (V1DLPViolation,),  # noqa: E501
-            'message': (V4Message,),  # noqa: E501
-            'diagnostic': (str,),  # noqa: E501
+            'violation': (V1DLPViolation, none_type),  # noqa: E501
+            'message': (V4Message, none_type),  # noqa: E501
+            'diagnostic': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -170,7 +167,9 @@ class V1DLPViolationMessage(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.violation: V1DLPViolation = None
+        self.message: V4Message = None
+        self.diagnostic: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v1_dlp_violation_message_response.py
+++ b/symphony/bdk/gen/agent_model/v1_dlp_violation_message_response.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v1_dlp_violation_message import V1DLPViolationMessage
-    globals()['V1DLPViolationMessage'] = V1DLPViolationMessage
+from symphony.bdk.gen.agent_model.v1_dlp_violation_message import V1DLPViolationMessage
+globals()['V1DLPViolationMessage'] = V1DLPViolationMessage
 
 
 class V1DLPViolationMessageResponse(ModelNormal):
@@ -77,10 +75,9 @@ class V1DLPViolationMessageResponse(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'violations': ([V1DLPViolationMessage],),  # noqa: E501
-            'next_offset': (str,),  # noqa: E501
+            'violations': ([V1DLPViolationMessage], none_type),  # noqa: E501
+            'next_offset': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -165,7 +162,8 @@ class V1DLPViolationMessageResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.violations: List[V1DLPViolationMessage] = None
+        self.next_offset: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v1_dlp_violation_signal.py
+++ b/symphony/bdk/gen/agent_model/v1_dlp_violation_signal.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v1_dlp_signal import V1DLPSignal
-    from symphony.bdk.gen.agent_model.v1_dlp_violation import V1DLPViolation
-    globals()['V1DLPSignal'] = V1DLPSignal
-    globals()['V1DLPViolation'] = V1DLPViolation
+from symphony.bdk.gen.agent_model.v1_dlp_signal import V1DLPSignal
+from symphony.bdk.gen.agent_model.v1_dlp_violation import V1DLPViolation
+globals()['V1DLPSignal'] = V1DLPSignal
+globals()['V1DLPViolation'] = V1DLPViolation
 
 
 class V1DLPViolationSignal(ModelNormal):
@@ -79,10 +77,9 @@ class V1DLPViolationSignal(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'violation': (V1DLPViolation,),  # noqa: E501
-            'signal': (V1DLPSignal,),  # noqa: E501
+            'violation': (V1DLPViolation, none_type),  # noqa: E501
+            'signal': (V1DLPSignal, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -167,7 +164,8 @@ class V1DLPViolationSignal(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.violation: V1DLPViolation = None
+        self.signal: V1DLPSignal = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v1_dlp_violation_signal_response.py
+++ b/symphony/bdk/gen/agent_model/v1_dlp_violation_signal_response.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v1_dlp_violation_signal import V1DLPViolationSignal
-    globals()['V1DLPViolationSignal'] = V1DLPViolationSignal
+from symphony.bdk.gen.agent_model.v1_dlp_violation_signal import V1DLPViolationSignal
+globals()['V1DLPViolationSignal'] = V1DLPViolationSignal
 
 
 class V1DLPViolationSignalResponse(ModelNormal):
@@ -77,10 +75,9 @@ class V1DLPViolationSignalResponse(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'violations': ([V1DLPViolationSignal],),  # noqa: E501
-            'next_offset': (str,),  # noqa: E501
+            'violations': ([V1DLPViolationSignal], none_type),  # noqa: E501
+            'next_offset': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -165,7 +162,8 @@ class V1DLPViolationSignalResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.violations: List[V1DLPViolationSignal] = None
+        self.next_offset: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v1_dlp_violation_stream.py
+++ b/symphony/bdk/gen/agent_model/v1_dlp_violation_stream.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v1_dlp_stream import V1DLPStream
-    from symphony.bdk.gen.agent_model.v1_dlp_violation import V1DLPViolation
-    globals()['V1DLPStream'] = V1DLPStream
-    globals()['V1DLPViolation'] = V1DLPViolation
+from symphony.bdk.gen.agent_model.v1_dlp_stream import V1DLPStream
+from symphony.bdk.gen.agent_model.v1_dlp_violation import V1DLPViolation
+globals()['V1DLPStream'] = V1DLPStream
+globals()['V1DLPViolation'] = V1DLPViolation
 
 
 class V1DLPViolationStream(ModelNormal):
@@ -79,10 +77,9 @@ class V1DLPViolationStream(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'violation': (V1DLPViolation,),  # noqa: E501
-            'stream': (V1DLPStream,),  # noqa: E501
+            'violation': (V1DLPViolation, none_type),  # noqa: E501
+            'stream': (V1DLPStream, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -167,7 +164,8 @@ class V1DLPViolationStream(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.violation: V1DLPViolation = None
+        self.stream: V1DLPStream = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v1_dlp_violation_stream_response.py
+++ b/symphony/bdk/gen/agent_model/v1_dlp_violation_stream_response.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v1_dlp_violation_stream import V1DLPViolationStream
-    globals()['V1DLPViolationStream'] = V1DLPViolationStream
+from symphony.bdk.gen.agent_model.v1_dlp_violation_stream import V1DLPViolationStream
+globals()['V1DLPViolationStream'] = V1DLPViolationStream
 
 
 class V1DLPViolationStreamResponse(ModelNormal):
@@ -77,10 +75,9 @@ class V1DLPViolationStreamResponse(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'violations': ([V1DLPViolationStream],),  # noqa: E501
-            'next_offset': (str,),  # noqa: E501
+            'violations': ([V1DLPViolationStream], none_type),  # noqa: E501
+            'next_offset': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -165,7 +162,8 @@ class V1DLPViolationStreamResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.violations: List[V1DLPViolationStream] = None
+        self.next_offset: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v2_base_message.py
+++ b/symphony/bdk/gen/agent_model/v2_base_message.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -27,28 +26,6 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     none_type,
     validate_get_composed_info,
 )
-
-def lazy_import():
-    from symphony.bdk.gen.agent_model.connection_request_message import ConnectionRequestMessage
-    from symphony.bdk.gen.agent_model.room_created_message import RoomCreatedMessage
-    from symphony.bdk.gen.agent_model.room_deactivated_message import RoomDeactivatedMessage
-    from symphony.bdk.gen.agent_model.room_member_demoted_from_owner_message import RoomMemberDemotedFromOwnerMessage
-    from symphony.bdk.gen.agent_model.room_member_promoted_to_owner_message import RoomMemberPromotedToOwnerMessage
-    from symphony.bdk.gen.agent_model.room_reactivated_message import RoomReactivatedMessage
-    from symphony.bdk.gen.agent_model.room_updated_message import RoomUpdatedMessage
-    from symphony.bdk.gen.agent_model.user_joined_room_message import UserJoinedRoomMessage
-    from symphony.bdk.gen.agent_model.user_left_room_message import UserLeftRoomMessage
-    from symphony.bdk.gen.agent_model.v2_message import V2Message
-    globals()['ConnectionRequestMessage'] = ConnectionRequestMessage
-    globals()['RoomCreatedMessage'] = RoomCreatedMessage
-    globals()['RoomDeactivatedMessage'] = RoomDeactivatedMessage
-    globals()['RoomMemberDemotedFromOwnerMessage'] = RoomMemberDemotedFromOwnerMessage
-    globals()['RoomMemberPromotedToOwnerMessage'] = RoomMemberPromotedToOwnerMessage
-    globals()['RoomReactivatedMessage'] = RoomReactivatedMessage
-    globals()['RoomUpdatedMessage'] = RoomUpdatedMessage
-    globals()['UserJoinedRoomMessage'] = UserJoinedRoomMessage
-    globals()['UserLeftRoomMessage'] = UserLeftRoomMessage
-    globals()['V2Message'] = V2Message
 
 
 class V2BaseMessage(ModelNormal):
@@ -95,17 +72,35 @@ class V2BaseMessage(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'timestamp': (str,),  # noqa: E501
             'v2message_type': (str,),  # noqa: E501
             'stream_id': (str,),  # noqa: E501
-            'id': (str,),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
         }
 
     @cached_property
     def discriminator():
-        lazy_import()
+        from symphony.bdk.gen.agent_model.connection_request_message import ConnectionRequestMessage
+        from symphony.bdk.gen.agent_model.room_created_message import RoomCreatedMessage
+        from symphony.bdk.gen.agent_model.room_deactivated_message import RoomDeactivatedMessage
+        from symphony.bdk.gen.agent_model.room_member_demoted_from_owner_message import RoomMemberDemotedFromOwnerMessage
+        from symphony.bdk.gen.agent_model.room_member_promoted_to_owner_message import RoomMemberPromotedToOwnerMessage
+        from symphony.bdk.gen.agent_model.room_reactivated_message import RoomReactivatedMessage
+        from symphony.bdk.gen.agent_model.room_updated_message import RoomUpdatedMessage
+        from symphony.bdk.gen.agent_model.user_joined_room_message import UserJoinedRoomMessage
+        from symphony.bdk.gen.agent_model.user_left_room_message import UserLeftRoomMessage
+        from symphony.bdk.gen.agent_model.v2_message import V2Message
+        globals()['ConnectionRequestMessage'] = ConnectionRequestMessage
+        globals()['RoomCreatedMessage'] = RoomCreatedMessage
+        globals()['RoomDeactivatedMessage'] = RoomDeactivatedMessage
+        globals()['RoomMemberDemotedFromOwnerMessage'] = RoomMemberDemotedFromOwnerMessage
+        globals()['RoomMemberPromotedToOwnerMessage'] = RoomMemberPromotedToOwnerMessage
+        globals()['RoomReactivatedMessage'] = RoomReactivatedMessage
+        globals()['RoomUpdatedMessage'] = RoomUpdatedMessage
+        globals()['UserJoinedRoomMessage'] = UserJoinedRoomMessage
+        globals()['UserLeftRoomMessage'] = UserLeftRoomMessage
+        globals()['V2Message'] = V2Message
         val = {
             'ConnectionRequestMessage': ConnectionRequestMessage,
             'RoomCreatedMessage': RoomCreatedMessage,
@@ -205,10 +200,10 @@ class V2BaseMessage(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.timestamp = timestamp
-        self.v2message_type = v2message_type
-        self.stream_id = stream_id
+        self.timestamp: str = timestamp
+        self.v2message_type: str = v2message_type
+        self.stream_id: str = stream_id
+        self.id: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v2_error.py
+++ b/symphony/bdk/gen/agent_model/v2_error.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -76,7 +75,7 @@ class V2Error(ModelNormal):
         return {
             'code': (int,),  # noqa: E501
             'message': (str,),  # noqa: E501
-            'details': ({str: (bool, date, datetime, dict, float, int, list, str, none_type)},),  # noqa: E501
+            'details': ({str: (bool, date, datetime, dict, float, int, list, str, none_type)}, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -165,9 +164,9 @@ class V2Error(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.code = code
-        self.message = message
+        self.code: int = code
+        self.message: str = message
+        self.details: {str: (bool, date, datetime, dict, float, int, list, str, none_type)} = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v2_health_check_response.py
+++ b/symphony/bdk/gen/agent_model/v2_health_check_response.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,20 +73,20 @@ class V2HealthCheckResponse(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'pod_connectivity': (bool,),  # noqa: E501
-            'pod_connectivity_error': (str,),  # noqa: E501
-            'key_manager_connectivity': (bool,),  # noqa: E501
-            'key_manager_connectivity_error': (str,),  # noqa: E501
-            'firehose_connectivity': (bool,),  # noqa: E501
-            'firehose_connectivity_error': (str,),  # noqa: E501
-            'encrypt_decrypt_success': (bool,),  # noqa: E501
-            'encrypt_decrypt_error': (str,),  # noqa: E501
-            'pod_version': (str,),  # noqa: E501
-            'agent_version': (str,),  # noqa: E501
-            'agent_service_user': (bool,),  # noqa: E501
-            'agent_service_user_error': (str,),  # noqa: E501
-            'ce_service_user': (bool,),  # noqa: E501
-            'ce_service_user_error': (str,),  # noqa: E501
+            'pod_connectivity': (bool, none_type),  # noqa: E501
+            'pod_connectivity_error': (str, none_type),  # noqa: E501
+            'key_manager_connectivity': (bool, none_type),  # noqa: E501
+            'key_manager_connectivity_error': (str, none_type),  # noqa: E501
+            'firehose_connectivity': (bool, none_type),  # noqa: E501
+            'firehose_connectivity_error': (str, none_type),  # noqa: E501
+            'encrypt_decrypt_success': (bool, none_type),  # noqa: E501
+            'encrypt_decrypt_error': (str, none_type),  # noqa: E501
+            'pod_version': (str, none_type),  # noqa: E501
+            'agent_version': (str, none_type),  # noqa: E501
+            'agent_service_user': (bool, none_type),  # noqa: E501
+            'agent_service_user_error': (str, none_type),  # noqa: E501
+            'ce_service_user': (bool, none_type),  # noqa: E501
+            'ce_service_user_error': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -196,7 +195,20 @@ class V2HealthCheckResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.pod_connectivity: bool = None
+        self.pod_connectivity_error: str = None
+        self.key_manager_connectivity: bool = None
+        self.key_manager_connectivity_error: str = None
+        self.firehose_connectivity: bool = None
+        self.firehose_connectivity_error: str = None
+        self.encrypt_decrypt_success: bool = None
+        self.encrypt_decrypt_error: str = None
+        self.pod_version: str = None
+        self.agent_version: str = None
+        self.agent_service_user: bool = None
+        self.agent_service_user_error: str = None
+        self.ce_service_user: bool = None
+        self.ce_service_user_error: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v2_message.py
+++ b/symphony/bdk/gen/agent_model/v2_message.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,13 +27,12 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.attachment_info import AttachmentInfo
-    from symphony.bdk.gen.agent_model.v2_base_message import V2BaseMessage
-    from symphony.bdk.gen.agent_model.v2_message_all_of import V2MessageAllOf
-    globals()['AttachmentInfo'] = AttachmentInfo
-    globals()['V2BaseMessage'] = V2BaseMessage
-    globals()['V2MessageAllOf'] = V2MessageAllOf
+from symphony.bdk.gen.agent_model.attachment_info import AttachmentInfo
+from symphony.bdk.gen.agent_model.v2_base_message import V2BaseMessage
+from symphony.bdk.gen.agent_model.v2_message_all_of import V2MessageAllOf
+globals()['AttachmentInfo'] = AttachmentInfo
+globals()['V2BaseMessage'] = V2BaseMessage
+globals()['V2MessageAllOf'] = V2MessageAllOf
 
 
 class V2Message(ModelComposed):
@@ -73,7 +71,6 @@ class V2Message(ModelComposed):
         This must be a method because a agent_model may have properties that are
         of type self, this must run after the class is loaded
         """
-        lazy_import()
         return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
 
     _nullable = False
@@ -88,15 +85,14 @@ class V2Message(ModelComposed):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'message': (str,),  # noqa: E501
             'from_user_id': (int,),  # noqa: E501
             'timestamp': (str,),  # noqa: E501
             'v2message_type': (str,),  # noqa: E501
             'stream_id': (str,),  # noqa: E501
-            'attachments': ([AttachmentInfo],),  # noqa: E501
-            'id': (str,),  # noqa: E501
+            'attachments': ([AttachmentInfo], none_type),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -212,11 +208,6 @@ class V2Message(ModelComposed):
             'v2message_type': v2message_type,
             'stream_id': stream_id,
         }
-        # remove args whose value is Null because they are unset
-        required_arg_names = list(required_args.keys())
-        for required_arg_name in required_arg_names:
-            if required_args[required_arg_name] is nulltype.Null:
-                del required_args[required_arg_name]
         model_args = {}
         model_args.update(required_args)
         model_args.update(kwargs)
@@ -226,9 +217,13 @@ class V2Message(ModelComposed):
         self._var_name_to_model_instances = composed_info[1]
         self._additional_properties_model_instances = composed_info[2]
         unused_args = composed_info[3]
-
-        for var_name, var_value in required_args.items():
-            setattr(self, var_name, var_value)
+        self.message: str = message
+        self.from_user_id: int = from_user_id
+        self.timestamp: str = timestamp
+        self.v2message_type: str = v2message_type
+        self.stream_id: str = stream_id
+        self.attachments: List[AttachmentInfo] = None
+        self.id: str = None
         for var_name, var_value in kwargs.items():
             if var_name in unused_args and \
                         self._configuration is not None and \
@@ -247,7 +242,6 @@ class V2Message(ModelComposed):
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        lazy_import()
         return {
           'anyOf': [
           ],

--- a/symphony/bdk/gen/agent_model/v2_message_all_of.py
+++ b/symphony/bdk/gen/agent_model/v2_message_all_of.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.attachment_info import AttachmentInfo
-    globals()['AttachmentInfo'] = AttachmentInfo
+from symphony.bdk.gen.agent_model.attachment_info import AttachmentInfo
+globals()['AttachmentInfo'] = AttachmentInfo
 
 
 class V2MessageAllOf(ModelNormal):
@@ -77,11 +75,10 @@ class V2MessageAllOf(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'message': (str,),  # noqa: E501
             'from_user_id': (int,),  # noqa: E501
-            'attachments': ([AttachmentInfo],),  # noqa: E501
+            'attachments': ([AttachmentInfo], none_type),  # noqa: E501
         }
 
     @cached_property
@@ -170,9 +167,9 @@ class V2MessageAllOf(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.message = message
-        self.from_user_id = from_user_id
+        self.message: str = message
+        self.from_user_id: int = from_user_id
+        self.attachments: List[AttachmentInfo] = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v2_message_list.py
+++ b/symphony/bdk/gen/agent_model/v2_message_list.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v2_base_message import V2BaseMessage
-    globals()['V2BaseMessage'] = V2BaseMessage
+from symphony.bdk.gen.agent_model.v2_base_message import V2BaseMessage
+globals()['V2BaseMessage'] = V2BaseMessage
 
 
 class V2MessageList(ModelSimple):
@@ -73,7 +71,6 @@ class V2MessageList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([V2BaseMessage],),
         }
@@ -138,6 +135,8 @@ class V2MessageList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -153,7 +152,6 @@ class V2MessageList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -173,7 +171,7 @@ class V2MessageList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[V2BaseMessage] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/agent_model/v3_dlp_dictionary_meta.py
+++ b/symphony/bdk/gen/agent_model/v3_dlp_dictionary_meta.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -165,10 +164,9 @@ class V3DLPDictionaryMeta(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.dict_id = dict_id
-        self.version = version
-        self.name = name
+        self.dict_id: str = dict_id
+        self.version: str = version
+        self.name: str = name
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v3_dlp_file_classifier_config.py
+++ b/symphony/bdk/gen/agent_model/v3_dlp_file_classifier_config.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -162,9 +161,8 @@ class V3DLPFileClassifierConfig(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.classifiers = classifiers
-        self.applicable_file_types = applicable_file_types
+        self.classifiers: {str: (str,)} = classifiers
+        self.applicable_file_types: List[str] = applicable_file_types
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v3_dlp_file_extension_config.py
+++ b/symphony/bdk/gen/agent_model/v3_dlp_file_extension_config.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -75,7 +74,7 @@ class V3DLPFileExtensionConfig(ModelNormal):
         """
         return {
             'allow_lists': ([str],),  # noqa: E501
-            'block_lists': ([str],),  # noqa: E501
+            'block_lists': ([str], none_type),  # noqa: E501
         }
 
     @cached_property
@@ -162,8 +161,8 @@ class V3DLPFileExtensionConfig(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.allow_lists = allow_lists
+        self.allow_lists: List[str] = allow_lists
+        self.block_lists: List[str] = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v3_dlp_file_password_config.py
+++ b/symphony/bdk/gen/agent_model/v3_dlp_file_password_config.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -162,9 +161,8 @@ class V3DLPFilePasswordConfig(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.applicable_file_types = applicable_file_types
-        self.match_criteria = match_criteria
+        self.applicable_file_types: List[str] = applicable_file_types
+        self.match_criteria: str = match_criteria
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v3_dlp_file_size_config.py
+++ b/symphony/bdk/gen/agent_model/v3_dlp_file_size_config.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,7 +73,7 @@ class V3DLPFileSizeConfig(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'size_limit': (int,),  # noqa: E501
+            'size_limit': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -157,7 +156,7 @@ class V3DLPFileSizeConfig(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.size_limit: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v3_dlp_policies_collection_response.py
+++ b/symphony/bdk/gen/agent_model/v3_dlp_policies_collection_response.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v3_dlp_policy import V3DLPPolicy
-    globals()['V3DLPPolicy'] = V3DLPPolicy
+from symphony.bdk.gen.agent_model.v3_dlp_policy import V3DLPPolicy
+globals()['V3DLPPolicy'] = V3DLPPolicy
 
 
 class V3DLPPoliciesCollectionResponse(ModelNormal):
@@ -77,12 +75,11 @@ class V3DLPPoliciesCollectionResponse(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'policies': ([V3DLPPolicy],),  # noqa: E501
-            'page': (int,),  # noqa: E501
-            'size': (int,),  # noqa: E501
-            'page_count': (int,),  # noqa: E501
+            'policies': ([V3DLPPolicy], none_type),  # noqa: E501
+            'page': (int, none_type),  # noqa: E501
+            'size': (int, none_type),  # noqa: E501
+            'page_count': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -171,7 +168,10 @@ class V3DLPPoliciesCollectionResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.policies: List[V3DLPPolicy] = None
+        self.page: int = None
+        self.size: int = None
+        self.page_count: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v3_dlp_policy.py
+++ b/symphony/bdk/gen/agent_model/v3_dlp_policy.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v3_dlp_policy_applies_to import V3DLPPolicyAppliesTo
-    globals()['V3DLPPolicyAppliesTo'] = V3DLPPolicyAppliesTo
+from symphony.bdk.gen.agent_model.v3_dlp_policy_applies_to import V3DLPPolicyAppliesTo
+globals()['V3DLPPolicyAppliesTo'] = V3DLPPolicyAppliesTo
 
 
 class V3DLPPolicy(ModelNormal):
@@ -77,21 +75,20 @@ class V3DLPPolicy(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'id': (str,),  # noqa: E501
-            'policy_id': (str,),  # noqa: E501
-            'version': (str,),  # noqa: E501
-            'name': (str,),  # noqa: E501
-            'creator_id': (int,),  # noqa: E501
-            'scopes': ([str],),  # noqa: E501
-            'applies_to': ([V3DLPPolicyAppliesTo],),  # noqa: E501
-            'active': (bool,),  # noqa: E501
-            'deleted': (bool,),  # noqa: E501
-            'creation_date': (int,),  # noqa: E501
-            'last_updated_date': (int,),  # noqa: E501
-            'last_disabled_date': (int,),  # noqa: E501
-            'system_policy': (bool,),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
+            'policy_id': (str, none_type),  # noqa: E501
+            'version': (str, none_type),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
+            'creator_id': (int, none_type),  # noqa: E501
+            'scopes': ([str], none_type),  # noqa: E501
+            'applies_to': ([V3DLPPolicyAppliesTo], none_type),  # noqa: E501
+            'active': (bool, none_type),  # noqa: E501
+            'deleted': (bool, none_type),  # noqa: E501
+            'creation_date': (int, none_type),  # noqa: E501
+            'last_updated_date': (int, none_type),  # noqa: E501
+            'last_disabled_date': (int, none_type),  # noqa: E501
+            'system_policy': (bool, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -198,7 +195,19 @@ class V3DLPPolicy(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: str = None
+        self.policy_id: str = None
+        self.version: str = None
+        self.name: str = None
+        self.creator_id: int = None
+        self.scopes: List[str] = None
+        self.applies_to: List[V3DLPPolicyAppliesTo] = None
+        self.active: bool = None
+        self.deleted: bool = None
+        self.creation_date: int = None
+        self.last_updated_date: int = None
+        self.last_disabled_date: int = None
+        self.system_policy: bool = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v3_dlp_policy_applies_to.py
+++ b/symphony/bdk/gen/agent_model/v3_dlp_policy_applies_to.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v3_dlp_rule import V3DLPRule
-    globals()['V3DLPRule'] = V3DLPRule
+from symphony.bdk.gen.agent_model.v3_dlp_rule import V3DLPRule
+globals()['V3DLPRule'] = V3DLPRule
 
 
 class V3DLPPolicyAppliesTo(ModelNormal):
@@ -77,7 +75,6 @@ class V3DLPPolicyAppliesTo(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'data_type': (str,),  # noqa: E501
             'action': (str,),  # noqa: E501
@@ -170,10 +167,9 @@ class V3DLPPolicyAppliesTo(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.data_type = data_type
-        self.action = action
-        self.rules = rules
+        self.data_type: str = data_type
+        self.action: str = action
+        self.rules: List[V3DLPRule] = rules
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v3_dlp_policy_request.py
+++ b/symphony/bdk/gen/agent_model/v3_dlp_policy_request.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v3_dlp_policy_applies_to import V3DLPPolicyAppliesTo
-    globals()['V3DLPPolicyAppliesTo'] = V3DLPPolicyAppliesTo
+from symphony.bdk.gen.agent_model.v3_dlp_policy_applies_to import V3DLPPolicyAppliesTo
+globals()['V3DLPPolicyAppliesTo'] = V3DLPPolicyAppliesTo
 
 
 class V3DLPPolicyRequest(ModelNormal):
@@ -77,7 +75,6 @@ class V3DLPPolicyRequest(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'name': (str,),  # noqa: E501
             'scopes': ([str],),  # noqa: E501
@@ -170,10 +167,9 @@ class V3DLPPolicyRequest(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.name = name
-        self.scopes = scopes
-        self.applies_to = applies_to
+        self.name: str = name
+        self.scopes: List[str] = scopes
+        self.applies_to: List[V3DLPPolicyAppliesTo] = applies_to
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v3_dlp_policy_response.py
+++ b/symphony/bdk/gen/agent_model/v3_dlp_policy_response.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v3_dlp_policy import V3DLPPolicy
-    globals()['V3DLPPolicy'] = V3DLPPolicy
+from symphony.bdk.gen.agent_model.v3_dlp_policy import V3DLPPolicy
+globals()['V3DLPPolicy'] = V3DLPPolicy
 
 
 class V3DLPPolicyResponse(ModelNormal):
@@ -77,9 +75,8 @@ class V3DLPPolicyResponse(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'data': (V3DLPPolicy,),  # noqa: E501
+            'data': (V3DLPPolicy, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -162,7 +159,7 @@ class V3DLPPolicyResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.data: V3DLPPolicy = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v3_dlp_rule.py
+++ b/symphony/bdk/gen/agent_model/v3_dlp_rule.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,17 +27,16 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v3_dlp_file_classifier_config import V3DLPFileClassifierConfig
-    from symphony.bdk.gen.agent_model.v3_dlp_file_extension_config import V3DLPFileExtensionConfig
-    from symphony.bdk.gen.agent_model.v3_dlp_file_password_config import V3DLPFilePasswordConfig
-    from symphony.bdk.gen.agent_model.v3_dlp_file_size_config import V3DLPFileSizeConfig
-    from symphony.bdk.gen.agent_model.v3_dlp_text_match_config import V3DLPTextMatchConfig
-    globals()['V3DLPFileClassifierConfig'] = V3DLPFileClassifierConfig
-    globals()['V3DLPFileExtensionConfig'] = V3DLPFileExtensionConfig
-    globals()['V3DLPFilePasswordConfig'] = V3DLPFilePasswordConfig
-    globals()['V3DLPFileSizeConfig'] = V3DLPFileSizeConfig
-    globals()['V3DLPTextMatchConfig'] = V3DLPTextMatchConfig
+from symphony.bdk.gen.agent_model.v3_dlp_file_classifier_config import V3DLPFileClassifierConfig
+from symphony.bdk.gen.agent_model.v3_dlp_file_extension_config import V3DLPFileExtensionConfig
+from symphony.bdk.gen.agent_model.v3_dlp_file_password_config import V3DLPFilePasswordConfig
+from symphony.bdk.gen.agent_model.v3_dlp_file_size_config import V3DLPFileSizeConfig
+from symphony.bdk.gen.agent_model.v3_dlp_text_match_config import V3DLPTextMatchConfig
+globals()['V3DLPFileClassifierConfig'] = V3DLPFileClassifierConfig
+globals()['V3DLPFileExtensionConfig'] = V3DLPFileExtensionConfig
+globals()['V3DLPFilePasswordConfig'] = V3DLPFilePasswordConfig
+globals()['V3DLPFileSizeConfig'] = V3DLPFileSizeConfig
+globals()['V3DLPTextMatchConfig'] = V3DLPTextMatchConfig
 
 
 class V3DLPRule(ModelNormal):
@@ -85,16 +83,15 @@ class V3DLPRule(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'type': (str,),  # noqa: E501
             'name': (str,),  # noqa: E501
-            'id': (str,),  # noqa: E501
-            'text_match_config': (V3DLPTextMatchConfig,),  # noqa: E501
-            'file_size_config': (V3DLPFileSizeConfig,),  # noqa: E501
-            'file_extension_config': (V3DLPFileExtensionConfig,),  # noqa: E501
-            'file_password_config': (V3DLPFilePasswordConfig,),  # noqa: E501
-            'file_classifier_config': (V3DLPFileClassifierConfig,),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
+            'text_match_config': (V3DLPTextMatchConfig, none_type),  # noqa: E501
+            'file_size_config': (V3DLPFileSizeConfig, none_type),  # noqa: E501
+            'file_extension_config': (V3DLPFileExtensionConfig, none_type),  # noqa: E501
+            'file_password_config': (V3DLPFilePasswordConfig, none_type),  # noqa: E501
+            'file_classifier_config': (V3DLPFileClassifierConfig, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -193,9 +190,14 @@ class V3DLPRule(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.type = type
-        self.name = name
+        self.type: str = type
+        self.name: str = name
+        self.id: str = None
+        self.text_match_config: V3DLPTextMatchConfig = None
+        self.file_size_config: V3DLPFileSizeConfig = None
+        self.file_extension_config: V3DLPFileExtensionConfig = None
+        self.file_password_config: V3DLPFilePasswordConfig = None
+        self.file_classifier_config: V3DLPFileClassifierConfig = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v3_dlp_text_match_config.py
+++ b/symphony/bdk/gen/agent_model/v3_dlp_text_match_config.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v3_dlp_dictionary_meta import V3DLPDictionaryMeta
-    globals()['V3DLPDictionaryMeta'] = V3DLPDictionaryMeta
+from symphony.bdk.gen.agent_model.v3_dlp_dictionary_meta import V3DLPDictionaryMeta
+globals()['V3DLPDictionaryMeta'] = V3DLPDictionaryMeta
 
 
 class V3DLPTextMatchConfig(ModelNormal):
@@ -77,11 +75,10 @@ class V3DLPTextMatchConfig(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'dictionaries': ([V3DLPDictionaryMeta],),  # noqa: E501
-            'count_unique_occurrences': (int,),  # noqa: E501
-            'applicable_file_types': ([str],),  # noqa: E501
+            'dictionaries': ([V3DLPDictionaryMeta], none_type),  # noqa: E501
+            'count_unique_occurrences': (int, none_type),  # noqa: E501
+            'applicable_file_types': ([str], none_type),  # noqa: E501
         }
 
     @cached_property
@@ -168,7 +165,9 @@ class V3DLPTextMatchConfig(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.dictionaries: List[V3DLPDictionaryMeta] = None
+        self.count_unique_occurrences: int = None
+        self.applicable_file_types: List[str] = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v3_dlp_violation.py
+++ b/symphony/bdk/gen/agent_model/v3_dlp_violation.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v1_dlp_outcome import V1DLPOutcome
-    globals()['V1DLPOutcome'] = V1DLPOutcome
+from symphony.bdk.gen.agent_model.v1_dlp_outcome import V1DLPOutcome
+globals()['V1DLPOutcome'] = V1DLPOutcome
 
 
 class V3DLPViolation(ModelNormal):
@@ -77,18 +75,17 @@ class V3DLPViolation(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'enforcement_event_id': (str,),  # noqa: E501
-            'entity_id': (str,),  # noqa: E501
-            'create_time': (int,),  # noqa: E501
-            'last_modified': (int,),  # noqa: E501
-            'requester_id': (int,),  # noqa: E501
-            'details': ([{str: (bool, date, datetime, dict, float, int, list, str, none_type)}],),  # noqa: E501
-            'action': (str,),  # noqa: E501
-            'outcome': (V1DLPOutcome,),  # noqa: E501
-            'version': (str,),  # noqa: E501
-            'ignore_dl_pwarning': (bool,),  # noqa: E501
+            'enforcement_event_id': (str, none_type),  # noqa: E501
+            'entity_id': (str, none_type),  # noqa: E501
+            'create_time': (int, none_type),  # noqa: E501
+            'last_modified': (int, none_type),  # noqa: E501
+            'requester_id': (int, none_type),  # noqa: E501
+            'details': ([{str: (bool, date, datetime, dict, float, int, list, str, none_type)}], none_type),  # noqa: E501
+            'action': (str, none_type),  # noqa: E501
+            'outcome': (V1DLPOutcome, none_type),  # noqa: E501
+            'version': (str, none_type),  # noqa: E501
+            'ignore_dl_pwarning': (bool, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -189,7 +186,16 @@ class V3DLPViolation(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.enforcement_event_id: str = None
+        self.entity_id: str = None
+        self.create_time: int = None
+        self.last_modified: int = None
+        self.requester_id: int = None
+        self.details: List[{str: (bool, date, datetime, dict, float, int, list, str, none_type)}] = None
+        self.action: str = None
+        self.outcome: V1DLPOutcome = None
+        self.version: str = None
+        self.ignore_dl_pwarning: bool = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v3_dlp_violation_message.py
+++ b/symphony/bdk/gen/agent_model/v3_dlp_violation_message.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v3_dlp_violation import V3DLPViolation
-    from symphony.bdk.gen.agent_model.v4_message import V4Message
-    globals()['V3DLPViolation'] = V3DLPViolation
-    globals()['V4Message'] = V4Message
+from symphony.bdk.gen.agent_model.v3_dlp_violation import V3DLPViolation
+from symphony.bdk.gen.agent_model.v4_message import V4Message
+globals()['V3DLPViolation'] = V3DLPViolation
+globals()['V4Message'] = V4Message
 
 
 class V3DLPViolationMessage(ModelNormal):
@@ -79,12 +77,11 @@ class V3DLPViolationMessage(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'violation': (V3DLPViolation,),  # noqa: E501
-            'message': (V4Message,),  # noqa: E501
-            'shared_message': (V4Message,),  # noqa: E501
-            'diagnostic': (str,),  # noqa: E501
+            'violation': (V3DLPViolation, none_type),  # noqa: E501
+            'message': (V4Message, none_type),  # noqa: E501
+            'shared_message': (V4Message, none_type),  # noqa: E501
+            'diagnostic': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -173,7 +170,10 @@ class V3DLPViolationMessage(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.violation: V3DLPViolation = None
+        self.message: V4Message = None
+        self.shared_message: V4Message = None
+        self.diagnostic: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v3_dlp_violation_message_response.py
+++ b/symphony/bdk/gen/agent_model/v3_dlp_violation_message_response.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v3_dlp_violation_message import V3DLPViolationMessage
-    globals()['V3DLPViolationMessage'] = V3DLPViolationMessage
+from symphony.bdk.gen.agent_model.v3_dlp_violation_message import V3DLPViolationMessage
+globals()['V3DLPViolationMessage'] = V3DLPViolationMessage
 
 
 class V3DLPViolationMessageResponse(ModelNormal):
@@ -77,10 +75,9 @@ class V3DLPViolationMessageResponse(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'violations': ([V3DLPViolationMessage],),  # noqa: E501
-            'next_offset': (str,),  # noqa: E501
+            'violations': ([V3DLPViolationMessage], none_type),  # noqa: E501
+            'next_offset': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -165,7 +162,8 @@ class V3DLPViolationMessageResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.violations: List[V3DLPViolationMessage] = None
+        self.next_offset: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v3_dlp_violation_signal.py
+++ b/symphony/bdk/gen/agent_model/v3_dlp_violation_signal.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v1_dlp_signal import V1DLPSignal
-    from symphony.bdk.gen.agent_model.v3_dlp_violation import V3DLPViolation
-    globals()['V1DLPSignal'] = V1DLPSignal
-    globals()['V3DLPViolation'] = V3DLPViolation
+from symphony.bdk.gen.agent_model.v1_dlp_signal import V1DLPSignal
+from symphony.bdk.gen.agent_model.v3_dlp_violation import V3DLPViolation
+globals()['V1DLPSignal'] = V1DLPSignal
+globals()['V3DLPViolation'] = V3DLPViolation
 
 
 class V3DLPViolationSignal(ModelNormal):
@@ -79,10 +77,9 @@ class V3DLPViolationSignal(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'violation': (V3DLPViolation,),  # noqa: E501
-            'signal': (V1DLPSignal,),  # noqa: E501
+            'violation': (V3DLPViolation, none_type),  # noqa: E501
+            'signal': (V1DLPSignal, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -167,7 +164,8 @@ class V3DLPViolationSignal(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.violation: V3DLPViolation = None
+        self.signal: V1DLPSignal = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v3_dlp_violation_signal_response.py
+++ b/symphony/bdk/gen/agent_model/v3_dlp_violation_signal_response.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v3_dlp_violation_signal import V3DLPViolationSignal
-    globals()['V3DLPViolationSignal'] = V3DLPViolationSignal
+from symphony.bdk.gen.agent_model.v3_dlp_violation_signal import V3DLPViolationSignal
+globals()['V3DLPViolationSignal'] = V3DLPViolationSignal
 
 
 class V3DLPViolationSignalResponse(ModelNormal):
@@ -77,10 +75,9 @@ class V3DLPViolationSignalResponse(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'violations': ([V3DLPViolationSignal],),  # noqa: E501
-            'next_offset': (str,),  # noqa: E501
+            'violations': ([V3DLPViolationSignal], none_type),  # noqa: E501
+            'next_offset': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -165,7 +162,8 @@ class V3DLPViolationSignalResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.violations: List[V3DLPViolationSignal] = None
+        self.next_offset: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v3_dlp_violation_stream.py
+++ b/symphony/bdk/gen/agent_model/v3_dlp_violation_stream.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v1_dlp_stream import V1DLPStream
-    from symphony.bdk.gen.agent_model.v3_dlp_violation import V3DLPViolation
-    globals()['V1DLPStream'] = V1DLPStream
-    globals()['V3DLPViolation'] = V3DLPViolation
+from symphony.bdk.gen.agent_model.v1_dlp_stream import V1DLPStream
+from symphony.bdk.gen.agent_model.v3_dlp_violation import V3DLPViolation
+globals()['V1DLPStream'] = V1DLPStream
+globals()['V3DLPViolation'] = V3DLPViolation
 
 
 class V3DLPViolationStream(ModelNormal):
@@ -79,10 +77,9 @@ class V3DLPViolationStream(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'violation': (V3DLPViolation,),  # noqa: E501
-            'stream': (V1DLPStream,),  # noqa: E501
+            'violation': (V3DLPViolation, none_type),  # noqa: E501
+            'stream': (V1DLPStream, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -167,7 +164,8 @@ class V3DLPViolationStream(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.violation: V3DLPViolation = None
+        self.stream: V1DLPStream = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v3_dlp_violation_stream_response.py
+++ b/symphony/bdk/gen/agent_model/v3_dlp_violation_stream_response.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v3_dlp_violation_stream import V3DLPViolationStream
-    globals()['V3DLPViolationStream'] = V3DLPViolationStream
+from symphony.bdk.gen.agent_model.v3_dlp_violation_stream import V3DLPViolationStream
+globals()['V3DLPViolationStream'] = V3DLPViolationStream
 
 
 class V3DLPViolationStreamResponse(ModelNormal):
@@ -77,10 +75,9 @@ class V3DLPViolationStreamResponse(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'violations': ([V3DLPViolationStream],),  # noqa: E501
-            'next_offset': (str,),  # noqa: E501
+            'violations': ([V3DLPViolationStream], none_type),  # noqa: E501
+            'next_offset': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -165,7 +162,8 @@ class V3DLPViolationStreamResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.violations: List[V3DLPViolationStream] = None
+        self.next_offset: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v3_health.py
+++ b/symphony/bdk/gen/agent_model/v3_health.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v3_health_component import V3HealthComponent
-    from symphony.bdk.gen.agent_model.v3_health_status import V3HealthStatus
-    globals()['V3HealthComponent'] = V3HealthComponent
-    globals()['V3HealthStatus'] = V3HealthStatus
+from symphony.bdk.gen.agent_model.v3_health_component import V3HealthComponent
+from symphony.bdk.gen.agent_model.v3_health_status import V3HealthStatus
+globals()['V3HealthComponent'] = V3HealthComponent
+globals()['V3HealthStatus'] = V3HealthStatus
 
 
 class V3Health(ModelNormal):
@@ -79,12 +77,11 @@ class V3Health(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'services': ({str: (V3HealthComponent,)},),  # noqa: E501
-            'status': (V3HealthStatus,),  # noqa: E501
-            'users': ({str: (V3HealthComponent,)},),  # noqa: E501
-            'version': (str,),  # noqa: E501
+            'services': ({str: (V3HealthComponent,)}, none_type),  # noqa: E501
+            'status': (V3HealthStatus, none_type),  # noqa: E501
+            'users': ({str: (V3HealthComponent,)}, none_type),  # noqa: E501
+            'version': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -173,7 +170,10 @@ class V3Health(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.services: {str: (V3HealthComponent,)} = None
+        self.status: V3HealthStatus = None
+        self.users: {str: (V3HealthComponent,)} = None
+        self.version: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v3_health_auth_type.py
+++ b/symphony/bdk/gen/agent_model/v3_health_auth_type.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -137,6 +136,8 @@ class V3HealthAuthType(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -152,7 +153,6 @@ class V3HealthAuthType(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -172,7 +172,7 @@ class V3HealthAuthType(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: str = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/agent_model/v3_health_component.py
+++ b/symphony/bdk/gen/agent_model/v3_health_component.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v3_health_auth_type import V3HealthAuthType
-    from symphony.bdk.gen.agent_model.v3_health_status import V3HealthStatus
-    globals()['V3HealthAuthType'] = V3HealthAuthType
-    globals()['V3HealthStatus'] = V3HealthStatus
+from symphony.bdk.gen.agent_model.v3_health_auth_type import V3HealthAuthType
+from symphony.bdk.gen.agent_model.v3_health_status import V3HealthStatus
+globals()['V3HealthAuthType'] = V3HealthAuthType
+globals()['V3HealthStatus'] = V3HealthStatus
 
 
 class V3HealthComponent(ModelNormal):
@@ -79,12 +77,11 @@ class V3HealthComponent(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'auth_type': (V3HealthAuthType,),  # noqa: E501
-            'message': (str,),  # noqa: E501
-            'status': (V3HealthStatus,),  # noqa: E501
-            'version': (str,),  # noqa: E501
+            'auth_type': (V3HealthAuthType, none_type),  # noqa: E501
+            'message': (str, none_type),  # noqa: E501
+            'status': (V3HealthStatus, none_type),  # noqa: E501
+            'version': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -173,7 +170,10 @@ class V3HealthComponent(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.auth_type: V3HealthAuthType = None
+        self.message: str = None
+        self.status: V3HealthStatus = None
+        self.version: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v3_health_status.py
+++ b/symphony/bdk/gen/agent_model/v3_health_status.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -137,6 +136,8 @@ class V3HealthStatus(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -152,7 +153,6 @@ class V3HealthStatus(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -172,7 +172,7 @@ class V3HealthStatus(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: str = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/agent_model/v4_attachment_info.py
+++ b/symphony/bdk/gen/agent_model/v4_attachment_info.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_thumbnail_info import V4ThumbnailInfo
-    globals()['V4ThumbnailInfo'] = V4ThumbnailInfo
+from symphony.bdk.gen.agent_model.v4_thumbnail_info import V4ThumbnailInfo
+globals()['V4ThumbnailInfo'] = V4ThumbnailInfo
 
 
 class V4AttachmentInfo(ModelNormal):
@@ -77,12 +75,11 @@ class V4AttachmentInfo(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'id': (str,),  # noqa: E501
             'name': (str,),  # noqa: E501
             'size': (int,),  # noqa: E501
-            'images': ([V4ThumbnailInfo],),  # noqa: E501
+            'images': ([V4ThumbnailInfo], none_type),  # noqa: E501
         }
 
     @cached_property
@@ -173,10 +170,10 @@ class V4AttachmentInfo(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.id = id
-        self.name = name
-        self.size = size
+        self.id: str = id
+        self.name: str = name
+        self.size: int = size
+        self.images: List[V4ThumbnailInfo] = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_connection_accepted.py
+++ b/symphony/bdk/gen/agent_model/v4_connection_accepted.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_user import V4User
-    globals()['V4User'] = V4User
+from symphony.bdk.gen.agent_model.v4_user import V4User
+globals()['V4User'] = V4User
 
 
 class V4ConnectionAccepted(ModelNormal):
@@ -77,9 +75,8 @@ class V4ConnectionAccepted(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'from_user': (V4User,),  # noqa: E501
+            'from_user': (V4User, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -162,7 +159,7 @@ class V4ConnectionAccepted(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.from_user: V4User = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_connection_requested.py
+++ b/symphony/bdk/gen/agent_model/v4_connection_requested.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_user import V4User
-    globals()['V4User'] = V4User
+from symphony.bdk.gen.agent_model.v4_user import V4User
+globals()['V4User'] = V4User
 
 
 class V4ConnectionRequested(ModelNormal):
@@ -77,9 +75,8 @@ class V4ConnectionRequested(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'to_user': (V4User,),  # noqa: E501
+            'to_user': (V4User, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -162,7 +159,7 @@ class V4ConnectionRequested(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.to_user: V4User = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_event.py
+++ b/symphony/bdk/gen/agent_model/v4_event.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_initiator import V4Initiator
-    from symphony.bdk.gen.agent_model.v4_payload import V4Payload
-    globals()['V4Initiator'] = V4Initiator
-    globals()['V4Payload'] = V4Payload
+from symphony.bdk.gen.agent_model.v4_initiator import V4Initiator
+from symphony.bdk.gen.agent_model.v4_payload import V4Payload
+globals()['V4Initiator'] = V4Initiator
+globals()['V4Payload'] = V4Payload
 
 
 class V4Event(ModelNormal):
@@ -79,15 +77,14 @@ class V4Event(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'id': (str,),  # noqa: E501
-            'message_id': (str,),  # noqa: E501
-            'timestamp': (int,),  # noqa: E501
-            'type': (str,),  # noqa: E501
-            'diagnostic': (str,),  # noqa: E501
-            'initiator': (V4Initiator,),  # noqa: E501
-            'payload': (V4Payload,),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
+            'message_id': (str, none_type),  # noqa: E501
+            'timestamp': (int, none_type),  # noqa: E501
+            'type': (str, none_type),  # noqa: E501
+            'diagnostic': (str, none_type),  # noqa: E501
+            'initiator': (V4Initiator, none_type),  # noqa: E501
+            'payload': (V4Payload, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -182,7 +179,13 @@ class V4Event(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: str = None
+        self.message_id: str = None
+        self.timestamp: int = None
+        self.type: str = None
+        self.diagnostic: str = None
+        self.initiator: V4Initiator = None
+        self.payload: V4Payload = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_event_list.py
+++ b/symphony/bdk/gen/agent_model/v4_event_list.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_event import V4Event
-    globals()['V4Event'] = V4Event
+from symphony.bdk.gen.agent_model.v4_event import V4Event
+globals()['V4Event'] = V4Event
 
 
 class V4EventList(ModelSimple):
@@ -73,7 +71,6 @@ class V4EventList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([V4Event],),
         }
@@ -138,6 +135,8 @@ class V4EventList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -153,7 +152,6 @@ class V4EventList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -173,7 +171,7 @@ class V4EventList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[V4Event] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/agent_model/v4_import_response.py
+++ b/symphony/bdk/gen/agent_model/v4_import_response.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,10 +73,10 @@ class V4ImportResponse(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'message_id': (str,),  # noqa: E501
-            'originating_system_id': (str,),  # noqa: E501
-            'original_message_id': (str,),  # noqa: E501
-            'diagnostic': (str,),  # noqa: E501
+            'message_id': (str, none_type),  # noqa: E501
+            'originating_system_id': (str, none_type),  # noqa: E501
+            'original_message_id': (str, none_type),  # noqa: E501
+            'diagnostic': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -166,7 +165,10 @@ class V4ImportResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.message_id: str = None
+        self.originating_system_id: str = None
+        self.original_message_id: str = None
+        self.diagnostic: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_import_response_list.py
+++ b/symphony/bdk/gen/agent_model/v4_import_response_list.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_import_response import V4ImportResponse
-    globals()['V4ImportResponse'] = V4ImportResponse
+from symphony.bdk.gen.agent_model.v4_import_response import V4ImportResponse
+globals()['V4ImportResponse'] = V4ImportResponse
 
 
 class V4ImportResponseList(ModelSimple):
@@ -73,7 +71,6 @@ class V4ImportResponseList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([V4ImportResponse],),
         }
@@ -138,6 +135,8 @@ class V4ImportResponseList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -153,7 +152,6 @@ class V4ImportResponseList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -173,7 +171,7 @@ class V4ImportResponseList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[V4ImportResponse] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/agent_model/v4_imported_message.py
+++ b/symphony/bdk/gen/agent_model/v4_imported_message.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -79,8 +78,8 @@ class V4ImportedMessage(ModelNormal):
             'intended_message_from_user_id': (int,),  # noqa: E501
             'originating_system_id': (str,),  # noqa: E501
             'stream_id': (str,),  # noqa: E501
-            'data': (str,),  # noqa: E501
-            'original_message_id': (str,),  # noqa: E501
+            'data': (str, none_type),  # noqa: E501
+            'original_message_id': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -177,12 +176,13 @@ class V4ImportedMessage(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.message = message
-        self.intended_message_timestamp = intended_message_timestamp
-        self.intended_message_from_user_id = intended_message_from_user_id
-        self.originating_system_id = originating_system_id
-        self.stream_id = stream_id
+        self.message: str = message
+        self.intended_message_timestamp: int = intended_message_timestamp
+        self.intended_message_from_user_id: int = intended_message_from_user_id
+        self.originating_system_id: str = originating_system_id
+        self.stream_id: str = stream_id
+        self.data: str = None
+        self.original_message_id: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_initiator.py
+++ b/symphony/bdk/gen/agent_model/v4_initiator.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_user import V4User
-    globals()['V4User'] = V4User
+from symphony.bdk.gen.agent_model.v4_user import V4User
+globals()['V4User'] = V4User
 
 
 class V4Initiator(ModelNormal):
@@ -77,9 +75,8 @@ class V4Initiator(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'user': (V4User,),  # noqa: E501
+            'user': (V4User, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -162,7 +159,7 @@ class V4Initiator(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.user: V4User = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_instant_message_created.py
+++ b/symphony/bdk/gen/agent_model/v4_instant_message_created.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_stream import V4Stream
-    globals()['V4Stream'] = V4Stream
+from symphony.bdk.gen.agent_model.v4_stream import V4Stream
+globals()['V4Stream'] = V4Stream
 
 
 class V4InstantMessageCreated(ModelNormal):
@@ -77,9 +75,8 @@ class V4InstantMessageCreated(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'stream': (V4Stream,),  # noqa: E501
+            'stream': (V4Stream, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -162,7 +159,7 @@ class V4InstantMessageCreated(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.stream: V4Stream = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_key_value_pair.py
+++ b/symphony/bdk/gen/agent_model/v4_key_value_pair.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,8 +73,8 @@ class V4KeyValuePair(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'key': (str,),  # noqa: E501
-            'value': (str,),  # noqa: E501
+            'key': (str, none_type),  # noqa: E501
+            'value': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -160,7 +159,8 @@ class V4KeyValuePair(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.key: str = None
+        self.value: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_message.py
+++ b/symphony/bdk/gen/agent_model/v4_message.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,13 +27,12 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_attachment_info import V4AttachmentInfo
-    from symphony.bdk.gen.agent_model.v4_stream import V4Stream
-    from symphony.bdk.gen.agent_model.v4_user import V4User
-    globals()['V4AttachmentInfo'] = V4AttachmentInfo
-    globals()['V4Stream'] = V4Stream
-    globals()['V4User'] = V4User
+from symphony.bdk.gen.agent_model.v4_attachment_info import V4AttachmentInfo
+from symphony.bdk.gen.agent_model.v4_stream import V4Stream
+from symphony.bdk.gen.agent_model.v4_user import V4User
+globals()['V4AttachmentInfo'] = V4AttachmentInfo
+globals()['V4Stream'] = V4Stream
+globals()['V4User'] = V4User
 
 
 class V4Message(ModelNormal):
@@ -81,22 +79,21 @@ class V4Message(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'message_id': (str,),  # noqa: E501
-            'timestamp': (int,),  # noqa: E501
-            'message': (str,),  # noqa: E501
-            'shared_message': (V4Message,),  # noqa: E501
-            'data': (str,),  # noqa: E501
-            'attachments': ([V4AttachmentInfo],),  # noqa: E501
-            'user': (V4User,),  # noqa: E501
-            'stream': (V4Stream,),  # noqa: E501
-            'external_recipients': (bool,),  # noqa: E501
-            'diagnostic': (str,),  # noqa: E501
-            'user_agent': (str,),  # noqa: E501
-            'original_format': (str,),  # noqa: E501
-            'disclaimer': (str,),  # noqa: E501
-            'sid': (str,),  # noqa: E501
+            'message_id': (str, none_type),  # noqa: E501
+            'timestamp': (int, none_type),  # noqa: E501
+            'message': (str, none_type),  # noqa: E501
+            'shared_message': (V4Message, none_type),  # noqa: E501
+            'data': (str, none_type),  # noqa: E501
+            'attachments': ([V4AttachmentInfo], none_type),  # noqa: E501
+            'user': (V4User, none_type),  # noqa: E501
+            'stream': (V4Stream, none_type),  # noqa: E501
+            'external_recipients': (bool, none_type),  # noqa: E501
+            'diagnostic': (str, none_type),  # noqa: E501
+            'user_agent': (str, none_type),  # noqa: E501
+            'original_format': (str, none_type),  # noqa: E501
+            'disclaimer': (str, none_type),  # noqa: E501
+            'sid': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -205,7 +202,20 @@ class V4Message(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.message_id: str = None
+        self.timestamp: int = None
+        self.message: str = None
+        self.shared_message: V4Message = None
+        self.data: str = None
+        self.attachments: List[V4AttachmentInfo] = None
+        self.user: V4User = None
+        self.stream: V4Stream = None
+        self.external_recipients: bool = None
+        self.diagnostic: str = None
+        self.user_agent: str = None
+        self.original_format: str = None
+        self.disclaimer: str = None
+        self.sid: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_message_blast_response.py
+++ b/symphony/bdk/gen/agent_model/v4_message_blast_response.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.error import Error
-    from symphony.bdk.gen.agent_model.v4_message import V4Message
-    globals()['Error'] = Error
-    globals()['V4Message'] = V4Message
+from symphony.bdk.gen.agent_model.error import Error
+from symphony.bdk.gen.agent_model.v4_message import V4Message
+globals()['Error'] = Error
+globals()['V4Message'] = V4Message
 
 
 class V4MessageBlastResponse(ModelNormal):
@@ -79,10 +77,9 @@ class V4MessageBlastResponse(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'messages': ([V4Message],),  # noqa: E501
-            'errors': ({str: (Error,)},),  # noqa: E501
+            'messages': ([V4Message], none_type),  # noqa: E501
+            'errors': ({str: (Error,)}, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -167,7 +164,8 @@ class V4MessageBlastResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.messages: List[V4Message] = None
+        self.errors: {str: (Error,)} = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_message_import_list.py
+++ b/symphony/bdk/gen/agent_model/v4_message_import_list.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_imported_message import V4ImportedMessage
-    globals()['V4ImportedMessage'] = V4ImportedMessage
+from symphony.bdk.gen.agent_model.v4_imported_message import V4ImportedMessage
+globals()['V4ImportedMessage'] = V4ImportedMessage
 
 
 class V4MessageImportList(ModelSimple):
@@ -73,7 +71,6 @@ class V4MessageImportList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([V4ImportedMessage],),
         }
@@ -138,6 +135,8 @@ class V4MessageImportList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -153,7 +152,6 @@ class V4MessageImportList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -173,7 +171,7 @@ class V4MessageImportList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[V4ImportedMessage] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/agent_model/v4_message_list.py
+++ b/symphony/bdk/gen/agent_model/v4_message_list.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_message import V4Message
-    globals()['V4Message'] = V4Message
+from symphony.bdk.gen.agent_model.v4_message import V4Message
+globals()['V4Message'] = V4Message
 
 
 class V4MessageList(ModelSimple):
@@ -73,7 +71,6 @@ class V4MessageList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([V4Message],),
         }
@@ -138,6 +135,8 @@ class V4MessageList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -153,7 +152,6 @@ class V4MessageList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -173,7 +171,7 @@ class V4MessageList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[V4Message] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/agent_model/v4_message_sent.py
+++ b/symphony/bdk/gen/agent_model/v4_message_sent.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_message import V4Message
-    globals()['V4Message'] = V4Message
+from symphony.bdk.gen.agent_model.v4_message import V4Message
+globals()['V4Message'] = V4Message
 
 
 class V4MessageSent(ModelNormal):
@@ -77,9 +75,8 @@ class V4MessageSent(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'message': (V4Message,),  # noqa: E501
+            'message': (V4Message, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -162,7 +159,7 @@ class V4MessageSent(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.message: V4Message = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_message_suppressed.py
+++ b/symphony/bdk/gen/agent_model/v4_message_suppressed.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_stream import V4Stream
-    globals()['V4Stream'] = V4Stream
+from symphony.bdk.gen.agent_model.v4_stream import V4Stream
+globals()['V4Stream'] = V4Stream
 
 
 class V4MessageSuppressed(ModelNormal):
@@ -77,10 +75,9 @@ class V4MessageSuppressed(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'message_id': (str,),  # noqa: E501
-            'stream': (V4Stream,),  # noqa: E501
+            'message_id': (str, none_type),  # noqa: E501
+            'stream': (V4Stream, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -165,7 +162,8 @@ class V4MessageSuppressed(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.message_id: str = None
+        self.stream: V4Stream = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_payload.py
+++ b/symphony/bdk/gen/agent_model/v4_payload.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,39 +27,38 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_connection_accepted import V4ConnectionAccepted
-    from symphony.bdk.gen.agent_model.v4_connection_requested import V4ConnectionRequested
-    from symphony.bdk.gen.agent_model.v4_instant_message_created import V4InstantMessageCreated
-    from symphony.bdk.gen.agent_model.v4_message_sent import V4MessageSent
-    from symphony.bdk.gen.agent_model.v4_message_suppressed import V4MessageSuppressed
-    from symphony.bdk.gen.agent_model.v4_room_created import V4RoomCreated
-    from symphony.bdk.gen.agent_model.v4_room_deactivated import V4RoomDeactivated
-    from symphony.bdk.gen.agent_model.v4_room_member_demoted_from_owner import V4RoomMemberDemotedFromOwner
-    from symphony.bdk.gen.agent_model.v4_room_member_promoted_to_owner import V4RoomMemberPromotedToOwner
-    from symphony.bdk.gen.agent_model.v4_room_reactivated import V4RoomReactivated
-    from symphony.bdk.gen.agent_model.v4_room_updated import V4RoomUpdated
-    from symphony.bdk.gen.agent_model.v4_shared_post import V4SharedPost
-    from symphony.bdk.gen.agent_model.v4_symphony_elements_action import V4SymphonyElementsAction
-    from symphony.bdk.gen.agent_model.v4_user_joined_room import V4UserJoinedRoom
-    from symphony.bdk.gen.agent_model.v4_user_left_room import V4UserLeftRoom
-    from symphony.bdk.gen.agent_model.v4_user_requested_to_join_room import V4UserRequestedToJoinRoom
-    globals()['V4ConnectionAccepted'] = V4ConnectionAccepted
-    globals()['V4ConnectionRequested'] = V4ConnectionRequested
-    globals()['V4InstantMessageCreated'] = V4InstantMessageCreated
-    globals()['V4MessageSent'] = V4MessageSent
-    globals()['V4MessageSuppressed'] = V4MessageSuppressed
-    globals()['V4RoomCreated'] = V4RoomCreated
-    globals()['V4RoomDeactivated'] = V4RoomDeactivated
-    globals()['V4RoomMemberDemotedFromOwner'] = V4RoomMemberDemotedFromOwner
-    globals()['V4RoomMemberPromotedToOwner'] = V4RoomMemberPromotedToOwner
-    globals()['V4RoomReactivated'] = V4RoomReactivated
-    globals()['V4RoomUpdated'] = V4RoomUpdated
-    globals()['V4SharedPost'] = V4SharedPost
-    globals()['V4SymphonyElementsAction'] = V4SymphonyElementsAction
-    globals()['V4UserJoinedRoom'] = V4UserJoinedRoom
-    globals()['V4UserLeftRoom'] = V4UserLeftRoom
-    globals()['V4UserRequestedToJoinRoom'] = V4UserRequestedToJoinRoom
+from symphony.bdk.gen.agent_model.v4_connection_accepted import V4ConnectionAccepted
+from symphony.bdk.gen.agent_model.v4_connection_requested import V4ConnectionRequested
+from symphony.bdk.gen.agent_model.v4_instant_message_created import V4InstantMessageCreated
+from symphony.bdk.gen.agent_model.v4_message_sent import V4MessageSent
+from symphony.bdk.gen.agent_model.v4_message_suppressed import V4MessageSuppressed
+from symphony.bdk.gen.agent_model.v4_room_created import V4RoomCreated
+from symphony.bdk.gen.agent_model.v4_room_deactivated import V4RoomDeactivated
+from symphony.bdk.gen.agent_model.v4_room_member_demoted_from_owner import V4RoomMemberDemotedFromOwner
+from symphony.bdk.gen.agent_model.v4_room_member_promoted_to_owner import V4RoomMemberPromotedToOwner
+from symphony.bdk.gen.agent_model.v4_room_reactivated import V4RoomReactivated
+from symphony.bdk.gen.agent_model.v4_room_updated import V4RoomUpdated
+from symphony.bdk.gen.agent_model.v4_shared_post import V4SharedPost
+from symphony.bdk.gen.agent_model.v4_symphony_elements_action import V4SymphonyElementsAction
+from symphony.bdk.gen.agent_model.v4_user_joined_room import V4UserJoinedRoom
+from symphony.bdk.gen.agent_model.v4_user_left_room import V4UserLeftRoom
+from symphony.bdk.gen.agent_model.v4_user_requested_to_join_room import V4UserRequestedToJoinRoom
+globals()['V4ConnectionAccepted'] = V4ConnectionAccepted
+globals()['V4ConnectionRequested'] = V4ConnectionRequested
+globals()['V4InstantMessageCreated'] = V4InstantMessageCreated
+globals()['V4MessageSent'] = V4MessageSent
+globals()['V4MessageSuppressed'] = V4MessageSuppressed
+globals()['V4RoomCreated'] = V4RoomCreated
+globals()['V4RoomDeactivated'] = V4RoomDeactivated
+globals()['V4RoomMemberDemotedFromOwner'] = V4RoomMemberDemotedFromOwner
+globals()['V4RoomMemberPromotedToOwner'] = V4RoomMemberPromotedToOwner
+globals()['V4RoomReactivated'] = V4RoomReactivated
+globals()['V4RoomUpdated'] = V4RoomUpdated
+globals()['V4SharedPost'] = V4SharedPost
+globals()['V4SymphonyElementsAction'] = V4SymphonyElementsAction
+globals()['V4UserJoinedRoom'] = V4UserJoinedRoom
+globals()['V4UserLeftRoom'] = V4UserLeftRoom
+globals()['V4UserRequestedToJoinRoom'] = V4UserRequestedToJoinRoom
 
 
 class V4Payload(ModelNormal):
@@ -107,24 +105,23 @@ class V4Payload(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'message_sent': (V4MessageSent,),  # noqa: E501
-            'shared_post': (V4SharedPost,),  # noqa: E501
-            'instant_message_created': (V4InstantMessageCreated,),  # noqa: E501
-            'room_created': (V4RoomCreated,),  # noqa: E501
-            'room_updated': (V4RoomUpdated,),  # noqa: E501
-            'room_deactivated': (V4RoomDeactivated,),  # noqa: E501
-            'room_reactivated': (V4RoomReactivated,),  # noqa: E501
-            'user_joined_room': (V4UserJoinedRoom,),  # noqa: E501
-            'user_left_room': (V4UserLeftRoom,),  # noqa: E501
-            'room_member_promoted_to_owner': (V4RoomMemberPromotedToOwner,),  # noqa: E501
-            'room_member_demoted_from_owner': (V4RoomMemberDemotedFromOwner,),  # noqa: E501
-            'connection_requested': (V4ConnectionRequested,),  # noqa: E501
-            'connection_accepted': (V4ConnectionAccepted,),  # noqa: E501
-            'message_suppressed': (V4MessageSuppressed,),  # noqa: E501
-            'symphony_elements_action': (V4SymphonyElementsAction,),  # noqa: E501
-            'user_requested_to_join_room': (V4UserRequestedToJoinRoom,),  # noqa: E501
+            'message_sent': (V4MessageSent, none_type),  # noqa: E501
+            'shared_post': (V4SharedPost, none_type),  # noqa: E501
+            'instant_message_created': (V4InstantMessageCreated, none_type),  # noqa: E501
+            'room_created': (V4RoomCreated, none_type),  # noqa: E501
+            'room_updated': (V4RoomUpdated, none_type),  # noqa: E501
+            'room_deactivated': (V4RoomDeactivated, none_type),  # noqa: E501
+            'room_reactivated': (V4RoomReactivated, none_type),  # noqa: E501
+            'user_joined_room': (V4UserJoinedRoom, none_type),  # noqa: E501
+            'user_left_room': (V4UserLeftRoom, none_type),  # noqa: E501
+            'room_member_promoted_to_owner': (V4RoomMemberPromotedToOwner, none_type),  # noqa: E501
+            'room_member_demoted_from_owner': (V4RoomMemberDemotedFromOwner, none_type),  # noqa: E501
+            'connection_requested': (V4ConnectionRequested, none_type),  # noqa: E501
+            'connection_accepted': (V4ConnectionAccepted, none_type),  # noqa: E501
+            'message_suppressed': (V4MessageSuppressed, none_type),  # noqa: E501
+            'symphony_elements_action': (V4SymphonyElementsAction, none_type),  # noqa: E501
+            'user_requested_to_join_room': (V4UserRequestedToJoinRoom, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -237,7 +234,22 @@ class V4Payload(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.message_sent: V4MessageSent = None
+        self.shared_post: V4SharedPost = None
+        self.instant_message_created: V4InstantMessageCreated = None
+        self.room_created: V4RoomCreated = None
+        self.room_updated: V4RoomUpdated = None
+        self.room_deactivated: V4RoomDeactivated = None
+        self.room_reactivated: V4RoomReactivated = None
+        self.user_joined_room: V4UserJoinedRoom = None
+        self.user_left_room: V4UserLeftRoom = None
+        self.room_member_promoted_to_owner: V4RoomMemberPromotedToOwner = None
+        self.room_member_demoted_from_owner: V4RoomMemberDemotedFromOwner = None
+        self.connection_requested: V4ConnectionRequested = None
+        self.connection_accepted: V4ConnectionAccepted = None
+        self.message_suppressed: V4MessageSuppressed = None
+        self.symphony_elements_action: V4SymphonyElementsAction = None
+        self.user_requested_to_join_room: V4UserRequestedToJoinRoom = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_room_created.py
+++ b/symphony/bdk/gen/agent_model/v4_room_created.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_room_properties import V4RoomProperties
-    from symphony.bdk.gen.agent_model.v4_stream import V4Stream
-    globals()['V4RoomProperties'] = V4RoomProperties
-    globals()['V4Stream'] = V4Stream
+from symphony.bdk.gen.agent_model.v4_room_properties import V4RoomProperties
+from symphony.bdk.gen.agent_model.v4_stream import V4Stream
+globals()['V4RoomProperties'] = V4RoomProperties
+globals()['V4Stream'] = V4Stream
 
 
 class V4RoomCreated(ModelNormal):
@@ -79,10 +77,9 @@ class V4RoomCreated(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'stream': (V4Stream,),  # noqa: E501
-            'room_properties': (V4RoomProperties,),  # noqa: E501
+            'stream': (V4Stream, none_type),  # noqa: E501
+            'room_properties': (V4RoomProperties, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -167,7 +164,8 @@ class V4RoomCreated(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.stream: V4Stream = None
+        self.room_properties: V4RoomProperties = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_room_deactivated.py
+++ b/symphony/bdk/gen/agent_model/v4_room_deactivated.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_stream import V4Stream
-    globals()['V4Stream'] = V4Stream
+from symphony.bdk.gen.agent_model.v4_stream import V4Stream
+globals()['V4Stream'] = V4Stream
 
 
 class V4RoomDeactivated(ModelNormal):
@@ -77,9 +75,8 @@ class V4RoomDeactivated(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'stream': (V4Stream,),  # noqa: E501
+            'stream': (V4Stream, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -162,7 +159,7 @@ class V4RoomDeactivated(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.stream: V4Stream = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_room_member_demoted_from_owner.py
+++ b/symphony/bdk/gen/agent_model/v4_room_member_demoted_from_owner.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_stream import V4Stream
-    from symphony.bdk.gen.agent_model.v4_user import V4User
-    globals()['V4Stream'] = V4Stream
-    globals()['V4User'] = V4User
+from symphony.bdk.gen.agent_model.v4_stream import V4Stream
+from symphony.bdk.gen.agent_model.v4_user import V4User
+globals()['V4Stream'] = V4Stream
+globals()['V4User'] = V4User
 
 
 class V4RoomMemberDemotedFromOwner(ModelNormal):
@@ -79,10 +77,9 @@ class V4RoomMemberDemotedFromOwner(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'stream': (V4Stream,),  # noqa: E501
-            'affected_user': (V4User,),  # noqa: E501
+            'stream': (V4Stream, none_type),  # noqa: E501
+            'affected_user': (V4User, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -167,7 +164,8 @@ class V4RoomMemberDemotedFromOwner(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.stream: V4Stream = None
+        self.affected_user: V4User = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_room_member_promoted_to_owner.py
+++ b/symphony/bdk/gen/agent_model/v4_room_member_promoted_to_owner.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_stream import V4Stream
-    from symphony.bdk.gen.agent_model.v4_user import V4User
-    globals()['V4Stream'] = V4Stream
-    globals()['V4User'] = V4User
+from symphony.bdk.gen.agent_model.v4_stream import V4Stream
+from symphony.bdk.gen.agent_model.v4_user import V4User
+globals()['V4Stream'] = V4Stream
+globals()['V4User'] = V4User
 
 
 class V4RoomMemberPromotedToOwner(ModelNormal):
@@ -79,10 +77,9 @@ class V4RoomMemberPromotedToOwner(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'stream': (V4Stream,),  # noqa: E501
-            'affected_user': (V4User,),  # noqa: E501
+            'stream': (V4Stream, none_type),  # noqa: E501
+            'affected_user': (V4User, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -167,7 +164,8 @@ class V4RoomMemberPromotedToOwner(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.stream: V4Stream = None
+        self.affected_user: V4User = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_room_properties.py
+++ b/symphony/bdk/gen/agent_model/v4_room_properties.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_key_value_pair import V4KeyValuePair
-    from symphony.bdk.gen.agent_model.v4_user import V4User
-    globals()['V4KeyValuePair'] = V4KeyValuePair
-    globals()['V4User'] = V4User
+from symphony.bdk.gen.agent_model.v4_key_value_pair import V4KeyValuePair
+from symphony.bdk.gen.agent_model.v4_user import V4User
+globals()['V4KeyValuePair'] = V4KeyValuePair
+globals()['V4User'] = V4User
 
 
 class V4RoomProperties(ModelNormal):
@@ -79,21 +77,20 @@ class V4RoomProperties(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'name': (str,),  # noqa: E501
-            'description': (str,),  # noqa: E501
-            'creator_user': (V4User,),  # noqa: E501
-            'created_date': (int,),  # noqa: E501
-            'external': (bool,),  # noqa: E501
-            'cross_pod': (bool,),  # noqa: E501
-            'public': (bool,),  # noqa: E501
-            'copy_protected': (bool,),  # noqa: E501
-            'read_only': (bool,),  # noqa: E501
-            'discoverable': (bool,),  # noqa: E501
-            'members_can_invite': (bool,),  # noqa: E501
-            'keywords': ([V4KeyValuePair],),  # noqa: E501
-            'can_view_history': (bool,),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
+            'description': (str, none_type),  # noqa: E501
+            'creator_user': (V4User, none_type),  # noqa: E501
+            'created_date': (int, none_type),  # noqa: E501
+            'external': (bool, none_type),  # noqa: E501
+            'cross_pod': (bool, none_type),  # noqa: E501
+            'public': (bool, none_type),  # noqa: E501
+            'copy_protected': (bool, none_type),  # noqa: E501
+            'read_only': (bool, none_type),  # noqa: E501
+            'discoverable': (bool, none_type),  # noqa: E501
+            'members_can_invite': (bool, none_type),  # noqa: E501
+            'keywords': ([V4KeyValuePair], none_type),  # noqa: E501
+            'can_view_history': (bool, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -200,7 +197,19 @@ class V4RoomProperties(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.name: str = None
+        self.description: str = None
+        self.creator_user: V4User = None
+        self.created_date: int = None
+        self.external: bool = None
+        self.cross_pod: bool = None
+        self.public: bool = None
+        self.copy_protected: bool = None
+        self.read_only: bool = None
+        self.discoverable: bool = None
+        self.members_can_invite: bool = None
+        self.keywords: List[V4KeyValuePair] = None
+        self.can_view_history: bool = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_room_reactivated.py
+++ b/symphony/bdk/gen/agent_model/v4_room_reactivated.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_stream import V4Stream
-    globals()['V4Stream'] = V4Stream
+from symphony.bdk.gen.agent_model.v4_stream import V4Stream
+globals()['V4Stream'] = V4Stream
 
 
 class V4RoomReactivated(ModelNormal):
@@ -77,9 +75,8 @@ class V4RoomReactivated(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'stream': (V4Stream,),  # noqa: E501
+            'stream': (V4Stream, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -162,7 +159,7 @@ class V4RoomReactivated(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.stream: V4Stream = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_room_updated.py
+++ b/symphony/bdk/gen/agent_model/v4_room_updated.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_room_properties import V4RoomProperties
-    from symphony.bdk.gen.agent_model.v4_stream import V4Stream
-    globals()['V4RoomProperties'] = V4RoomProperties
-    globals()['V4Stream'] = V4Stream
+from symphony.bdk.gen.agent_model.v4_room_properties import V4RoomProperties
+from symphony.bdk.gen.agent_model.v4_stream import V4Stream
+globals()['V4RoomProperties'] = V4RoomProperties
+globals()['V4Stream'] = V4Stream
 
 
 class V4RoomUpdated(ModelNormal):
@@ -79,10 +77,9 @@ class V4RoomUpdated(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'stream': (V4Stream,),  # noqa: E501
-            'new_room_properties': (V4RoomProperties,),  # noqa: E501
+            'stream': (V4Stream, none_type),  # noqa: E501
+            'new_room_properties': (V4RoomProperties, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -167,7 +164,8 @@ class V4RoomUpdated(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.stream: V4Stream = None
+        self.new_room_properties: V4RoomProperties = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_shared_post.py
+++ b/symphony/bdk/gen/agent_model/v4_shared_post.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_message import V4Message
-    globals()['V4Message'] = V4Message
+from symphony.bdk.gen.agent_model.v4_message import V4Message
+globals()['V4Message'] = V4Message
 
 
 class V4SharedPost(ModelNormal):
@@ -77,10 +75,9 @@ class V4SharedPost(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'message': (V4Message,),  # noqa: E501
-            'shared_message': (V4Message,),  # noqa: E501
+            'message': (V4Message, none_type),  # noqa: E501
+            'shared_message': (V4Message, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -165,7 +162,8 @@ class V4SharedPost(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.message: V4Message = None
+        self.shared_message: V4Message = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_stream.py
+++ b/symphony/bdk/gen/agent_model/v4_stream.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_user import V4User
-    globals()['V4User'] = V4User
+from symphony.bdk.gen.agent_model.v4_user import V4User
+globals()['V4User'] = V4User
 
 
 class V4Stream(ModelNormal):
@@ -77,14 +75,13 @@ class V4Stream(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'stream_id': (str,),  # noqa: E501
-            'stream_type': (str,),  # noqa: E501
-            'room_name': (str,),  # noqa: E501
-            'members': ([V4User],),  # noqa: E501
-            'external': (bool,),  # noqa: E501
-            'cross_pod': (bool,),  # noqa: E501
+            'stream_id': (str, none_type),  # noqa: E501
+            'stream_type': (str, none_type),  # noqa: E501
+            'room_name': (str, none_type),  # noqa: E501
+            'members': ([V4User], none_type),  # noqa: E501
+            'external': (bool, none_type),  # noqa: E501
+            'cross_pod': (bool, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -177,7 +174,12 @@ class V4Stream(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.stream_id: str = None
+        self.stream_type: str = None
+        self.room_name: str = None
+        self.members: List[V4User] = None
+        self.external: bool = None
+        self.cross_pod: bool = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_symphony_elements_action.py
+++ b/symphony/bdk/gen/agent_model/v4_symphony_elements_action.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_stream import V4Stream
-    globals()['V4Stream'] = V4Stream
+from symphony.bdk.gen.agent_model.v4_stream import V4Stream
+globals()['V4Stream'] = V4Stream
 
 
 class V4SymphonyElementsAction(ModelNormal):
@@ -77,12 +75,11 @@ class V4SymphonyElementsAction(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'stream': (V4Stream,),  # noqa: E501
-            'form_message_id': (str,),  # noqa: E501
-            'form_id': (str,),  # noqa: E501
-            'form_values': ({str: (bool, date, datetime, dict, float, int, list, str, none_type)},),  # noqa: E501
+            'stream': (V4Stream, none_type),  # noqa: E501
+            'form_message_id': (str, none_type),  # noqa: E501
+            'form_id': (str, none_type),  # noqa: E501
+            'form_values': ({str: (bool, date, datetime, dict, float, int, list, str, none_type)}, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -171,7 +168,10 @@ class V4SymphonyElementsAction(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.stream: V4Stream = None
+        self.form_message_id: str = None
+        self.form_id: str = None
+        self.form_values: {str: (bool, date, datetime, dict, float, int, list, str, none_type)} = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_thumbnail_info.py
+++ b/symphony/bdk/gen/agent_model/v4_thumbnail_info.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,8 +73,8 @@ class V4ThumbnailInfo(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'id': (str,),  # noqa: E501
-            'dimension': (str,),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
+            'dimension': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -160,7 +159,8 @@ class V4ThumbnailInfo(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: str = None
+        self.dimension: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_user.py
+++ b/symphony/bdk/gen/agent_model/v4_user.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,12 +73,12 @@ class V4User(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'user_id': (int,),  # noqa: E501
-            'first_name': (str,),  # noqa: E501
-            'last_name': (str,),  # noqa: E501
-            'display_name': (str,),  # noqa: E501
-            'email': (str,),  # noqa: E501
-            'username': (str,),  # noqa: E501
+            'user_id': (int, none_type),  # noqa: E501
+            'first_name': (str, none_type),  # noqa: E501
+            'last_name': (str, none_type),  # noqa: E501
+            'display_name': (str, none_type),  # noqa: E501
+            'email': (str, none_type),  # noqa: E501
+            'username': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -172,7 +171,12 @@ class V4User(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.user_id: int = None
+        self.first_name: str = None
+        self.last_name: str = None
+        self.display_name: str = None
+        self.email: str = None
+        self.username: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_user_joined_room.py
+++ b/symphony/bdk/gen/agent_model/v4_user_joined_room.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_stream import V4Stream
-    from symphony.bdk.gen.agent_model.v4_user import V4User
-    globals()['V4Stream'] = V4Stream
-    globals()['V4User'] = V4User
+from symphony.bdk.gen.agent_model.v4_stream import V4Stream
+from symphony.bdk.gen.agent_model.v4_user import V4User
+globals()['V4Stream'] = V4Stream
+globals()['V4User'] = V4User
 
 
 class V4UserJoinedRoom(ModelNormal):
@@ -79,10 +77,9 @@ class V4UserJoinedRoom(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'stream': (V4Stream,),  # noqa: E501
-            'affected_user': (V4User,),  # noqa: E501
+            'stream': (V4Stream, none_type),  # noqa: E501
+            'affected_user': (V4User, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -167,7 +164,8 @@ class V4UserJoinedRoom(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.stream: V4Stream = None
+        self.affected_user: V4User = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_user_left_room.py
+++ b/symphony/bdk/gen/agent_model/v4_user_left_room.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_stream import V4Stream
-    from symphony.bdk.gen.agent_model.v4_user import V4User
-    globals()['V4Stream'] = V4Stream
-    globals()['V4User'] = V4User
+from symphony.bdk.gen.agent_model.v4_stream import V4Stream
+from symphony.bdk.gen.agent_model.v4_user import V4User
+globals()['V4Stream'] = V4Stream
+globals()['V4User'] = V4User
 
 
 class V4UserLeftRoom(ModelNormal):
@@ -79,10 +77,9 @@ class V4UserLeftRoom(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'stream': (V4Stream,),  # noqa: E501
-            'affected_user': (V4User,),  # noqa: E501
+            'stream': (V4Stream, none_type),  # noqa: E501
+            'affected_user': (V4User, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -167,7 +164,8 @@ class V4UserLeftRoom(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.stream: V4Stream = None
+        self.affected_user: V4User = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v4_user_requested_to_join_room.py
+++ b/symphony/bdk/gen/agent_model/v4_user_requested_to_join_room.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_stream import V4Stream
-    from symphony.bdk.gen.agent_model.v4_user import V4User
-    globals()['V4Stream'] = V4Stream
-    globals()['V4User'] = V4User
+from symphony.bdk.gen.agent_model.v4_stream import V4Stream
+from symphony.bdk.gen.agent_model.v4_user import V4User
+globals()['V4Stream'] = V4Stream
+globals()['V4User'] = V4User
 
 
 class V4UserRequestedToJoinRoom(ModelNormal):
@@ -79,10 +77,9 @@ class V4UserRequestedToJoinRoom(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'stream': (V4Stream,),  # noqa: E501
-            'affected_users': ([V4User],),  # noqa: E501
+            'stream': (V4Stream, none_type),  # noqa: E501
+            'affected_users': ([V4User], none_type),  # noqa: E501
         }
 
     @cached_property
@@ -167,7 +164,8 @@ class V4UserRequestedToJoinRoom(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.stream: V4Stream = None
+        self.affected_users: List[V4User] = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v5_datafeed.py
+++ b/symphony/bdk/gen/agent_model/v5_datafeed.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,8 +73,8 @@ class V5Datafeed(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'id': (str,),  # noqa: E501
-            'created_at': (int,),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
+            'created_at': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -160,7 +159,8 @@ class V5Datafeed(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: str = None
+        self.created_at: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/agent_model/v5_event_list.py
+++ b/symphony/bdk/gen/agent_model/v5_event_list.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -28,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.agent_model.v4_event import V4Event
-    globals()['V4Event'] = V4Event
+from symphony.bdk.gen.agent_model.v4_event import V4Event
+globals()['V4Event'] = V4Event
 
 
 class V5EventList(ModelNormal):
@@ -77,10 +75,9 @@ class V5EventList(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'events': ([V4Event],),  # noqa: E501
-            'ack_id': (str,),  # noqa: E501
+            'events': ([V4Event], none_type),  # noqa: E501
+            'ack_id': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -165,7 +162,8 @@ class V5EventList(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.events: List[V4Event] = None
+        self.ack_id: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/auth_api/certificate_authentication_api.py
+++ b/symphony/bdk/gen/auth_api/certificate_authentication_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -101,7 +101,7 @@ class CertificateAuthenticationApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             return self.call_with_http_info(**kwargs)
 
-        self.v1_app_authenticate_post = Endpoint(
+        self.v1_app_authenticate_post = _Endpoint(
             settings={
                 'response_type': (Token,),
                 'auth': [],
@@ -214,7 +214,7 @@ class CertificateAuthenticationApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_app_user_uid_authenticate_post = Endpoint(
+        self.v1_app_user_uid_authenticate_post = _Endpoint(
             settings={
                 'response_type': (OboAuthResponse,),
                 'auth': [],
@@ -269,6 +269,132 @@ class CertificateAuthenticationApi(object):
             },
             api_client=api_client,
             callable=__v1_app_user_uid_authenticate_post
+        )
+
+        def __v1_app_username_username_authenticate_post(
+            self,
+            username,
+            session_token,
+            **kwargs
+        ):
+            """PROVISIONAL - Authenicate an application in a delegated context to act on behalf of a user  # noqa: E501
+
+            This method makes a synchronous HTTP request by default. To make an
+            asynchronous HTTP request, please pass async_req=True
+
+            >>> thread = auth_api.v1_app_username_username_authenticate_post(username, session_token, async_req=True)
+            >>> result = thread.get()
+
+            Args:
+                username (str): username
+                session_token (str): Authorization token obtains from app/authenicate API
+
+            Keyword Args:
+                _return_http_data_only (bool): response data without head status
+                    code and headers. Default is True.
+                _preload_content (bool): if False, the urllib3.HTTPResponse object
+                    will be returned without reading/decoding response data.
+                    Default is True.
+                _request_timeout (float/tuple): timeout setting for this request. If one
+                    number provided, it will be total request timeout. It can also
+                    be a pair (tuple) of (connection, read) timeouts.
+                    Default is None.
+                _check_input_type (bool): specifies if type checking
+                    should be done one the data sent to the server.
+                    Default is True.
+                _check_return_type (bool): specifies if type checking
+                    should be done one the data received from the server.
+                    Default is True.
+                _host_index (int/None): specifies the index of the server
+                    that we want to use.
+                    Default is read from the configuration.
+                async_req (bool): execute request asynchronously
+
+            Returns:
+                OboAuthResponse
+                    If the method is called asynchronously, returns the request
+                    thread.
+            """
+            kwargs['async_req'] = kwargs.get(
+                'async_req', False
+            )
+            kwargs['_return_http_data_only'] = kwargs.get(
+                '_return_http_data_only', True
+            )
+            kwargs['_preload_content'] = kwargs.get(
+                '_preload_content', True
+            )
+            kwargs['_request_timeout'] = kwargs.get(
+                '_request_timeout', None
+            )
+            kwargs['_check_input_type'] = kwargs.get(
+                '_check_input_type', True
+            )
+            kwargs['_check_return_type'] = kwargs.get(
+                '_check_return_type', True
+            )
+            kwargs['_host_index'] = kwargs.get('_host_index')
+            kwargs['username'] = \
+                username
+            kwargs['session_token'] = \
+                session_token
+            return self.call_with_http_info(**kwargs)
+
+        self.v1_app_username_username_authenticate_post = _Endpoint(
+            settings={
+                'response_type': (OboAuthResponse,),
+                'auth': [],
+                'endpoint_path': '/v1/app/username/{username}/authenticate',
+                'operation_id': 'v1_app_username_username_authenticate_post',
+                'http_method': 'POST',
+                'servers': None,
+            },
+            params_map={
+                'all': [
+                    'username',
+                    'session_token',
+                ],
+                'required': [
+                    'username',
+                    'session_token',
+                ],
+                'nullable': [
+                ],
+                'enum': [
+                ],
+                'validation': [
+                ]
+            },
+            root_map={
+                'validations': {
+                },
+                'allowed_values': {
+                },
+                'openapi_types': {
+                    'username':
+                        (str,),
+                    'session_token':
+                        (str,),
+                },
+                'attribute_map': {
+                    'username': 'username',
+                    'session_token': 'sessionToken',
+                },
+                'location_map': {
+                    'username': 'path',
+                    'session_token': 'header',
+                },
+                'collection_format_map': {
+                }
+            },
+            headers_map={
+                'accept': [
+                    'application/json'
+                ],
+                'content_type': [],
+            },
+            api_client=api_client,
+            callable=__v1_app_username_username_authenticate_post
         )
 
         def __v1_authenticate_extension_app_post(
@@ -337,7 +463,7 @@ class CertificateAuthenticationApi(object):
                 auth_request
             return self.call_with_http_info(**kwargs)
 
-        self.v1_authenticate_extension_app_post = Endpoint(
+        self.v1_authenticate_extension_app_post = _Endpoint(
             settings={
                 'response_type': (ExtensionAppTokens,),
                 'auth': [],
@@ -450,7 +576,7 @@ class CertificateAuthenticationApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             return self.call_with_http_info(**kwargs)
 
-        self.v1_authenticate_post = Endpoint(
+        self.v1_authenticate_post = _Endpoint(
             settings={
                 'response_type': (Token,),
                 'auth': [],
@@ -560,7 +686,7 @@ class CertificateAuthenticationApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_logout_post = Endpoint(
+        self.v1_logout_post = _Endpoint(
             settings={
                 'response_type': (Token,),
                 'auth': [],

--- a/symphony/bdk/gen/auth_api/certificate_pod_api.py
+++ b/symphony/bdk/gen/auth_api/certificate_pod_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -97,7 +97,7 @@ class CertificatePodApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             return self.call_with_http_info(**kwargs)
 
-        self.v1_app_pod_certificate_get = Endpoint(
+        self.v1_app_pod_certificate_get = _Endpoint(
             settings={
                 'response_type': (PodCertificate,),
                 'auth': [],

--- a/symphony/bdk/gen/auth_model/error.py
+++ b/symphony/bdk/gen/auth_model/error.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,8 +73,8 @@ class Error(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'code': (int,),  # noqa: E501
-            'message': (str,),  # noqa: E501
+            'code': (int, none_type),  # noqa: E501
+            'message': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -160,7 +159,8 @@ class Error(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.code: int = None
+        self.message: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/auth_model/extension_app_authenticate_request.py
+++ b/symphony/bdk/gen/auth_model/extension_app_authenticate_request.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,7 +73,7 @@ class ExtensionAppAuthenticateRequest(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'app_token': (str,),  # noqa: E501
+            'app_token': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -157,7 +156,7 @@ class ExtensionAppAuthenticateRequest(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.app_token: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/auth_model/extension_app_tokens.py
+++ b/symphony/bdk/gen/auth_model/extension_app_tokens.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,10 +73,10 @@ class ExtensionAppTokens(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'app_id': (str,),  # noqa: E501
-            'app_token': (str,),  # noqa: E501
-            'symphony_token': (str,),  # noqa: E501
-            'expire_at': (int,),  # noqa: E501
+            'app_id': (str, none_type),  # noqa: E501
+            'app_token': (str, none_type),  # noqa: E501
+            'symphony_token': (str, none_type),  # noqa: E501
+            'expire_at': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -166,7 +165,10 @@ class ExtensionAppTokens(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.app_id: str = None
+        self.app_token: str = None
+        self.symphony_token: str = None
+        self.expire_at: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/auth_model/obo_auth_response.py
+++ b/symphony/bdk/gen/auth_model/obo_auth_response.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,7 +73,7 @@ class OboAuthResponse(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'session_token': (str,),  # noqa: E501
+            'session_token': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -157,7 +156,7 @@ class OboAuthResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.session_token: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/auth_model/pod_certificate.py
+++ b/symphony/bdk/gen/auth_model/pod_certificate.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,7 +73,7 @@ class PodCertificate(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'certificate': (str,),  # noqa: E501
+            'certificate': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -157,7 +156,7 @@ class PodCertificate(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.certificate: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/auth_model/token.py
+++ b/symphony/bdk/gen/auth_model/token.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,8 +73,8 @@ class Token(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'name': (str,),  # noqa: E501
-            'token': (str,),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
+            'token': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -160,7 +159,8 @@ class Token(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.name: str = None
+        self.token: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/login_api/authentication_api.py
+++ b/symphony/bdk/gen/login_api/authentication_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -106,7 +106,7 @@ class AuthenticationApi(object):
                 authenticate_request
             return self.call_with_http_info(**kwargs)
 
-        self.pubkey_app_authenticate_post = Endpoint(
+        self.pubkey_app_authenticate_post = _Endpoint(
             settings={
                 'response_type': (Token,),
                 'auth': [],
@@ -227,7 +227,7 @@ class AuthenticationApi(object):
                 user_id
             return self.call_with_http_info(**kwargs)
 
-        self.pubkey_app_user_user_id_authenticate_post = Endpoint(
+        self.pubkey_app_user_user_id_authenticate_post = _Endpoint(
             settings={
                 'response_type': (Token,),
                 'auth': [],
@@ -353,7 +353,7 @@ class AuthenticationApi(object):
                 username
             return self.call_with_http_info(**kwargs)
 
-        self.pubkey_app_username_username_authenticate_post = Endpoint(
+        self.pubkey_app_username_username_authenticate_post = _Endpoint(
             settings={
                 'response_type': (Token,),
                 'auth': [],
@@ -476,7 +476,7 @@ class AuthenticationApi(object):
                 authenticate_request
             return self.call_with_http_info(**kwargs)
 
-        self.pubkey_authenticate_post = Endpoint(
+        self.pubkey_authenticate_post = _Endpoint(
             settings={
                 'response_type': (Token,),
                 'auth': [],
@@ -594,7 +594,7 @@ class AuthenticationApi(object):
                 authenticate_request
             return self.call_with_http_info(**kwargs)
 
-        self.v1_pubkey_app_authenticate_extension_app_post = Endpoint(
+        self.v1_pubkey_app_authenticate_extension_app_post = _Endpoint(
             settings={
                 'response_type': (ExtensionAppTokens,),
                 'auth': [],

--- a/symphony/bdk/gen/login_model/authenticate_extension_app_request.py
+++ b/symphony/bdk/gen/login_model/authenticate_extension_app_request.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,8 +73,8 @@ class AuthenticateExtensionAppRequest(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'app_token': (str,),  # noqa: E501
-            'auth_token': (str,),  # noqa: E501
+            'app_token': (str, none_type),  # noqa: E501
+            'auth_token': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -160,7 +159,8 @@ class AuthenticateExtensionAppRequest(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.app_token: str = None
+        self.auth_token: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/login_model/authenticate_request.py
+++ b/symphony/bdk/gen/login_model/authenticate_request.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,7 +73,7 @@ class AuthenticateRequest(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'token': (str,),  # noqa: E501
+            'token': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -157,7 +156,7 @@ class AuthenticateRequest(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.token: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/login_model/error.py
+++ b/symphony/bdk/gen/login_model/error.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,8 +73,8 @@ class Error(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'code': (int,),  # noqa: E501
-            'message': (str,),  # noqa: E501
+            'code': (int, none_type),  # noqa: E501
+            'message': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -160,7 +159,8 @@ class Error(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.code: int = None
+        self.message: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/login_model/extension_app_tokens.py
+++ b/symphony/bdk/gen/login_model/extension_app_tokens.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,10 +73,10 @@ class ExtensionAppTokens(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'app_id': (str,),  # noqa: E501
-            'app_token': (str,),  # noqa: E501
-            'symphony_token': (str,),  # noqa: E501
-            'expire_at': (int,),  # noqa: E501
+            'app_id': (str, none_type),  # noqa: E501
+            'app_token': (str, none_type),  # noqa: E501
+            'symphony_token': (str, none_type),  # noqa: E501
+            'expire_at': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -166,7 +165,10 @@ class ExtensionAppTokens(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.app_id: str = None
+        self.app_token: str = None
+        self.symphony_token: str = None
+        self.expire_at: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/login_model/token.py
+++ b/symphony/bdk/gen/login_model/token.py
@@ -10,8 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
-
-import nulltype  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,8 +73,8 @@ class Token(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'name': (str,),  # noqa: E501
-            'token': (str,),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
+            'token': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -160,7 +159,8 @@ class Token(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.name: str = None
+        self.token: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/model_utils.py
+++ b/symphony/bdk/gen/model_utils.py
@@ -139,7 +139,7 @@ class OpenApiModel(object):
             value = validate_and_convert_types(
                 value, required_types_mixed, path_to_item, self._spec_property_naming,
                 self._check_type, configuration=self._configuration)
-        if (name,) in self.allowed_values:
+        if (name,) in self.allowed_values and value is not None:
             check_allowed_values(
                 self.allowed_values,
                 (name,),

--- a/symphony/bdk/gen/pod_api/app_entitlement_api.py
+++ b/symphony/bdk/gen/pod_api/app_entitlement_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -103,7 +103,7 @@ class AppEntitlementApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_app_entitlement_list_get = Endpoint(
+        self.v1_admin_app_entitlement_list_get = _Endpoint(
             settings={
                 'response_type': (PodAppEntitlementList,),
                 'auth': [],
@@ -223,7 +223,7 @@ class AppEntitlementApi(object):
                 payload
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_app_entitlement_list_post = Endpoint(
+        self.v1_admin_app_entitlement_list_post = _Endpoint(
             settings={
                 'response_type': (PodAppEntitlementList,),
                 'auth': [],
@@ -350,7 +350,7 @@ class AppEntitlementApi(object):
                 uid
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_user_uid_app_entitlement_list_get = Endpoint(
+        self.v1_admin_user_uid_app_entitlement_list_get = _Endpoint(
             settings={
                 'response_type': (UserAppEntitlementList,),
                 'auth': [],
@@ -480,7 +480,7 @@ class AppEntitlementApi(object):
                 payload
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_user_uid_app_entitlement_list_post = Endpoint(
+        self.v1_admin_user_uid_app_entitlement_list_post = _Endpoint(
             settings={
                 'response_type': (UserAppEntitlementList,),
                 'auth': [],

--- a/symphony/bdk/gen/pod_api/application_api.py
+++ b/symphony/bdk/gen/pod_api/application_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -107,7 +107,7 @@ class ApplicationApi(object):
                 application_detail
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_app_create_post = Endpoint(
+        self.v1_admin_app_create_post = _Endpoint(
             settings={
                 'response_type': (ApplicationDetail,),
                 'auth': [],
@@ -234,7 +234,7 @@ class ApplicationApi(object):
                 id
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_app_id_delete_post = Endpoint(
+        self.v1_admin_app_id_delete_post = _Endpoint(
             settings={
                 'response_type': (SuccessResponse,),
                 'auth': [],
@@ -360,7 +360,7 @@ class ApplicationApi(object):
                 id
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_app_id_get_get = Endpoint(
+        self.v1_admin_app_id_get_get = _Endpoint(
             settings={
                 'response_type': (ApplicationDetail,),
                 'auth': [],
@@ -490,7 +490,7 @@ class ApplicationApi(object):
                 application_detail
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_app_id_update_post = Endpoint(
+        self.v1_admin_app_id_update_post = _Endpoint(
             settings={
                 'response_type': (ApplicationDetail,),
                 'auth': [],

--- a/symphony/bdk/gen/pod_api/connection_api.py
+++ b/symphony/bdk/gen/pod_api/connection_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -109,7 +109,7 @@ class ConnectionApi(object):
                 connection_request
             return self.call_with_http_info(**kwargs)
 
-        self.v1_connection_accept_post = Endpoint(
+        self.v1_connection_accept_post = _Endpoint(
             settings={
                 'response_type': (UserConnection,),
                 'auth': [],
@@ -236,7 +236,7 @@ class ConnectionApi(object):
                 connection_request
             return self.call_with_http_info(**kwargs)
 
-        self.v1_connection_create_post = Endpoint(
+        self.v1_connection_create_post = _Endpoint(
             settings={
                 'response_type': (UserConnection,),
                 'auth': [],
@@ -362,7 +362,7 @@ class ConnectionApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_connection_list_get = Endpoint(
+        self.v1_connection_list_get = _Endpoint(
             settings={
                 'response_type': (UserConnectionList,),
                 'auth': [],
@@ -502,7 +502,7 @@ class ConnectionApi(object):
                 connection_request
             return self.call_with_http_info(**kwargs)
 
-        self.v1_connection_reject_post = Endpoint(
+        self.v1_connection_reject_post = _Endpoint(
             settings={
                 'response_type': (UserConnection,),
                 'auth': [],
@@ -629,7 +629,7 @@ class ConnectionApi(object):
                 uid
             return self.call_with_http_info(**kwargs)
 
-        self.v1_connection_user_uid_remove_post = Endpoint(
+        self.v1_connection_user_uid_remove_post = _Endpoint(
             settings={
                 'response_type': (SuccessResponse,),
                 'auth': [],
@@ -755,7 +755,7 @@ class ConnectionApi(object):
                 user_id
             return self.call_with_http_info(**kwargs)
 
-        self.v1_connection_user_user_id_info_get = Endpoint(
+        self.v1_connection_user_user_id_info_get = _Endpoint(
             settings={
                 'response_type': (UserConnection,),
                 'auth': [],

--- a/symphony/bdk/gen/pod_api/default_api.py
+++ b/symphony/bdk/gen/pod_api/default_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -113,7 +113,7 @@ class DefaultApi(object):
                 extension
             return self.call_with_http_info(**kwargs)
 
-        self.delete_allowed_file_extension = Endpoint(
+        self.delete_allowed_file_extension = _Endpoint(
             settings={
                 'response_type': None,
                 'auth': [],
@@ -234,7 +234,7 @@ class DefaultApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             return self.call_with_http_info(**kwargs)
 
-        self.list_allowed_file_extensions = Endpoint(
+        self.list_allowed_file_extensions = _Endpoint(
             settings={
                 'response_type': (FileExtensionsResponse,),
                 'auth': [],
@@ -367,7 +367,7 @@ class DefaultApi(object):
                 v3_file_extension
             return self.call_with_http_info(**kwargs)
 
-        self.put_allowed_file_extension = Endpoint(
+        self.put_allowed_file_extension = _Endpoint(
             settings={
                 'response_type': (FileExtension,),
                 'auth': [],
@@ -504,7 +504,7 @@ class DefaultApi(object):
                 message_id
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_messages_message_id_metadata_relationships_get = Endpoint(
+        self.v1_admin_messages_message_id_metadata_relationships_get = _Endpoint(
             settings={
                 'response_type': (MessageMetadataResponse,),
                 'auth': [],
@@ -638,7 +638,7 @@ class DefaultApi(object):
                 message_id
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_messages_message_id_receipts_get = Endpoint(
+        self.v1_admin_messages_message_id_receipts_get = _Endpoint(
             settings={
                 'response_type': (MessageReceiptDetailResponse,),
                 'auth': [],
@@ -774,7 +774,7 @@ class DefaultApi(object):
                 message_ids
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_messages_post = Endpoint(
+        self.v1_admin_messages_post = _Endpoint(
             settings={
                 'response_type': (MessageDetails,),
                 'auth': [],
@@ -906,7 +906,7 @@ class DefaultApi(object):
                 stream_id
             return self.call_with_http_info(**kwargs)
 
-        self.v2_admin_streams_stream_id_message_ids_get = Endpoint(
+        self.v2_admin_streams_stream_id_message_ids_get = _Endpoint(
             settings={
                 'response_type': (MessageIdsFromStream,),
                 'auth': [],

--- a/symphony/bdk/gen/pod_api/disclaimer_api.py
+++ b/symphony/bdk/gen/pod_api/disclaimer_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -108,7 +108,7 @@ class DisclaimerApi(object):
                 did
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_disclaimer_did_get = Endpoint(
+        self.v1_admin_disclaimer_did_get = _Endpoint(
             settings={
                 'response_type': (Disclaimer,),
                 'auth': [],
@@ -234,7 +234,7 @@ class DisclaimerApi(object):
                 did
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_disclaimer_did_users_get = Endpoint(
+        self.v1_admin_disclaimer_did_users_get = _Endpoint(
             settings={
                 'response_type': (UserIdList,),
                 'auth': [],
@@ -356,7 +356,7 @@ class DisclaimerApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_disclaimer_list_get = Endpoint(
+        self.v1_admin_disclaimer_list_get = _Endpoint(
             settings={
                 'response_type': (DisclaimerList,),
                 'auth': [],

--- a/symphony/bdk/gen/pod_api/info_barriers_api.py
+++ b/symphony/bdk/gen/pod_api/info_barriers_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -113,7 +113,7 @@ class InfoBarriersApi(object):
                 users
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_group_gid_membership_add_post = Endpoint(
+        self.v1_admin_group_gid_membership_add_post = _Endpoint(
             settings={
                 'response_type': (BulkActionResult,),
                 'auth': [],
@@ -246,7 +246,7 @@ class InfoBarriersApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_group_gid_membership_list_get = Endpoint(
+        self.v1_admin_group_gid_membership_list_get = _Endpoint(
             settings={
                 'response_type': (IntegerList,),
                 'auth': [],
@@ -376,7 +376,7 @@ class InfoBarriersApi(object):
                 users
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_group_gid_membership_remove_post = Endpoint(
+        self.v1_admin_group_gid_membership_remove_post = _Endpoint(
             settings={
                 'response_type': (BulkActionResult,),
                 'auth': [],
@@ -505,7 +505,7 @@ class InfoBarriersApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_group_list_get = Endpoint(
+        self.v1_admin_group_list_get = _Endpoint(
             settings={
                 'response_type': (GroupList,),
                 'auth': [],
@@ -621,7 +621,7 @@ class InfoBarriersApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_policy_list_get = Endpoint(
+        self.v1_admin_policy_list_get = _Endpoint(
             settings={
                 'response_type': (PolicyList,),
                 'auth': [],

--- a/symphony/bdk/gen/pod_api/message_api.py
+++ b/symphony/bdk/gen/pod_api/message_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -106,7 +106,7 @@ class MessageApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_message_mid_status_get = Endpoint(
+        self.v1_message_mid_status_get = _Endpoint(
             settings={
                 'response_type': (MessageStatus,),
                 'auth': [],

--- a/symphony/bdk/gen/pod_api/message_suppression_api.py
+++ b/symphony/bdk/gen/pod_api/message_suppression_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -106,7 +106,7 @@ class MessageSuppressionApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_messagesuppression_id_suppress_post = Endpoint(
+        self.v1_admin_messagesuppression_id_suppress_post = _Endpoint(
             settings={
                 'response_type': (MessageSuppressionResponse,),
                 'auth': [],

--- a/symphony/bdk/gen/pod_api/pod_api.py
+++ b/symphony/bdk/gen/pod_api/pod_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -104,7 +104,7 @@ class PodApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_files_allowed_types_get = Endpoint(
+        self.v1_files_allowed_types_get = _Endpoint(
             settings={
                 'response_type': (StringList,),
                 'auth': [],
@@ -215,7 +215,7 @@ class PodApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             return self.call_with_http_info(**kwargs)
 
-        self.v1_languages_get = Endpoint(
+        self.v1_languages_get = _Endpoint(
             settings={
                 'response_type': (Languages,),
                 'auth': [],
@@ -319,7 +319,7 @@ class PodApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             return self.call_with_http_info(**kwargs)
 
-        self.v1_podcert_get = Endpoint(
+        self.v1_podcert_get = _Endpoint(
             settings={
                 'response_type': (PodCertificate,),
                 'auth': [],

--- a/symphony/bdk/gen/pod_api/presence_api.py
+++ b/symphony/bdk/gen/pod_api/presence_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -110,7 +110,7 @@ class PresenceApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_presence_feed_create_post = Endpoint(
+        self.v1_presence_feed_create_post = _Endpoint(
             settings={
                 'response_type': (StringId,),
                 'auth': [],
@@ -231,7 +231,7 @@ class PresenceApi(object):
                 feed_id
             return self.call_with_http_info(**kwargs)
 
-        self.v1_presence_feed_feed_id_delete_post = Endpoint(
+        self.v1_presence_feed_feed_id_delete_post = _Endpoint(
             settings={
                 'response_type': (StringId,),
                 'auth': [],
@@ -358,7 +358,7 @@ class PresenceApi(object):
                 feed_id
             return self.call_with_http_info(**kwargs)
 
-        self.v1_presence_feed_feed_id_read_get = Endpoint(
+        self.v1_presence_feed_feed_id_read_get = _Endpoint(
             settings={
                 'response_type': (V2PresenceList,),
                 'auth': [],
@@ -480,7 +480,7 @@ class PresenceApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_user_presence_get = Endpoint(
+        self.v1_user_presence_get = _Endpoint(
             settings={
                 'response_type': (Presence,),
                 'auth': [],
@@ -600,7 +600,7 @@ class PresenceApi(object):
                 presence
             return self.call_with_http_info(**kwargs)
 
-        self.v1_user_presence_post = Endpoint(
+        self.v1_user_presence_post = _Endpoint(
             settings={
                 'response_type': (Presence,),
                 'auth': [],
@@ -725,7 +725,7 @@ class PresenceApi(object):
                 uid_list
             return self.call_with_http_info(**kwargs)
 
-        self.v1_user_presence_register_post = Endpoint(
+        self.v1_user_presence_register_post = _Endpoint(
             settings={
                 'response_type': (SuccessResponse,),
                 'auth': [],
@@ -852,7 +852,7 @@ class PresenceApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_user_uid_presence_get = Endpoint(
+        self.v1_user_uid_presence_get = _Endpoint(
             settings={
                 'response_type': (Presence,),
                 'auth': [],
@@ -983,7 +983,7 @@ class PresenceApi(object):
                 presence
             return self.call_with_http_info(**kwargs)
 
-        self.v1_user_uid_presence_post = Endpoint(
+        self.v1_user_uid_presence_post = _Endpoint(
             settings={
                 'response_type': (Presence,),
                 'auth': [],
@@ -1112,7 +1112,7 @@ class PresenceApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v2_user_presence_get = Endpoint(
+        self.v2_user_presence_get = _Endpoint(
             settings={
                 'response_type': (V2Presence,),
                 'auth': [],
@@ -1233,7 +1233,7 @@ class PresenceApi(object):
                 presence
             return self.call_with_http_info(**kwargs)
 
-        self.v2_user_presence_post = Endpoint(
+        self.v2_user_presence_post = _Endpoint(
             settings={
                 'response_type': (V2Presence,),
                 'auth': [],
@@ -1366,7 +1366,7 @@ class PresenceApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v2_user_uid_presence_get = Endpoint(
+        self.v2_user_uid_presence_get = _Endpoint(
             settings={
                 'response_type': (Presence,),
                 'auth': [],
@@ -1496,7 +1496,7 @@ class PresenceApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v2_users_presence_get = Endpoint(
+        self.v2_users_presence_get = _Endpoint(
             settings={
                 'response_type': (V2PresenceList,),
                 'auth': [],
@@ -1627,7 +1627,7 @@ class PresenceApi(object):
                 presence
             return self.call_with_http_info(**kwargs)
 
-        self.v3_user_presence_post = Endpoint(
+        self.v3_user_presence_post = _Endpoint(
             settings={
                 'response_type': (V2Presence,),
                 'auth': [],
@@ -1758,7 +1758,7 @@ class PresenceApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v3_user_uid_presence_get = Endpoint(
+        self.v3_user_uid_presence_get = _Endpoint(
             settings={
                 'response_type': (V2Presence,),
                 'auth': [],

--- a/symphony/bdk/gen/pod_api/room_membership_api.py
+++ b/symphony/bdk/gen/pod_api/room_membership_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -112,7 +112,7 @@ class RoomMembershipApi(object):
                 payload
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_room_id_membership_add_post = Endpoint(
+        self.v1_admin_room_id_membership_add_post = _Endpoint(
             settings={
                 'response_type': (SuccessResponse,),
                 'auth': [],
@@ -246,7 +246,7 @@ class RoomMembershipApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_room_id_membership_list_get = Endpoint(
+        self.v1_admin_room_id_membership_list_get = _Endpoint(
             settings={
                 'response_type': (MembershipList,),
                 'auth': [],
@@ -381,7 +381,7 @@ class RoomMembershipApi(object):
                 payload
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_room_id_membership_remove_post = Endpoint(
+        self.v1_admin_room_id_membership_remove_post = _Endpoint(
             settings={
                 'response_type': (SuccessResponse,),
                 'auth': [],
@@ -518,7 +518,7 @@ class RoomMembershipApi(object):
                 payload
             return self.call_with_http_info(**kwargs)
 
-        self.v1_room_id_membership_add_post = Endpoint(
+        self.v1_room_id_membership_add_post = _Endpoint(
             settings={
                 'response_type': (SuccessResponse,),
                 'auth': [],
@@ -655,7 +655,7 @@ class RoomMembershipApi(object):
                 payload
             return self.call_with_http_info(**kwargs)
 
-        self.v1_room_id_membership_demote_owner_post = Endpoint(
+        self.v1_room_id_membership_demote_owner_post = _Endpoint(
             settings={
                 'response_type': (SuccessResponse,),
                 'auth': [],
@@ -789,7 +789,7 @@ class RoomMembershipApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_room_id_membership_list_get = Endpoint(
+        self.v1_room_id_membership_list_get = _Endpoint(
             settings={
                 'response_type': (MembershipList,),
                 'auth': [],
@@ -919,7 +919,7 @@ class RoomMembershipApi(object):
                 payload
             return self.call_with_http_info(**kwargs)
 
-        self.v1_room_id_membership_promote_owner_post = Endpoint(
+        self.v1_room_id_membership_promote_owner_post = _Endpoint(
             settings={
                 'response_type': (SuccessResponse,),
                 'auth': [],
@@ -1056,7 +1056,7 @@ class RoomMembershipApi(object):
                 payload
             return self.call_with_http_info(**kwargs)
 
-        self.v1_room_id_membership_remove_post = Endpoint(
+        self.v1_room_id_membership_remove_post = _Endpoint(
             settings={
                 'response_type': (SuccessResponse,),
                 'auth': [],
@@ -1189,7 +1189,7 @@ class RoomMembershipApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v2_room_id_membership_list_get = Endpoint(
+        self.v2_room_id_membership_list_get = _Endpoint(
             settings={
                 'response_type': (MembershipList,),
                 'auth': [],

--- a/symphony/bdk/gen/pod_api/security_api.py
+++ b/symphony/bdk/gen/pod_api/security_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -112,7 +112,7 @@ class SecurityApi(object):
                 cert
             return self.call_with_http_info(**kwargs)
 
-        self.v1_companycert_create_post = Endpoint(
+        self.v1_companycert_create_post = _Endpoint(
             settings={
                 'response_type': (SuccessResponse,),
                 'auth': [],
@@ -239,7 +239,7 @@ class SecurityApi(object):
                 finger_print
             return self.call_with_http_info(**kwargs)
 
-        self.v1_companycert_delete_post = Endpoint(
+        self.v1_companycert_delete_post = _Endpoint(
             settings={
                 'response_type': (SuccessResponse,),
                 'auth': [],
@@ -366,7 +366,7 @@ class SecurityApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_companycert_finger_print_get_get = Endpoint(
+        self.v1_companycert_finger_print_get_get = _Endpoint(
             settings={
                 'response_type': (CompanyCertDetail,),
                 'auth': [],
@@ -492,7 +492,7 @@ class SecurityApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_companycert_finger_print_issued_by_get = Endpoint(
+        self.v1_companycert_finger_print_issued_by_get = _Endpoint(
             settings={
                 'response_type': (CompanyCertInfoList,),
                 'auth': [],
@@ -622,7 +622,7 @@ class SecurityApi(object):
                 cert_attributes
             return self.call_with_http_info(**kwargs)
 
-        self.v1_companycert_finger_print_update_post = Endpoint(
+        self.v1_companycert_finger_print_update_post = _Endpoint(
             settings={
                 'response_type': (SuccessResponse,),
                 'auth': [],
@@ -753,7 +753,7 @@ class SecurityApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_companycert_list_get = Endpoint(
+        self.v1_companycert_list_get = _Endpoint(
             settings={
                 'response_type': (CompanyCertInfoList,),
                 'auth': [],
@@ -881,7 +881,7 @@ class SecurityApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_companycert_podmanaged_list_get = Endpoint(
+        self.v1_companycert_podmanaged_list_get = _Endpoint(
             settings={
                 'response_type': (CompanyCertInfoList,),
                 'auth': [],
@@ -1013,7 +1013,7 @@ class SecurityApi(object):
                 type_id_list
             return self.call_with_http_info(**kwargs)
 
-        self.v1_companycert_type_list_post = Endpoint(
+        self.v1_companycert_type_list_post = _Endpoint(
             settings={
                 'response_type': (CompanyCertInfoList,),
                 'auth': [],
@@ -1150,7 +1150,7 @@ class SecurityApi(object):
                 cert
             return self.call_with_http_info(**kwargs)
 
-        self.v2_companycert_create_post = Endpoint(
+        self.v2_companycert_create_post = _Endpoint(
             settings={
                 'response_type': (CompanyCertDetail,),
                 'auth': [],

--- a/symphony/bdk/gen/pod_api/session_api.py
+++ b/symphony/bdk/gen/pod_api/session_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -103,7 +103,7 @@ class SessionApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_sessioninfo_get = Endpoint(
+        self.v1_sessioninfo_get = _Endpoint(
             settings={
                 'response_type': (SessionInfo,),
                 'auth': [],
@@ -219,7 +219,7 @@ class SessionApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v2_sessioninfo_get = Endpoint(
+        self.v2_sessioninfo_get = _Endpoint(
             settings={
                 'response_type': (UserV2,),
                 'auth': [],

--- a/symphony/bdk/gen/pod_api/streams_api.py
+++ b/symphony/bdk/gen/pod_api/streams_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -129,7 +129,7 @@ class StreamsApi(object):
                 uid_list
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_im_create_post = Endpoint(
+        self.v1_admin_im_create_post = _Endpoint(
             settings={
                 'response_type': (Stream,),
                 'auth': [],
@@ -260,7 +260,7 @@ class StreamsApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_room_id_set_active_post = Endpoint(
+        self.v1_admin_room_id_set_active_post = _Endpoint(
             settings={
                 'response_type': (RoomDetail,),
                 'auth': [],
@@ -394,7 +394,7 @@ class StreamsApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_stream_id_membership_list_get = Endpoint(
+        self.v1_admin_stream_id_membership_list_get = _Endpoint(
             settings={
                 'response_type': (V2MembershipList,),
                 'auth': [],
@@ -529,7 +529,7 @@ class StreamsApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_streams_list_post = Endpoint(
+        self.v1_admin_streams_list_post = _Endpoint(
             settings={
                 'response_type': (AdminStreamList,),
                 'auth': [],
@@ -666,7 +666,7 @@ class StreamsApi(object):
                 uid_list
             return self.call_with_http_info(**kwargs)
 
-        self.v1_im_create_post = Endpoint(
+        self.v1_im_create_post = _Endpoint(
             settings={
                 'response_type': (Stream,),
                 'auth': [],
@@ -794,7 +794,7 @@ class StreamsApi(object):
                 payload
             return self.call_with_http_info(**kwargs)
 
-        self.v1_room_create_post = Endpoint(
+        self.v1_room_create_post = _Endpoint(
             settings={
                 'response_type': (RoomDetail,),
                 'auth': [],
@@ -921,7 +921,7 @@ class StreamsApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_room_id_info_get = Endpoint(
+        self.v1_room_id_info_get = _Endpoint(
             settings={
                 'response_type': (RoomDetail,),
                 'auth': [],
@@ -1051,7 +1051,7 @@ class StreamsApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_room_id_set_active_post = Endpoint(
+        self.v1_room_id_set_active_post = _Endpoint(
             settings={
                 'response_type': (RoomDetail,),
                 'auth': [],
@@ -1187,7 +1187,7 @@ class StreamsApi(object):
                 payload
             return self.call_with_http_info(**kwargs)
 
-        self.v1_room_id_update_post = Endpoint(
+        self.v1_room_id_update_post = _Endpoint(
             settings={
                 'response_type': (RoomDetail,),
                 'auth': [],
@@ -1319,7 +1319,7 @@ class StreamsApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_streams_list_post = Endpoint(
+        self.v1_streams_list_post = _Endpoint(
             settings={
                 'response_type': (StreamList,),
                 'auth': [],
@@ -1459,7 +1459,7 @@ class StreamsApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_streams_sid_attachments_get = Endpoint(
+        self.v1_streams_sid_attachments_get = _Endpoint(
             settings={
                 'response_type': (StreamAttachmentResponse,),
                 'auth': [],
@@ -1605,7 +1605,7 @@ class StreamsApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_streams_sid_info_get = Endpoint(
+        self.v1_streams_sid_info_get = _Endpoint(
             settings={
                 'response_type': (StreamAttributes,),
                 'auth': [],
@@ -1730,7 +1730,7 @@ class StreamsApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v2_admin_streams_list_post = Endpoint(
+        self.v2_admin_streams_list_post = _Endpoint(
             settings={
                 'response_type': (V2AdminStreamList,),
                 'auth': [],
@@ -1867,7 +1867,7 @@ class StreamsApi(object):
                 payload
             return self.call_with_http_info(**kwargs)
 
-        self.v2_room_create_post = Endpoint(
+        self.v2_room_create_post = _Endpoint(
             settings={
                 'response_type': (V2RoomDetail,),
                 'auth': [],
@@ -1994,7 +1994,7 @@ class StreamsApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v2_room_id_info_get = Endpoint(
+        self.v2_room_id_info_get = _Endpoint(
             settings={
                 'response_type': (V2RoomDetail,),
                 'auth': [],
@@ -2124,7 +2124,7 @@ class StreamsApi(object):
                 payload
             return self.call_with_http_info(**kwargs)
 
-        self.v2_room_id_update_post = Endpoint(
+        self.v2_room_id_update_post = _Endpoint(
             settings={
                 'response_type': (V2RoomDetail,),
                 'auth': [],
@@ -2259,7 +2259,7 @@ class StreamsApi(object):
                 query
             return self.call_with_http_info(**kwargs)
 
-        self.v2_room_search_post = Endpoint(
+        self.v2_room_search_post = _Endpoint(
             settings={
                 'response_type': (RoomSearchResults,),
                 'auth': [],
@@ -2396,7 +2396,7 @@ class StreamsApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v2_streams_sid_info_get = Endpoint(
+        self.v2_streams_sid_info_get = _Endpoint(
             settings={
                 'response_type': (V2StreamAttributes,),
                 'auth': [],
@@ -2523,7 +2523,7 @@ class StreamsApi(object):
                 payload
             return self.call_with_http_info(**kwargs)
 
-        self.v3_room_create_post = Endpoint(
+        self.v3_room_create_post = _Endpoint(
             settings={
                 'response_type': (V3RoomDetail,),
                 'auth': [],
@@ -2650,7 +2650,7 @@ class StreamsApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v3_room_id_info_get = Endpoint(
+        self.v3_room_id_info_get = _Endpoint(
             settings={
                 'response_type': (V3RoomDetail,),
                 'auth': [],
@@ -2780,7 +2780,7 @@ class StreamsApi(object):
                 payload
             return self.call_with_http_info(**kwargs)
 
-        self.v3_room_id_update_post = Endpoint(
+        self.v3_room_id_update_post = _Endpoint(
             settings={
                 'response_type': (V3RoomDetail,),
                 'auth': [],
@@ -2915,7 +2915,7 @@ class StreamsApi(object):
                 query
             return self.call_with_http_info(**kwargs)
 
-        self.v3_room_search_post = Endpoint(
+        self.v3_room_search_post = _Endpoint(
             settings={
                 'response_type': (V3RoomSearchResults,),
                 'auth': [],

--- a/symphony/bdk/gen/pod_api/system_api.py
+++ b/symphony/bdk/gen/pod_api/system_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -23,7 +23,6 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
 )
 from symphony.bdk.gen.pod_model.error import Error
 from symphony.bdk.gen.pod_model.protocol import Protocol
-from symphony.bdk.gen.pod_model.role_detail_list import RoleDetailList
 from symphony.bdk.gen.pod_model.string_list import StringList
 
 
@@ -104,7 +103,7 @@ class SystemApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_system_features_list_get = Endpoint(
+        self.v1_admin_system_features_list_get = _Endpoint(
             settings={
                 'response_type': (StringList,),
                 'auth': [],
@@ -220,7 +219,7 @@ class SystemApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_system_protocols_list_get = Endpoint(
+        self.v1_admin_system_protocols_list_get = _Endpoint(
             settings={
                 'response_type': (StringList,),
                 'auth': [],
@@ -340,7 +339,7 @@ class SystemApi(object):
                 protocol
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_system_protocols_post = Endpoint(
+        self.v1_admin_system_protocols_post = _Endpoint(
             settings={
                 'response_type': (Protocol,),
                 'auth': [],
@@ -467,7 +466,7 @@ class SystemApi(object):
                 scheme
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_system_protocols_scheme_delete = Endpoint(
+        self.v1_admin_system_protocols_scheme_delete = _Endpoint(
             settings={
                 'response_type': None,
                 'auth': [],
@@ -522,122 +521,6 @@ class SystemApi(object):
             },
             api_client=api_client,
             callable=__v1_admin_system_protocols_scheme_delete
-        )
-
-        def __v1_admin_system_roles_list_get(
-            self,
-            session_token,
-            **kwargs
-        ):
-            """Get a list of all roles available in the company (pod)  # noqa: E501
-
-            This method makes a synchronous HTTP request by default. To make an
-            asynchronous HTTP request, please pass async_req=True
-
-            >>> thread = pod_api.v1_admin_system_roles_list_get(session_token, async_req=True)
-            >>> result = thread.get()
-
-            Args:
-                session_token (str): Session authentication token.
-
-            Keyword Args:
-                _return_http_data_only (bool): response data without head status
-                    code and headers. Default is True.
-                _preload_content (bool): if False, the urllib3.HTTPResponse object
-                    will be returned without reading/decoding response data.
-                    Default is True.
-                _request_timeout (float/tuple): timeout setting for this request. If one
-                    number provided, it will be total request timeout. It can also
-                    be a pair (tuple) of (connection, read) timeouts.
-                    Default is None.
-                _check_input_type (bool): specifies if type checking
-                    should be done one the data sent to the server.
-                    Default is True.
-                _check_return_type (bool): specifies if type checking
-                    should be done one the data received from the server.
-                    Default is True.
-                _host_index (int/None): specifies the index of the server
-                    that we want to use.
-                    Default is read from the configuration.
-                async_req (bool): execute request asynchronously
-
-            Returns:
-                RoleDetailList
-                    If the method is called asynchronously, returns the request
-                    thread.
-            """
-            kwargs['async_req'] = kwargs.get(
-                'async_req', False
-            )
-            kwargs['_return_http_data_only'] = kwargs.get(
-                '_return_http_data_only', True
-            )
-            kwargs['_preload_content'] = kwargs.get(
-                '_preload_content', True
-            )
-            kwargs['_request_timeout'] = kwargs.get(
-                '_request_timeout', None
-            )
-            kwargs['_check_input_type'] = kwargs.get(
-                '_check_input_type', True
-            )
-            kwargs['_check_return_type'] = kwargs.get(
-                '_check_return_type', True
-            )
-            kwargs['_host_index'] = kwargs.get('_host_index')
-            kwargs['session_token'] = \
-                session_token
-            return self.call_with_http_info(**kwargs)
-
-        self.v1_admin_system_roles_list_get = Endpoint(
-            settings={
-                'response_type': (RoleDetailList,),
-                'auth': [],
-                'endpoint_path': '/v1/admin/system/roles/list',
-                'operation_id': 'v1_admin_system_roles_list_get',
-                'http_method': 'GET',
-                'servers': None,
-            },
-            params_map={
-                'all': [
-                    'session_token',
-                ],
-                'required': [
-                    'session_token',
-                ],
-                'nullable': [
-                ],
-                'enum': [
-                ],
-                'validation': [
-                ]
-            },
-            root_map={
-                'validations': {
-                },
-                'allowed_values': {
-                },
-                'openapi_types': {
-                    'session_token':
-                        (str,),
-                },
-                'attribute_map': {
-                    'session_token': 'sessionToken',
-                },
-                'location_map': {
-                    'session_token': 'header',
-                },
-                'collection_format_map': {
-                }
-            },
-            headers_map={
-                'accept': [
-                    'application/json'
-                ],
-                'content_type': [],
-            },
-            api_client=api_client,
-            callable=__v1_admin_system_roles_list_get
         )
 
         def __v2_system_protocols_get(
@@ -707,7 +590,7 @@ class SystemApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v2_system_protocols_get = Endpoint(
+        self.v2_system_protocols_get = _Endpoint(
             settings={
                 'response_type': (StringList,),
                 'auth': [],

--- a/symphony/bdk/gen/pod_api/user_api.py
+++ b/symphony/bdk/gen/pod_api/user_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -31,6 +31,7 @@ from symphony.bdk.gen.pod_model.followers_list import FollowersList
 from symphony.bdk.gen.pod_model.followers_list_response import FollowersListResponse
 from symphony.bdk.gen.pod_model.following_list_response import FollowingListResponse
 from symphony.bdk.gen.pod_model.integer_list import IntegerList
+from symphony.bdk.gen.pod_model.role_detail_list import RoleDetailList
 from symphony.bdk.gen.pod_model.string_id import StringId
 from symphony.bdk.gen.pod_model.success_response import SuccessResponse
 from symphony.bdk.gen.pod_model.user_attributes import UserAttributes
@@ -58,6 +59,122 @@ class UserApi(object):
         if api_client is None:
             api_client = ApiClient()
         self.api_client = api_client
+
+        def __v1_admin_system_roles_list_get(
+            self,
+            session_token,
+            **kwargs
+        ):
+            """Get a list of all roles available in the company (pod)  # noqa: E501
+
+            This method makes a synchronous HTTP request by default. To make an
+            asynchronous HTTP request, please pass async_req=True
+
+            >>> thread = pod_api.v1_admin_system_roles_list_get(session_token, async_req=True)
+            >>> result = thread.get()
+
+            Args:
+                session_token (str): Session authentication token.
+
+            Keyword Args:
+                _return_http_data_only (bool): response data without head status
+                    code and headers. Default is True.
+                _preload_content (bool): if False, the urllib3.HTTPResponse object
+                    will be returned without reading/decoding response data.
+                    Default is True.
+                _request_timeout (float/tuple): timeout setting for this request. If one
+                    number provided, it will be total request timeout. It can also
+                    be a pair (tuple) of (connection, read) timeouts.
+                    Default is None.
+                _check_input_type (bool): specifies if type checking
+                    should be done one the data sent to the server.
+                    Default is True.
+                _check_return_type (bool): specifies if type checking
+                    should be done one the data received from the server.
+                    Default is True.
+                _host_index (int/None): specifies the index of the server
+                    that we want to use.
+                    Default is read from the configuration.
+                async_req (bool): execute request asynchronously
+
+            Returns:
+                RoleDetailList
+                    If the method is called asynchronously, returns the request
+                    thread.
+            """
+            kwargs['async_req'] = kwargs.get(
+                'async_req', False
+            )
+            kwargs['_return_http_data_only'] = kwargs.get(
+                '_return_http_data_only', True
+            )
+            kwargs['_preload_content'] = kwargs.get(
+                '_preload_content', True
+            )
+            kwargs['_request_timeout'] = kwargs.get(
+                '_request_timeout', None
+            )
+            kwargs['_check_input_type'] = kwargs.get(
+                '_check_input_type', True
+            )
+            kwargs['_check_return_type'] = kwargs.get(
+                '_check_return_type', True
+            )
+            kwargs['_host_index'] = kwargs.get('_host_index')
+            kwargs['session_token'] = \
+                session_token
+            return self.call_with_http_info(**kwargs)
+
+        self.v1_admin_system_roles_list_get = _Endpoint(
+            settings={
+                'response_type': (RoleDetailList,),
+                'auth': [],
+                'endpoint_path': '/v1/admin/system/roles/list',
+                'operation_id': 'v1_admin_system_roles_list_get',
+                'http_method': 'GET',
+                'servers': None,
+            },
+            params_map={
+                'all': [
+                    'session_token',
+                ],
+                'required': [
+                    'session_token',
+                ],
+                'nullable': [
+                ],
+                'enum': [
+                ],
+                'validation': [
+                ]
+            },
+            root_map={
+                'validations': {
+                },
+                'allowed_values': {
+                },
+                'openapi_types': {
+                    'session_token':
+                        (str,),
+                },
+                'attribute_map': {
+                    'session_token': 'sessionToken',
+                },
+                'location_map': {
+                    'session_token': 'header',
+                },
+                'collection_format_map': {
+                }
+            },
+            headers_map={
+                'accept': [
+                    'application/json'
+                ],
+                'content_type': [],
+            },
+            api_client=api_client,
+            callable=__v1_admin_system_roles_list_get
+        )
 
         def __v1_admin_user_create_post(
             self,
@@ -128,7 +245,7 @@ class UserApi(object):
                 payload
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_user_create_post = Endpoint(
+        self.v1_admin_user_create_post = _Endpoint(
             settings={
                 'response_type': (UserDetail,),
                 'auth': [],
@@ -257,7 +374,7 @@ class UserApi(object):
                 payload
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_user_find_post = Endpoint(
+        self.v1_admin_user_find_post = _Endpoint(
             settings={
                 'response_type': (UserDetailList,),
                 'auth': [],
@@ -390,7 +507,7 @@ class UserApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_user_list_get = Endpoint(
+        self.v1_admin_user_list_get = _Endpoint(
             settings={
                 'response_type': (UserIdList,),
                 'auth': [],
@@ -510,7 +627,7 @@ class UserApi(object):
                 uid
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_user_uid_avatar_get = Endpoint(
+        self.v1_admin_user_uid_avatar_get = _Endpoint(
             settings={
                 'response_type': (AvatarList,),
                 'auth': [],
@@ -640,7 +757,7 @@ class UserApi(object):
                 payload
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_user_uid_avatar_update_post = Endpoint(
+        self.v1_admin_user_uid_avatar_update_post = _Endpoint(
             settings={
                 'response_type': (SuccessResponse,),
                 'auth': [],
@@ -773,7 +890,7 @@ class UserApi(object):
                 uid
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_user_uid_delegates_get = Endpoint(
+        self.v1_admin_user_uid_delegates_get = _Endpoint(
             settings={
                 'response_type': (IntegerList,),
                 'auth': [],
@@ -903,7 +1020,7 @@ class UserApi(object):
                 payload
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_user_uid_delegates_update_post = Endpoint(
+        self.v1_admin_user_uid_delegates_update_post = _Endpoint(
             settings={
                 'response_type': (SuccessResponse,),
                 'auth': [],
@@ -1036,7 +1153,7 @@ class UserApi(object):
                 uid
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_user_uid_disclaimer_delete = Endpoint(
+        self.v1_admin_user_uid_disclaimer_delete = _Endpoint(
             settings={
                 'response_type': (SuccessResponse,),
                 'auth': [],
@@ -1162,7 +1279,7 @@ class UserApi(object):
                 uid
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_user_uid_disclaimer_get = Endpoint(
+        self.v1_admin_user_uid_disclaimer_get = _Endpoint(
             settings={
                 'response_type': (Disclaimer,),
                 'auth': [],
@@ -1292,7 +1409,7 @@ class UserApi(object):
                 payload
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_user_uid_disclaimer_update_post = Endpoint(
+        self.v1_admin_user_uid_disclaimer_update_post = _Endpoint(
             settings={
                 'response_type': (SuccessResponse,),
                 'auth': [],
@@ -1425,7 +1542,7 @@ class UserApi(object):
                 uid
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_user_uid_features_get = Endpoint(
+        self.v1_admin_user_uid_features_get = _Endpoint(
             settings={
                 'response_type': (FeatureList,),
                 'auth': [],
@@ -1555,7 +1672,7 @@ class UserApi(object):
                 payload
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_user_uid_features_update_post = Endpoint(
+        self.v1_admin_user_uid_features_update_post = _Endpoint(
             settings={
                 'response_type': (SuccessResponse,),
                 'auth': [],
@@ -1688,7 +1805,7 @@ class UserApi(object):
                 uid
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_user_uid_get = Endpoint(
+        self.v1_admin_user_uid_get = _Endpoint(
             settings={
                 'response_type': (UserDetail,),
                 'auth': [],
@@ -1818,7 +1935,7 @@ class UserApi(object):
                 payload
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_user_uid_roles_add_post = Endpoint(
+        self.v1_admin_user_uid_roles_add_post = _Endpoint(
             settings={
                 'response_type': (SuccessResponse,),
                 'auth': [],
@@ -1955,7 +2072,7 @@ class UserApi(object):
                 payload
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_user_uid_roles_remove_post = Endpoint(
+        self.v1_admin_user_uid_roles_remove_post = _Endpoint(
             settings={
                 'response_type': (SuccessResponse,),
                 'auth': [],
@@ -2088,7 +2205,7 @@ class UserApi(object):
                 uid
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_user_uid_status_get = Endpoint(
+        self.v1_admin_user_uid_status_get = _Endpoint(
             settings={
                 'response_type': (UserStatus,),
                 'auth': [],
@@ -2218,7 +2335,7 @@ class UserApi(object):
                 payload
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_user_uid_status_update_post = Endpoint(
+        self.v1_admin_user_uid_status_update_post = _Endpoint(
             settings={
                 'response_type': (SuccessResponse,),
                 'auth': [],
@@ -2355,7 +2472,7 @@ class UserApi(object):
                 payload
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_user_uid_update_post = Endpoint(
+        self.v1_admin_user_uid_update_post = _Endpoint(
             settings={
                 'response_type': (UserDetail,),
                 'auth': [],
@@ -2492,7 +2609,7 @@ class UserApi(object):
                 payload
             return self.call_with_http_info(**kwargs)
 
-        self.v1_admin_user_user_id_suspension_update_put = Endpoint(
+        self.v1_admin_user_user_id_suspension_update_put = _Endpoint(
             settings={
                 'response_type': (SuccessResponse,),
                 'auth': [],
@@ -2629,7 +2746,7 @@ class UserApi(object):
                 uid_list
             return self.call_with_http_info(**kwargs)
 
-        self.v1_user_uid_follow_post = Endpoint(
+        self.v1_user_uid_follow_post = _Endpoint(
             settings={
                 'response_type': (SuccessResponse,),
                 'auth': [],
@@ -2765,7 +2882,7 @@ class UserApi(object):
                 uid
             return self.call_with_http_info(**kwargs)
 
-        self.v1_user_uid_followers_get = Endpoint(
+        self.v1_user_uid_followers_get = _Endpoint(
             settings={
                 'response_type': (FollowersListResponse,),
                 'auth': [],
@@ -2909,7 +3026,7 @@ class UserApi(object):
                 uid
             return self.call_with_http_info(**kwargs)
 
-        self.v1_user_uid_following_get = Endpoint(
+        self.v1_user_uid_following_get = _Endpoint(
             settings={
                 'response_type': (FollowingListResponse,),
                 'auth': [],
@@ -3054,7 +3171,7 @@ class UserApi(object):
                 uid_list
             return self.call_with_http_info(**kwargs)
 
-        self.v1_user_uid_unfollow_post = Endpoint(
+        self.v1_user_uid_unfollow_post = _Endpoint(
             settings={
                 'response_type': (SuccessResponse,),
                 'auth': [],
@@ -3187,7 +3304,7 @@ class UserApi(object):
                 payload
             return self.call_with_http_info(**kwargs)
 
-        self.v2_admin_user_create_post = Endpoint(
+        self.v2_admin_user_create_post = _Endpoint(
             settings={
                 'response_type': (V2UserDetail,),
                 'auth': [],
@@ -3312,7 +3429,7 @@ class UserApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v2_admin_user_list_get = Endpoint(
+        self.v2_admin_user_list_get = _Endpoint(
             settings={
                 'response_type': (V2UserDetailList,),
                 'auth': [],
@@ -3442,7 +3559,7 @@ class UserApi(object):
                 uid
             return self.call_with_http_info(**kwargs)
 
-        self.v2_admin_user_uid_get = Endpoint(
+        self.v2_admin_user_uid_get = _Endpoint(
             settings={
                 'response_type': (V2UserDetail,),
                 'auth': [],
@@ -3572,7 +3689,7 @@ class UserApi(object):
                 payload
             return self.call_with_http_info(**kwargs)
 
-        self.v2_admin_user_uid_update_post = Endpoint(
+        self.v2_admin_user_uid_update_post = _Endpoint(
             settings={
                 'response_type': (V2UserDetail,),
                 'auth': [],

--- a/symphony/bdk/gen/pod_api/users_api.py
+++ b/symphony/bdk/gen/pod_api/users_api.py
@@ -11,7 +11,7 @@
 import re  # noqa: F401
 import sys  # noqa: F401
 
-from symphony.bdk.gen.api_client import ApiClient, Endpoint
+from symphony.bdk.gen.api_client import ApiClient, Endpoint as _Endpoint
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     check_allowed_values,
     check_validations,
@@ -111,7 +111,7 @@ class UsersApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_user_get = Endpoint(
+        self.v1_user_get = _Endpoint(
             settings={
                 'response_type': (User,),
                 'auth': [],
@@ -243,7 +243,7 @@ class UsersApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v1_user_name_user_name_get_get = Endpoint(
+        self.v1_user_name_user_name_get_get = _Endpoint(
             settings={
                 'response_type': (User,),
                 'auth': [],
@@ -372,7 +372,7 @@ class UsersApi(object):
                 search_request
             return self.call_with_http_info(**kwargs)
 
-        self.v1_user_search_post = Endpoint(
+        self.v1_user_search_post = _Endpoint(
             settings={
                 'response_type': (UserSearchResults,),
                 'auth': [],
@@ -514,7 +514,7 @@ class UsersApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v2_user_get = Endpoint(
+        self.v2_user_get = _Endpoint(
             settings={
                 'response_type': (UserV2,),
                 'auth': [],
@@ -655,7 +655,7 @@ class UsersApi(object):
                 session_token
             return self.call_with_http_info(**kwargs)
 
-        self.v3_users_get = Endpoint(
+        self.v3_users_get = _Endpoint(
             settings={
                 'response_type': (V2UserList,),
                 'auth': [],

--- a/symphony/bdk/gen/pod_model/admin_justified_action.py
+++ b/symphony/bdk/gen/pod_model/admin_justified_action.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,7 +73,7 @@ class AdminJustifiedAction(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'justification': (str,),  # noqa: E501
+            'justification': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -155,7 +156,7 @@ class AdminJustifiedAction(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.justification: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/admin_justified_user_action.py
+++ b/symphony/bdk/gen/pod_model/admin_justified_user_action.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,8 +73,8 @@ class AdminJustifiedUserAction(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'user_id': (int,),  # noqa: E501
-            'justification': (str,),  # noqa: E501
+            'user_id': (int, none_type),  # noqa: E501
+            'justification': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -158,7 +159,8 @@ class AdminJustifiedUserAction(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.user_id: int = None
+        self.justification: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/admin_stream_attributes.py
+++ b/symphony/bdk/gen/pod_model/admin_stream_attributes.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,15 +73,15 @@ class AdminStreamAttributes(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'room_name': (str,),  # noqa: E501
-            'room_description': (str,),  # noqa: E501
-            'members': ([int],),  # noqa: E501
-            'created_by_user_id': (int,),  # noqa: E501
-            'created_date': (int,),  # noqa: E501
-            'last_modified_date': (int,),  # noqa: E501
-            'origin_company': (str,),  # noqa: E501
-            'origin_company_id': (int,),  # noqa: E501
-            'members_count': (int,),  # noqa: E501
+            'room_name': (str, none_type),  # noqa: E501
+            'room_description': (str, none_type),  # noqa: E501
+            'members': ([int], none_type),  # noqa: E501
+            'created_by_user_id': (int, none_type),  # noqa: E501
+            'created_date': (int, none_type),  # noqa: E501
+            'last_modified_date': (int, none_type),  # noqa: E501
+            'origin_company': (str, none_type),  # noqa: E501
+            'origin_company_id': (int, none_type),  # noqa: E501
+            'members_count': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -179,7 +180,15 @@ class AdminStreamAttributes(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.room_name: str = None
+        self.room_description: str = None
+        self.members: List[int] = None
+        self.created_by_user_id: int = None
+        self.created_date: int = None
+        self.last_modified_date: int = None
+        self.origin_company: str = None
+        self.origin_company_id: int = None
+        self.members_count: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/admin_stream_filter.py
+++ b/symphony/bdk/gen/pod_model/admin_stream_filter.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.admin_stream_type_enum import AdminStreamTypeEnum
-    globals()['AdminStreamTypeEnum'] = AdminStreamTypeEnum
+from symphony.bdk.gen.pod_model.admin_stream_type_enum import AdminStreamTypeEnum
+globals()['AdminStreamTypeEnum'] = AdminStreamTypeEnum
 
 
 class AdminStreamFilter(ModelNormal):
@@ -91,15 +91,14 @@ class AdminStreamFilter(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'stream_types': ([AdminStreamTypeEnum],),  # noqa: E501
-            'scope': (str,),  # noqa: E501
-            'origin': (str,),  # noqa: E501
-            'status': (str,),  # noqa: E501
-            'privacy': (str,),  # noqa: E501
-            'start_date': (int,),  # noqa: E501
-            'end_date': (int,),  # noqa: E501
+            'stream_types': ([AdminStreamTypeEnum], none_type),  # noqa: E501
+            'scope': (str, none_type),  # noqa: E501
+            'origin': (str, none_type),  # noqa: E501
+            'status': (str, none_type),  # noqa: E501
+            'privacy': (str, none_type),  # noqa: E501
+            'start_date': (int, none_type),  # noqa: E501
+            'end_date': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -194,7 +193,13 @@ class AdminStreamFilter(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.stream_types: List[AdminStreamTypeEnum] = None
+        self.scope: str = None
+        self.origin: str = None
+        self.status: str = None
+        self.privacy: str = None
+        self.start_date: int = None
+        self.end_date: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/admin_stream_info.py
+++ b/symphony/bdk/gen/pod_model/admin_stream_info.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.admin_stream_attributes import AdminStreamAttributes
-    globals()['AdminStreamAttributes'] = AdminStreamAttributes
+from symphony.bdk.gen.pod_model.admin_stream_attributes import AdminStreamAttributes
+globals()['AdminStreamAttributes'] = AdminStreamAttributes
 
 
 class AdminStreamInfo(ModelNormal):
@@ -75,14 +75,13 @@ class AdminStreamInfo(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'id': (str,),  # noqa: E501
-            'is_external': (bool,),  # noqa: E501
-            'is_active': (bool,),  # noqa: E501
-            'is_public': (bool,),  # noqa: E501
-            'type': (str,),  # noqa: E501
-            'attributes': (AdminStreamAttributes,),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
+            'is_external': (bool, none_type),  # noqa: E501
+            'is_active': (bool, none_type),  # noqa: E501
+            'is_public': (bool, none_type),  # noqa: E501
+            'type': (str, none_type),  # noqa: E501
+            'attributes': (AdminStreamAttributes, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -175,7 +174,12 @@ class AdminStreamInfo(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: str = None
+        self.is_external: bool = None
+        self.is_active: bool = None
+        self.is_public: bool = None
+        self.type: str = None
+        self.attributes: AdminStreamAttributes = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/admin_stream_info_list.py
+++ b/symphony/bdk/gen/pod_model/admin_stream_info_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.admin_stream_info import AdminStreamInfo
-    globals()['AdminStreamInfo'] = AdminStreamInfo
+from symphony.bdk.gen.pod_model.admin_stream_info import AdminStreamInfo
+globals()['AdminStreamInfo'] = AdminStreamInfo
 
 
 class AdminStreamInfoList(ModelSimple):
@@ -71,7 +71,6 @@ class AdminStreamInfoList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([AdminStreamInfo],),
         }
@@ -136,6 +135,8 @@ class AdminStreamInfoList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -151,7 +152,6 @@ class AdminStreamInfoList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -171,7 +171,7 @@ class AdminStreamInfoList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[AdminStreamInfo] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/admin_stream_list.py
+++ b/symphony/bdk/gen/pod_model/admin_stream_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.admin_stream_filter import AdminStreamFilter
-    from symphony.bdk.gen.pod_model.admin_stream_info_list import AdminStreamInfoList
-    globals()['AdminStreamFilter'] = AdminStreamFilter
-    globals()['AdminStreamInfoList'] = AdminStreamInfoList
+from symphony.bdk.gen.pod_model.admin_stream_filter import AdminStreamFilter
+from symphony.bdk.gen.pod_model.admin_stream_info_list import AdminStreamInfoList
+globals()['AdminStreamFilter'] = AdminStreamFilter
+globals()['AdminStreamInfoList'] = AdminStreamInfoList
 
 
 class AdminStreamList(ModelNormal):
@@ -77,13 +77,12 @@ class AdminStreamList(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'count': (int,),  # noqa: E501
-            'skip': (int,),  # noqa: E501
-            'limit': (int,),  # noqa: E501
-            'filter': (AdminStreamFilter,),  # noqa: E501
-            'streams': (AdminStreamInfoList,),  # noqa: E501
+            'count': (int, none_type),  # noqa: E501
+            'skip': (int, none_type),  # noqa: E501
+            'limit': (int, none_type),  # noqa: E501
+            'filter': (AdminStreamFilter, none_type),  # noqa: E501
+            'streams': (AdminStreamInfoList, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -174,7 +173,11 @@ class AdminStreamList(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.count: int = None
+        self.skip: int = None
+        self.limit: int = None
+        self.filter: AdminStreamFilter = None
+        self.streams: AdminStreamInfoList = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/admin_stream_type_enum.py
+++ b/symphony/bdk/gen/pod_model/admin_stream_type_enum.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -77,7 +78,7 @@ class AdminStreamTypeEnum(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'type': (str,),  # noqa: E501
+            'type': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -160,7 +161,7 @@ class AdminStreamTypeEnum(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.type: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/app_authentication_key.py
+++ b/symphony/bdk/gen/pod_model/app_authentication_key.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,9 +73,9 @@ class AppAuthenticationKey(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'key': (str,),  # noqa: E501
-            'expiration_date': (int,),  # noqa: E501
-            'action': (str,),  # noqa: E501
+            'key': (str, none_type),  # noqa: E501
+            'expiration_date': (int, none_type),  # noqa: E501
+            'action': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -161,7 +162,9 @@ class AppAuthenticationKey(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.key: str = None
+        self.expiration_date: int = None
+        self.action: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/app_authentication_keys.py
+++ b/symphony/bdk/gen/pod_model/app_authentication_keys.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.app_authentication_key import AppAuthenticationKey
-    globals()['AppAuthenticationKey'] = AppAuthenticationKey
+from symphony.bdk.gen.pod_model.app_authentication_key import AppAuthenticationKey
+globals()['AppAuthenticationKey'] = AppAuthenticationKey
 
 
 class AppAuthenticationKeys(ModelNormal):
@@ -75,10 +75,9 @@ class AppAuthenticationKeys(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'current': (AppAuthenticationKey,),  # noqa: E501
-            'previous': (AppAuthenticationKey,),  # noqa: E501
+            'current': (AppAuthenticationKey, none_type),  # noqa: E501
+            'previous': (AppAuthenticationKey, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -163,7 +162,8 @@ class AppAuthenticationKeys(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.current: AppAuthenticationKey = None
+        self.previous: AppAuthenticationKey = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/app_notification.py
+++ b/symphony/bdk/gen/pod_model/app_notification.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,8 +73,8 @@ class AppNotification(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'url': (str,),  # noqa: E501
-            'api_key': (str,),  # noqa: E501
+            'url': (str, none_type),  # noqa: E501
+            'api_key': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -158,7 +159,8 @@ class AppNotification(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.url: str = None
+        self.api_key: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/application_detail.py
+++ b/symphony/bdk/gen/pod_model/application_detail.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,13 +27,12 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.app_authentication_keys import AppAuthenticationKeys
-    from symphony.bdk.gen.pod_model.app_notification import AppNotification
-    from symphony.bdk.gen.pod_model.application_info import ApplicationInfo
-    globals()['AppAuthenticationKeys'] = AppAuthenticationKeys
-    globals()['AppNotification'] = AppNotification
-    globals()['ApplicationInfo'] = ApplicationInfo
+from symphony.bdk.gen.pod_model.app_authentication_keys import AppAuthenticationKeys
+from symphony.bdk.gen.pod_model.app_notification import AppNotification
+from symphony.bdk.gen.pod_model.application_info import ApplicationInfo
+globals()['AppAuthenticationKeys'] = AppAuthenticationKeys
+globals()['AppNotification'] = AppNotification
+globals()['ApplicationInfo'] = ApplicationInfo
 
 
 class ApplicationDetail(ModelNormal):
@@ -79,16 +79,15 @@ class ApplicationDetail(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'application_info': (ApplicationInfo,),  # noqa: E501
-            'icon_url': (str,),  # noqa: E501
-            'description': (str,),  # noqa: E501
-            'allow_origins': (str,),  # noqa: E501
-            'permissions': ([str],),  # noqa: E501
-            'cert': (str,),  # noqa: E501
-            'authentication_keys': (AppAuthenticationKeys,),  # noqa: E501
-            'notification': (AppNotification,),  # noqa: E501
+            'application_info': (ApplicationInfo, none_type),  # noqa: E501
+            'icon_url': (str, none_type),  # noqa: E501
+            'description': (str, none_type),  # noqa: E501
+            'allow_origins': (str, none_type),  # noqa: E501
+            'permissions': ([str], none_type),  # noqa: E501
+            'cert': (str, none_type),  # noqa: E501
+            'authentication_keys': (AppAuthenticationKeys, none_type),  # noqa: E501
+            'notification': (AppNotification, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -185,7 +184,14 @@ class ApplicationDetail(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.application_info: ApplicationInfo = None
+        self.icon_url: str = None
+        self.description: str = None
+        self.allow_origins: str = None
+        self.permissions: List[str] = None
+        self.cert: str = None
+        self.authentication_keys: AppAuthenticationKeys = None
+        self.notification: AppNotification = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/application_info.py
+++ b/symphony/bdk/gen/pod_model/application_info.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,11 +73,11 @@ class ApplicationInfo(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'app_id': (str,),  # noqa: E501
-            'name': (str,),  # noqa: E501
-            'app_url': (str,),  # noqa: E501
-            'domain': (str,),  # noqa: E501
-            'publisher': (str,),  # noqa: E501
+            'app_id': (str, none_type),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
+            'app_url': (str, none_type),  # noqa: E501
+            'domain': (str, none_type),  # noqa: E501
+            'publisher': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -167,7 +168,11 @@ class ApplicationInfo(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.app_id: str = None
+        self.name: str = None
+        self.app_url: str = None
+        self.domain: str = None
+        self.publisher: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/assignee_candidate.py
+++ b/symphony/bdk/gen/pod_model/assignee_candidate.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.string_list import StringList
-    globals()['StringList'] = StringList
+from symphony.bdk.gen.pod_model.string_list import StringList
+globals()['StringList'] = StringList
 
 
 class AssigneeCandidate(ModelNormal):
@@ -75,15 +75,14 @@ class AssigneeCandidate(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'user_id': (int,),  # noqa: E501
-            'username': (str,),  # noqa: E501
-            'first_name': (str,),  # noqa: E501
-            'surname': (str,),  # noqa: E501
-            'email_address': (str,),  # noqa: E501
-            'can_be_assigned': (bool,),  # noqa: E501
-            'roles': (StringList,),  # noqa: E501
+            'user_id': (int, none_type),  # noqa: E501
+            'username': (str, none_type),  # noqa: E501
+            'first_name': (str, none_type),  # noqa: E501
+            'surname': (str, none_type),  # noqa: E501
+            'email_address': (str, none_type),  # noqa: E501
+            'can_be_assigned': (bool, none_type),  # noqa: E501
+            'roles': (StringList, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -178,7 +177,13 @@ class AssigneeCandidate(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.user_id: int = None
+        self.username: str = None
+        self.first_name: str = None
+        self.surname: str = None
+        self.email_address: str = None
+        self.can_be_assigned: bool = None
+        self.roles: StringList = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/assignee_candidates.py
+++ b/symphony/bdk/gen/pod_model/assignee_candidates.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.assignee_candidate import AssigneeCandidate
-    from symphony.bdk.gen.pod_model.pagination import Pagination
-    globals()['AssigneeCandidate'] = AssigneeCandidate
-    globals()['Pagination'] = Pagination
+from symphony.bdk.gen.pod_model.assignee_candidate import AssigneeCandidate
+from symphony.bdk.gen.pod_model.pagination import Pagination
+globals()['AssigneeCandidate'] = AssigneeCandidate
+globals()['Pagination'] = Pagination
 
 
 class AssigneeCandidates(ModelNormal):
@@ -77,10 +77,9 @@ class AssigneeCandidates(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'users': ([AssigneeCandidate],),  # noqa: E501
-            'pagination': (Pagination,),  # noqa: E501
+            'users': ([AssigneeCandidate], none_type),  # noqa: E501
+            'pagination': (Pagination, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -165,7 +164,8 @@ class AssigneeCandidates(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.users: List[AssigneeCandidate] = None
+        self.pagination: Pagination = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/attachment_preview.py
+++ b/symphony/bdk/gen/pod_model/attachment_preview.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,8 +73,8 @@ class AttachmentPreview(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'file_id': (str,),  # noqa: E501
-            'width': (int,),  # noqa: E501
+            'file_id': (str, none_type),  # noqa: E501
+            'width': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -158,7 +159,8 @@ class AttachmentPreview(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.file_id: str = None
+        self.width: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/avatar.py
+++ b/symphony/bdk/gen/pod_model/avatar.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,8 +73,8 @@ class Avatar(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'size': (str,),  # noqa: E501
-            'url': (str,),  # noqa: E501
+            'size': (str, none_type),  # noqa: E501
+            'url': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -158,7 +159,8 @@ class Avatar(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.size: str = None
+        self.url: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/avatar_list.py
+++ b/symphony/bdk/gen/pod_model/avatar_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.avatar import Avatar
-    globals()['Avatar'] = Avatar
+from symphony.bdk.gen.pod_model.avatar import Avatar
+globals()['Avatar'] = Avatar
 
 
 class AvatarList(ModelSimple):
@@ -71,7 +71,6 @@ class AvatarList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([Avatar],),
         }
@@ -136,6 +135,8 @@ class AvatarList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -151,7 +152,6 @@ class AvatarList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -171,7 +171,7 @@ class AvatarList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[Avatar] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/avatar_update.py
+++ b/symphony/bdk/gen/pod_model/avatar_update.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,7 +73,7 @@ class AvatarUpdate(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'image': (str,),  # noqa: E501
+            'image': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -155,7 +156,7 @@ class AvatarUpdate(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.image: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/bulk_action_result.py
+++ b/symphony/bdk/gen/pod_model/bulk_action_result.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -76,8 +77,8 @@ class BulkActionResult(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'overall_result': (str,),  # noqa: E501
-            'results': ([str],),  # noqa: E501
+            'overall_result': (str, none_type),  # noqa: E501
+            'results': ([str], none_type),  # noqa: E501
         }
 
     @cached_property
@@ -162,7 +163,8 @@ class BulkActionResult(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.overall_result: str = None
+        self.results: List[str] = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/cert_info.py
+++ b/symphony/bdk/gen/pod_model/cert_info.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.cert_info_item import CertInfoItem
-    globals()['CertInfoItem'] = CertInfoItem
+from symphony.bdk.gen.pod_model.cert_info_item import CertInfoItem
+globals()['CertInfoItem'] = CertInfoItem
 
 
 class CertInfo(ModelSimple):
@@ -71,7 +71,6 @@ class CertInfo(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([CertInfoItem],),
         }
@@ -136,6 +135,8 @@ class CertInfo(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -151,7 +152,6 @@ class CertInfo(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -171,7 +171,7 @@ class CertInfo(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[CertInfoItem] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/cert_info_item.py
+++ b/symphony/bdk/gen/pod_model/cert_info_item.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.name_value_pair import NameValuePair
-    globals()['NameValuePair'] = NameValuePair
+from symphony.bdk.gen.pod_model.name_value_pair import NameValuePair
+globals()['NameValuePair'] = NameValuePair
 
 
 class CertInfoItem(ModelNormal):
@@ -75,10 +75,9 @@ class CertInfoItem(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'name': (str,),  # noqa: E501
-            'attributes': ([NameValuePair],),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
+            'attributes': ([NameValuePair], none_type),  # noqa: E501
         }
 
     @cached_property
@@ -163,7 +162,8 @@ class CertInfoItem(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.name: str = None
+        self.attributes: List[NameValuePair] = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/company_cert.py
+++ b/symphony/bdk/gen/pod_model/company_cert.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.company_cert_attributes import CompanyCertAttributes
-    globals()['CompanyCertAttributes'] = CompanyCertAttributes
+from symphony.bdk.gen.pod_model.company_cert_attributes import CompanyCertAttributes
+globals()['CompanyCertAttributes'] = CompanyCertAttributes
 
 
 class CompanyCert(ModelNormal):
@@ -75,10 +75,9 @@ class CompanyCert(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'pem': (str,),  # noqa: E501
-            'attributes': (CompanyCertAttributes,),  # noqa: E501
+            'pem': (str, none_type),  # noqa: E501
+            'attributes': (CompanyCertAttributes, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -163,7 +162,8 @@ class CompanyCert(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.pem: str = None
+        self.attributes: CompanyCertAttributes = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/company_cert_attributes.py
+++ b/symphony/bdk/gen/pod_model/company_cert_attributes.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.company_cert_status import CompanyCertStatus
-    from symphony.bdk.gen.pod_model.company_cert_type import CompanyCertType
-    globals()['CompanyCertStatus'] = CompanyCertStatus
-    globals()['CompanyCertType'] = CompanyCertType
+from symphony.bdk.gen.pod_model.company_cert_status import CompanyCertStatus
+from symphony.bdk.gen.pod_model.company_cert_type import CompanyCertType
+globals()['CompanyCertStatus'] = CompanyCertStatus
+globals()['CompanyCertType'] = CompanyCertType
 
 
 class CompanyCertAttributes(ModelNormal):
@@ -77,11 +77,10 @@ class CompanyCertAttributes(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'name': (str,),  # noqa: E501
-            'type': (CompanyCertType,),  # noqa: E501
-            'status': (CompanyCertStatus,),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
+            'type': (CompanyCertType, none_type),  # noqa: E501
+            'status': (CompanyCertStatus, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -168,7 +167,9 @@ class CompanyCertAttributes(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.name: str = None
+        self.type: CompanyCertType = None
+        self.status: CompanyCertStatus = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/company_cert_detail.py
+++ b/symphony/bdk/gen/pod_model/company_cert_detail.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,13 +27,12 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.cert_info import CertInfo
-    from symphony.bdk.gen.pod_model.company_cert_attributes import CompanyCertAttributes
-    from symphony.bdk.gen.pod_model.company_cert_info import CompanyCertInfo
-    globals()['CertInfo'] = CertInfo
-    globals()['CompanyCertAttributes'] = CompanyCertAttributes
-    globals()['CompanyCertInfo'] = CompanyCertInfo
+from symphony.bdk.gen.pod_model.cert_info import CertInfo
+from symphony.bdk.gen.pod_model.company_cert_attributes import CompanyCertAttributes
+from symphony.bdk.gen.pod_model.company_cert_info import CompanyCertInfo
+globals()['CertInfo'] = CertInfo
+globals()['CompanyCertAttributes'] = CompanyCertAttributes
+globals()['CompanyCertInfo'] = CompanyCertInfo
 
 
 class CompanyCertDetail(ModelNormal):
@@ -79,11 +79,10 @@ class CompanyCertDetail(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'company_cert_attributes': (CompanyCertAttributes,),  # noqa: E501
-            'company_cert_info': (CompanyCertInfo,),  # noqa: E501
-            'cert_info': (CertInfo,),  # noqa: E501
+            'company_cert_attributes': (CompanyCertAttributes, none_type),  # noqa: E501
+            'company_cert_info': (CompanyCertInfo, none_type),  # noqa: E501
+            'cert_info': (CertInfo, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -170,7 +169,9 @@ class CompanyCertDetail(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.company_cert_attributes: CompanyCertAttributes = None
+        self.company_cert_info: CompanyCertInfo = None
+        self.cert_info: CertInfo = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/company_cert_info.py
+++ b/symphony/bdk/gen/pod_model/company_cert_info.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,13 +73,13 @@ class CompanyCertInfo(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'finger_print': (str,),  # noqa: E501
-            'issuer_finger_print': (str,),  # noqa: E501
-            'last_seen': (int,),  # noqa: E501
-            'updated_at': (int,),  # noqa: E501
-            'updated_by': (int,),  # noqa: E501
-            'common_name': (str,),  # noqa: E501
-            'expiry_date': (int,),  # noqa: E501
+            'finger_print': (str, none_type),  # noqa: E501
+            'issuer_finger_print': (str, none_type),  # noqa: E501
+            'last_seen': (int, none_type),  # noqa: E501
+            'updated_at': (int, none_type),  # noqa: E501
+            'updated_by': (int, none_type),  # noqa: E501
+            'common_name': (str, none_type),  # noqa: E501
+            'expiry_date': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -173,7 +174,13 @@ class CompanyCertInfo(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.finger_print: str = None
+        self.issuer_finger_print: str = None
+        self.last_seen: int = None
+        self.updated_at: int = None
+        self.updated_by: int = None
+        self.common_name: str = None
+        self.expiry_date: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/company_cert_info_list.py
+++ b/symphony/bdk/gen/pod_model/company_cert_info_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -131,6 +132,8 @@ class CompanyCertInfoList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -146,7 +149,6 @@ class CompanyCertInfoList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -166,7 +168,7 @@ class CompanyCertInfoList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[{str: (bool, date, datetime, dict, float, int, list, str, none_type)}] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/company_cert_status.py
+++ b/symphony/bdk/gen/pod_model/company_cert_status.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -78,7 +79,7 @@ class CompanyCertStatus(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'type': (str,),  # noqa: E501
+            'type': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -161,7 +162,7 @@ class CompanyCertStatus(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.type: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/company_cert_type.py
+++ b/symphony/bdk/gen/pod_model/company_cert_type.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -78,7 +79,7 @@ class CompanyCertType(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'type': (str,),  # noqa: E501
+            'type': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -161,7 +162,7 @@ class CompanyCertType(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.type: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/company_cert_type_list.py
+++ b/symphony/bdk/gen/pod_model/company_cert_type_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.company_cert_type import CompanyCertType
-    globals()['CompanyCertType'] = CompanyCertType
+from symphony.bdk.gen.pod_model.company_cert_type import CompanyCertType
+globals()['CompanyCertType'] = CompanyCertType
 
 
 class CompanyCertTypeList(ModelSimple):
@@ -71,7 +71,6 @@ class CompanyCertTypeList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([CompanyCertType],),
         }
@@ -136,6 +135,8 @@ class CompanyCertTypeList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -151,7 +152,6 @@ class CompanyCertTypeList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -171,7 +171,7 @@ class CompanyCertTypeList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[CompanyCertType] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/conversation_specific_stream_attributes.py
+++ b/symphony/bdk/gen/pod_model/conversation_specific_stream_attributes.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.user_id_list import UserIdList
-    globals()['UserIdList'] = UserIdList
+from symphony.bdk.gen.pod_model.user_id_list import UserIdList
+globals()['UserIdList'] = UserIdList
 
 
 class ConversationSpecificStreamAttributes(ModelNormal):
@@ -75,9 +75,8 @@ class ConversationSpecificStreamAttributes(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'members': (UserIdList,),  # noqa: E501
+            'members': (UserIdList, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -160,7 +159,7 @@ class ConversationSpecificStreamAttributes(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.members: UserIdList = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/delegate_action.py
+++ b/symphony/bdk/gen/pod_model/delegate_action.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -76,8 +77,8 @@ class DelegateAction(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'user_id': (int,),  # noqa: E501
-            'action': (str,),  # noqa: E501
+            'user_id': (int, none_type),  # noqa: E501
+            'action': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -162,7 +163,8 @@ class DelegateAction(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.user_id: int = None
+        self.action: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/disclaimer.py
+++ b/symphony/bdk/gen/pod_model/disclaimer.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -76,15 +77,15 @@ class Disclaimer(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'id': (str,),  # noqa: E501
-            'name': (str,),  # noqa: E501
-            'content': (str,),  # noqa: E501
-            'frequency_in_hours': (int,),  # noqa: E501
-            'is_default': (bool,),  # noqa: E501
-            'is_active': (bool,),  # noqa: E501
-            'created_date': (int,),  # noqa: E501
-            'modified_date': (int,),  # noqa: E501
-            'format': (str,),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
+            'content': (str, none_type),  # noqa: E501
+            'frequency_in_hours': (int, none_type),  # noqa: E501
+            'is_default': (bool, none_type),  # noqa: E501
+            'is_active': (bool, none_type),  # noqa: E501
+            'created_date': (int, none_type),  # noqa: E501
+            'modified_date': (int, none_type),  # noqa: E501
+            'format': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -183,7 +184,15 @@ class Disclaimer(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: str = None
+        self.name: str = None
+        self.content: str = None
+        self.frequency_in_hours: int = None
+        self.is_default: bool = None
+        self.is_active: bool = None
+        self.created_date: int = None
+        self.modified_date: int = None
+        self.format: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/disclaimer_list.py
+++ b/symphony/bdk/gen/pod_model/disclaimer_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.disclaimer import Disclaimer
-    globals()['Disclaimer'] = Disclaimer
+from symphony.bdk.gen.pod_model.disclaimer import Disclaimer
+globals()['Disclaimer'] = Disclaimer
 
 
 class DisclaimerList(ModelSimple):
@@ -71,7 +71,6 @@ class DisclaimerList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([Disclaimer],),
         }
@@ -136,6 +135,8 @@ class DisclaimerList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -151,7 +152,6 @@ class DisclaimerList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -171,7 +171,7 @@ class DisclaimerList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[Disclaimer] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/download_receipt_count.py
+++ b/symphony/bdk/gen/pod_model/download_receipt_count.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,8 +73,8 @@ class DownloadReceiptCount(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'file_name': (str,),  # noqa: E501
-            'timestamp': (int,),  # noqa: E501
+            'file_name': (str, none_type),  # noqa: E501
+            'timestamp': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -158,7 +159,8 @@ class DownloadReceiptCount(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.file_name: str = None
+        self.timestamp: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/error.py
+++ b/symphony/bdk/gen/pod_model/error.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,8 +73,8 @@ class Error(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'code': (int,),  # noqa: E501
-            'message': (str,),  # noqa: E501
+            'code': (int, none_type),  # noqa: E501
+            'message': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -158,7 +159,8 @@ class Error(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.code: int = None
+        self.message: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/faceted_match_count.py
+++ b/symphony/bdk/gen/pod_model/faceted_match_count.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,8 +73,8 @@ class FacetedMatchCount(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'facet': (str,),  # noqa: E501
-            'count': (int,),  # noqa: E501
+            'facet': (str, none_type),  # noqa: E501
+            'count': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -158,7 +159,8 @@ class FacetedMatchCount(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.facet: str = None
+        self.count: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/feature.py
+++ b/symphony/bdk/gen/pod_model/feature.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,8 +73,8 @@ class Feature(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'entitlment': (str,),  # noqa: E501
-            'enabled': (bool,),  # noqa: E501
+            'entitlment': (str, none_type),  # noqa: E501
+            'enabled': (bool, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -158,7 +159,8 @@ class Feature(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.entitlment: str = None
+        self.enabled: bool = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/feature_list.py
+++ b/symphony/bdk/gen/pod_model/feature_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.feature import Feature
-    globals()['Feature'] = Feature
+from symphony.bdk.gen.pod_model.feature import Feature
+globals()['Feature'] = Feature
 
 
 class FeatureList(ModelSimple):
@@ -71,7 +71,6 @@ class FeatureList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([Feature],),
         }
@@ -136,6 +135,8 @@ class FeatureList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -151,7 +152,6 @@ class FeatureList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -171,7 +171,7 @@ class FeatureList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[Feature] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/file_extension.py
+++ b/symphony/bdk/gen/pod_model/file_extension.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -77,9 +78,9 @@ class FileExtension(ModelNormal):
         """
         return {
             'extension': (str,),  # noqa: E501
-            'scope_internal': (bool,),  # noqa: E501
-            'scope_external': (bool,),  # noqa: E501
-            'source': (str,),  # noqa: E501
+            'scope_internal': (bool, none_type),  # noqa: E501
+            'scope_external': (bool, none_type),  # noqa: E501
+            'source': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -170,8 +171,10 @@ class FileExtension(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.extension = extension
+        self.extension: str = extension
+        self.scope_internal: bool = None
+        self.scope_external: bool = None
+        self.source: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/file_extensions_response.py
+++ b/symphony/bdk/gen/pod_model/file_extensions_response.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.file_extension import FileExtension
-    globals()['FileExtension'] = FileExtension
+from symphony.bdk.gen.pod_model.file_extension import FileExtension
+globals()['FileExtension'] = FileExtension
 
 
 class FileExtensionsResponse(ModelNormal):
@@ -75,7 +75,6 @@ class FileExtensionsResponse(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'data': ([FileExtension],),  # noqa: E501
         }
@@ -162,8 +161,7 @@ class FileExtensionsResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.data = data
+        self.data: List[FileExtension] = data
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/followers_list.py
+++ b/symphony/bdk/gen/pod_model/followers_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.user_id_list import UserIdList
-    globals()['UserIdList'] = UserIdList
+from symphony.bdk.gen.pod_model.user_id_list import UserIdList
+globals()['UserIdList'] = UserIdList
 
 
 class FollowersList(ModelNormal):
@@ -75,9 +75,8 @@ class FollowersList(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'followers': (UserIdList,),  # noqa: E501
+            'followers': (UserIdList, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -160,7 +159,7 @@ class FollowersList(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.followers: UserIdList = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/followers_list_response.py
+++ b/symphony/bdk/gen/pod_model/followers_list_response.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.pagination import Pagination
-    globals()['Pagination'] = Pagination
+from symphony.bdk.gen.pod_model.pagination import Pagination
+globals()['Pagination'] = Pagination
 
 
 class FollowersListResponse(ModelNormal):
@@ -75,11 +75,10 @@ class FollowersListResponse(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'count': (int,),  # noqa: E501
-            'followers': ([int],),  # noqa: E501
-            'pagination': (Pagination,),  # noqa: E501
+            'count': (int, none_type),  # noqa: E501
+            'followers': ([int], none_type),  # noqa: E501
+            'pagination': (Pagination, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -166,7 +165,9 @@ class FollowersListResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.count: int = None
+        self.followers: List[int] = None
+        self.pagination: Pagination = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/following_list_response.py
+++ b/symphony/bdk/gen/pod_model/following_list_response.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.pagination import Pagination
-    globals()['Pagination'] = Pagination
+from symphony.bdk.gen.pod_model.pagination import Pagination
+globals()['Pagination'] = Pagination
 
 
 class FollowingListResponse(ModelNormal):
@@ -75,11 +75,10 @@ class FollowingListResponse(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'count': (int,),  # noqa: E501
-            'following': ([int],),  # noqa: E501
-            'pagination': (Pagination,),  # noqa: E501
+            'count': (int, none_type),  # noqa: E501
+            'following': ([int], none_type),  # noqa: E501
+            'pagination': (Pagination, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -166,7 +165,9 @@ class FollowingListResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.count: int = None
+        self.following: List[int] = None
+        self.pagination: Pagination = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/group.py
+++ b/symphony/bdk/gen/pod_model/group.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,13 +73,13 @@ class Group(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'id': (str,),  # noqa: E501
-            'name': (str,),  # noqa: E501
-            'active': (bool,),  # noqa: E501
-            'member_count': (int,),  # noqa: E501
-            'policies': ([str],),  # noqa: E501
-            'created_date': (int,),  # noqa: E501
-            'modified_date': (int,),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
+            'active': (bool, none_type),  # noqa: E501
+            'member_count': (int, none_type),  # noqa: E501
+            'policies': ([str], none_type),  # noqa: E501
+            'created_date': (int, none_type),  # noqa: E501
+            'modified_date': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -173,7 +174,13 @@ class Group(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: str = None
+        self.name: str = None
+        self.active: bool = None
+        self.member_count: int = None
+        self.policies: List[str] = None
+        self.created_date: int = None
+        self.modified_date: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/group_list.py
+++ b/symphony/bdk/gen/pod_model/group_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.group import Group
-    globals()['Group'] = Group
+from symphony.bdk.gen.pod_model.group import Group
+globals()['Group'] = Group
 
 
 class GroupList(ModelSimple):
@@ -71,7 +71,6 @@ class GroupList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([Group],),
         }
@@ -136,6 +135,8 @@ class GroupList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -151,7 +152,6 @@ class GroupList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -171,7 +171,7 @@ class GroupList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[Group] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/group_role_scope.py
+++ b/symphony/bdk/gen/pod_model/group_role_scope.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,11 +73,11 @@ class GroupRoleScope(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'id': (str,),  # noqa: E501
-            'name': (str,),  # noqa: E501
-            'area': (str,),  # noqa: E501
-            'type': (str,),  # noqa: E501
-            'active': (bool,),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
+            'area': (str, none_type),  # noqa: E501
+            'type': (str, none_type),  # noqa: E501
+            'active': (bool, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -167,7 +168,11 @@ class GroupRoleScope(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: str = None
+        self.name: str = None
+        self.area: str = None
+        self.type: str = None
+        self.active: bool = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/immutable_room_attributes.py
+++ b/symphony/bdk/gen/pod_model/immutable_room_attributes.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,9 +73,9 @@ class ImmutableRoomAttributes(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'public': (bool,),  # noqa: E501
-            'read_only': (bool,),  # noqa: E501
-            'copy_protected': (bool,),  # noqa: E501
+            'public': (bool, none_type),  # noqa: E501
+            'read_only': (bool, none_type),  # noqa: E501
+            'copy_protected': (bool, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -161,7 +162,9 @@ class ImmutableRoomAttributes(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.public: bool = None
+        self.read_only: bool = None
+        self.copy_protected: bool = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/integer_list.py
+++ b/symphony/bdk/gen/pod_model/integer_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -131,6 +132,8 @@ class IntegerList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -146,7 +149,6 @@ class IntegerList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -166,7 +168,7 @@ class IntegerList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[int] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/languages.py
+++ b/symphony/bdk/gen/pod_model/languages.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.string_list import StringList
-    globals()['StringList'] = StringList
+from symphony.bdk.gen.pod_model.string_list import StringList
+globals()['StringList'] = StringList
 
 
 class Languages(ModelNormal):
@@ -75,9 +75,8 @@ class Languages(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'languages': (StringList,),  # noqa: E501
+            'languages': (StringList, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -160,7 +159,7 @@ class Languages(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.languages: StringList = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/member_info.py
+++ b/symphony/bdk/gen/pod_model/member_info.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,9 +73,9 @@ class MemberInfo(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'id': (int,),  # noqa: E501
-            'owner': (bool,),  # noqa: E501
-            'join_date': (int,),  # noqa: E501
+            'id': (int, none_type),  # noqa: E501
+            'owner': (bool, none_type),  # noqa: E501
+            'join_date': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -161,7 +162,9 @@ class MemberInfo(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: int = None
+        self.owner: bool = None
+        self.join_date: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/membership_data.py
+++ b/symphony/bdk/gen/pod_model/membership_data.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,11 +73,11 @@ class MembershipData(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'id': (int,),  # noqa: E501
-            'user_name': (str,),  # noqa: E501
-            'first_name': (str,),  # noqa: E501
-            'last_name': (str,),  # noqa: E501
-            'email_address': (str,),  # noqa: E501
+            'id': (int, none_type),  # noqa: E501
+            'user_name': (str, none_type),  # noqa: E501
+            'first_name': (str, none_type),  # noqa: E501
+            'last_name': (str, none_type),  # noqa: E501
+            'email_address': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -167,7 +168,11 @@ class MembershipData(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: int = None
+        self.user_name: str = None
+        self.first_name: str = None
+        self.last_name: str = None
+        self.email_address: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/membership_list.py
+++ b/symphony/bdk/gen/pod_model/membership_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.member_info import MemberInfo
-    globals()['MemberInfo'] = MemberInfo
+from symphony.bdk.gen.pod_model.member_info import MemberInfo
+globals()['MemberInfo'] = MemberInfo
 
 
 class MembershipList(ModelSimple):
@@ -71,7 +71,6 @@ class MembershipList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([MemberInfo],),
         }
@@ -136,6 +135,8 @@ class MembershipList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -151,7 +152,6 @@ class MembershipList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -171,7 +171,7 @@ class MembershipList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[MemberInfo] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/message_detail.py
+++ b/symphony/bdk/gen/pod_model/message_detail.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,13 +27,12 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.message_download_receipt_count import MessageDownloadReceiptCount
-    from symphony.bdk.gen.pod_model.message_stream import MessageStream
-    from symphony.bdk.gen.pod_model.message_user import MessageUser
-    globals()['MessageDownloadReceiptCount'] = MessageDownloadReceiptCount
-    globals()['MessageStream'] = MessageStream
-    globals()['MessageUser'] = MessageUser
+from symphony.bdk.gen.pod_model.message_download_receipt_count import MessageDownloadReceiptCount
+from symphony.bdk.gen.pod_model.message_stream import MessageStream
+from symphony.bdk.gen.pod_model.message_user import MessageUser
+globals()['MessageDownloadReceiptCount'] = MessageDownloadReceiptCount
+globals()['MessageStream'] = MessageStream
+globals()['MessageUser'] = MessageUser
 
 
 class MessageDetail(ModelNormal):
@@ -79,17 +79,16 @@ class MessageDetail(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'message_id': (str,),  # noqa: E501
-            'creator': (MessageUser,),  # noqa: E501
-            'on_behalf_of_user': (MessageUser,),  # noqa: E501
-            'stream': (MessageStream,),  # noqa: E501
-            'creation_date': (int,),  # noqa: E501
-            'delivery_receipt_count': (int,),  # noqa: E501
-            'read_receipt_count': (int,),  # noqa: E501
-            'email_notification_count': (int,),  # noqa: E501
-            'download_receipt_counts': ([MessageDownloadReceiptCount],),  # noqa: E501
+            'message_id': (str, none_type),  # noqa: E501
+            'creator': (MessageUser, none_type),  # noqa: E501
+            'on_behalf_of_user': (MessageUser, none_type),  # noqa: E501
+            'stream': (MessageStream, none_type),  # noqa: E501
+            'creation_date': (int, none_type),  # noqa: E501
+            'delivery_receipt_count': (int, none_type),  # noqa: E501
+            'read_receipt_count': (int, none_type),  # noqa: E501
+            'email_notification_count': (int, none_type),  # noqa: E501
+            'download_receipt_counts': ([MessageDownloadReceiptCount], none_type),  # noqa: E501
         }
 
     @cached_property
@@ -188,7 +187,15 @@ class MessageDetail(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.message_id: str = None
+        self.creator: MessageUser = None
+        self.on_behalf_of_user: MessageUser = None
+        self.stream: MessageStream = None
+        self.creation_date: int = None
+        self.delivery_receipt_count: int = None
+        self.read_receipt_count: int = None
+        self.email_notification_count: int = None
+        self.download_receipt_counts: List[MessageDownloadReceiptCount] = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/message_details.py
+++ b/symphony/bdk/gen/pod_model/message_details.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.message_detail import MessageDetail
-    globals()['MessageDetail'] = MessageDetail
+from symphony.bdk.gen.pod_model.message_detail import MessageDetail
+globals()['MessageDetail'] = MessageDetail
 
 
 class MessageDetails(ModelSimple):
@@ -71,7 +71,6 @@ class MessageDetails(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([MessageDetail],),
         }
@@ -136,6 +135,8 @@ class MessageDetails(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -151,7 +152,6 @@ class MessageDetails(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -171,7 +171,7 @@ class MessageDetails(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[MessageDetail] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/message_download_receipt_count.py
+++ b/symphony/bdk/gen/pod_model/message_download_receipt_count.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,8 +73,8 @@ class MessageDownloadReceiptCount(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'file_name': (str,),  # noqa: E501
-            'count': (int,),  # noqa: E501
+            'file_name': (str, none_type),  # noqa: E501
+            'count': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -158,7 +159,8 @@ class MessageDownloadReceiptCount(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.file_name: str = None
+        self.count: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/message_ids.py
+++ b/symphony/bdk/gen/pod_model/message_ids.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.string_list import StringList
-    globals()['StringList'] = StringList
+from symphony.bdk.gen.pod_model.string_list import StringList
+globals()['StringList'] = StringList
 
 
 class MessageIds(ModelNormal):
@@ -75,9 +75,8 @@ class MessageIds(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'message_ids': (StringList,),  # noqa: E501
+            'message_ids': (StringList, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -160,7 +159,7 @@ class MessageIds(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.message_ids: StringList = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/message_ids_from_stream.py
+++ b/symphony/bdk/gen/pod_model/message_ids_from_stream.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,10 +73,10 @@ class MessageIdsFromStream(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'data': ([str],),  # noqa: E501
-            'total_number_found': (int,),  # noqa: E501
-            'number_returned': (int,),  # noqa: E501
-            'next_start_number': (int,),  # noqa: E501
+            'data': ([str], none_type),  # noqa: E501
+            'total_number_found': (int, none_type),  # noqa: E501
+            'number_returned': (int, none_type),  # noqa: E501
+            'next_start_number': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -164,7 +165,10 @@ class MessageIdsFromStream(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.data: List[str] = None
+        self.total_number_found: int = None
+        self.number_returned: int = None
+        self.next_start_number: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/message_metadata_response.py
+++ b/symphony/bdk/gen/pod_model/message_metadata_response.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.message_metadata_response_parent import MessageMetadataResponseParent
-    globals()['MessageMetadataResponseParent'] = MessageMetadataResponseParent
+from symphony.bdk.gen.pod_model.message_metadata_response_parent import MessageMetadataResponseParent
+globals()['MessageMetadataResponseParent'] = MessageMetadataResponseParent
 
 
 class MessageMetadataResponse(ModelNormal):
@@ -75,13 +75,12 @@ class MessageMetadataResponse(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'message_id': (str,),  # noqa: E501
-            'parent': (MessageMetadataResponseParent,),  # noqa: E501
-            'replies': ([str],),  # noqa: E501
-            'forwards': ([str],),  # noqa: E501
-            'form_replies': ([str],),  # noqa: E501
+            'message_id': (str, none_type),  # noqa: E501
+            'parent': (MessageMetadataResponseParent, none_type),  # noqa: E501
+            'replies': ([str], none_type),  # noqa: E501
+            'forwards': ([str], none_type),  # noqa: E501
+            'form_replies': ([str], none_type),  # noqa: E501
         }
 
     @cached_property
@@ -172,7 +171,11 @@ class MessageMetadataResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.message_id: str = None
+        self.parent: MessageMetadataResponseParent = None
+        self.replies: List[str] = None
+        self.forwards: List[str] = None
+        self.form_replies: List[str] = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/message_metadata_response_parent.py
+++ b/symphony/bdk/gen/pod_model/message_metadata_response_parent.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -77,8 +78,8 @@ class MessageMetadataResponseParent(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'message_id': (str,),  # noqa: E501
-            'relationship_type': (str,),  # noqa: E501
+            'message_id': (str, none_type),  # noqa: E501
+            'relationship_type': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -163,7 +164,8 @@ class MessageMetadataResponseParent(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.message_id: str = None
+        self.relationship_type: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/message_receipt_detail.py
+++ b/symphony/bdk/gen/pod_model/message_receipt_detail.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.download_receipt_count import DownloadReceiptCount
-    from symphony.bdk.gen.pod_model.user_compp import UserCompp
-    globals()['DownloadReceiptCount'] = DownloadReceiptCount
-    globals()['UserCompp'] = UserCompp
+from symphony.bdk.gen.pod_model.download_receipt_count import DownloadReceiptCount
+from symphony.bdk.gen.pod_model.user_compp import UserCompp
+globals()['DownloadReceiptCount'] = DownloadReceiptCount
+globals()['UserCompp'] = UserCompp
 
 
 class MessageReceiptDetail(ModelNormal):
@@ -77,13 +77,12 @@ class MessageReceiptDetail(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'user': (UserCompp,),  # noqa: E501
-            'delivery_receipt_timestamp': (int,),  # noqa: E501
-            'read_receipt_timestamp': (int,),  # noqa: E501
-            'email_notification_timestamp': (int,),  # noqa: E501
-            'download_receipt_counts': ([DownloadReceiptCount],),  # noqa: E501
+            'user': (UserCompp, none_type),  # noqa: E501
+            'delivery_receipt_timestamp': (int, none_type),  # noqa: E501
+            'read_receipt_timestamp': (int, none_type),  # noqa: E501
+            'email_notification_timestamp': (int, none_type),  # noqa: E501
+            'download_receipt_counts': ([DownloadReceiptCount], none_type),  # noqa: E501
         }
 
     @cached_property
@@ -174,7 +173,11 @@ class MessageReceiptDetail(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.user: UserCompp = None
+        self.delivery_receipt_timestamp: int = None
+        self.read_receipt_timestamp: int = None
+        self.email_notification_timestamp: int = None
+        self.download_receipt_counts: List[DownloadReceiptCount] = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/message_receipt_detail_response.py
+++ b/symphony/bdk/gen/pod_model/message_receipt_detail_response.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,17 +27,16 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.message_download_receipt_count import MessageDownloadReceiptCount
-    from symphony.bdk.gen.pod_model.message_receipt_detail import MessageReceiptDetail
-    from symphony.bdk.gen.pod_model.message_stream import MessageStream
-    from symphony.bdk.gen.pod_model.message_user import MessageUser
-    from symphony.bdk.gen.pod_model.pagination import Pagination
-    globals()['MessageDownloadReceiptCount'] = MessageDownloadReceiptCount
-    globals()['MessageReceiptDetail'] = MessageReceiptDetail
-    globals()['MessageStream'] = MessageStream
-    globals()['MessageUser'] = MessageUser
-    globals()['Pagination'] = Pagination
+from symphony.bdk.gen.pod_model.message_download_receipt_count import MessageDownloadReceiptCount
+from symphony.bdk.gen.pod_model.message_receipt_detail import MessageReceiptDetail
+from symphony.bdk.gen.pod_model.message_stream import MessageStream
+from symphony.bdk.gen.pod_model.message_user import MessageUser
+from symphony.bdk.gen.pod_model.pagination import Pagination
+globals()['MessageDownloadReceiptCount'] = MessageDownloadReceiptCount
+globals()['MessageReceiptDetail'] = MessageReceiptDetail
+globals()['MessageStream'] = MessageStream
+globals()['MessageUser'] = MessageUser
+globals()['Pagination'] = Pagination
 
 
 class MessageReceiptDetailResponse(ModelNormal):
@@ -83,18 +83,17 @@ class MessageReceiptDetailResponse(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'creator': (MessageUser,),  # noqa: E501
-            'on_behalf_of_user': (MessageUser,),  # noqa: E501
-            'stream': (MessageStream,),  # noqa: E501
-            'creation_date': (int,),  # noqa: E501
-            'delivery_receipt_count': (int,),  # noqa: E501
-            'read_receipt_count': (int,),  # noqa: E501
-            'email_notification_count': (int,),  # noqa: E501
-            'download_receipt_counts': ([MessageDownloadReceiptCount],),  # noqa: E501
-            'message_receipt_detail': ([MessageReceiptDetail],),  # noqa: E501
-            'pagination': (Pagination,),  # noqa: E501
+            'creator': (MessageUser, none_type),  # noqa: E501
+            'on_behalf_of_user': (MessageUser, none_type),  # noqa: E501
+            'stream': (MessageStream, none_type),  # noqa: E501
+            'creation_date': (int, none_type),  # noqa: E501
+            'delivery_receipt_count': (int, none_type),  # noqa: E501
+            'read_receipt_count': (int, none_type),  # noqa: E501
+            'email_notification_count': (int, none_type),  # noqa: E501
+            'download_receipt_counts': ([MessageDownloadReceiptCount], none_type),  # noqa: E501
+            'message_receipt_detail': ([MessageReceiptDetail], none_type),  # noqa: E501
+            'pagination': (Pagination, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -195,7 +194,16 @@ class MessageReceiptDetailResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.creator: MessageUser = None
+        self.on_behalf_of_user: MessageUser = None
+        self.stream: MessageStream = None
+        self.creation_date: int = None
+        self.delivery_receipt_count: int = None
+        self.read_receipt_count: int = None
+        self.email_notification_count: int = None
+        self.download_receipt_counts: List[MessageDownloadReceiptCount] = None
+        self.message_receipt_detail: List[MessageReceiptDetail] = None
+        self.pagination: Pagination = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/message_status.py
+++ b/symphony/bdk/gen/pod_model/message_status.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.message_status_user import MessageStatusUser
-    globals()['MessageStatusUser'] = MessageStatusUser
+from symphony.bdk.gen.pod_model.message_status_user import MessageStatusUser
+globals()['MessageStatusUser'] = MessageStatusUser
 
 
 class MessageStatus(ModelNormal):
@@ -75,12 +75,11 @@ class MessageStatus(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'author': (MessageStatusUser,),  # noqa: E501
-            'read': ([MessageStatusUser],),  # noqa: E501
-            'delivered': ([MessageStatusUser],),  # noqa: E501
-            'sent': ([MessageStatusUser],),  # noqa: E501
+            'author': (MessageStatusUser, none_type),  # noqa: E501
+            'read': ([MessageStatusUser], none_type),  # noqa: E501
+            'delivered': ([MessageStatusUser], none_type),  # noqa: E501
+            'sent': ([MessageStatusUser], none_type),  # noqa: E501
         }
 
     @cached_property
@@ -169,7 +168,10 @@ class MessageStatus(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.author: MessageStatusUser = None
+        self.read: List[MessageStatusUser] = None
+        self.delivered: List[MessageStatusUser] = None
+        self.sent: List[MessageStatusUser] = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/message_status_user.py
+++ b/symphony/bdk/gen/pod_model/message_status_user.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,13 +73,13 @@ class MessageStatusUser(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'user_id': (str,),  # noqa: E501
-            'first_name': (str,),  # noqa: E501
-            'last_name': (str,),  # noqa: E501
-            'display_name': (str,),  # noqa: E501
-            'email': (str,),  # noqa: E501
-            'user_name': (str,),  # noqa: E501
-            'timestamp': (str,),  # noqa: E501
+            'user_id': (str, none_type),  # noqa: E501
+            'first_name': (str, none_type),  # noqa: E501
+            'last_name': (str, none_type),  # noqa: E501
+            'display_name': (str, none_type),  # noqa: E501
+            'email': (str, none_type),  # noqa: E501
+            'user_name': (str, none_type),  # noqa: E501
+            'timestamp': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -173,7 +174,13 @@ class MessageStatusUser(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.user_id: str = None
+        self.first_name: str = None
+        self.last_name: str = None
+        self.display_name: str = None
+        self.email: str = None
+        self.user_name: str = None
+        self.timestamp: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/message_stream.py
+++ b/symphony/bdk/gen/pod_model/message_stream.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,9 +73,9 @@ class MessageStream(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'id': (str,),  # noqa: E501
-            'name': (str,),  # noqa: E501
-            'stream_type': (str,),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
+            'stream_type': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -161,7 +162,9 @@ class MessageStream(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: str = None
+        self.name: str = None
+        self.stream_type: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/message_suppression_response.py
+++ b/symphony/bdk/gen/pod_model/message_suppression_response.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,9 +73,9 @@ class MessageSuppressionResponse(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'message_id': (str,),  # noqa: E501
-            'suppressed': (bool,),  # noqa: E501
-            'suppression_date': (int,),  # noqa: E501
+            'message_id': (str, none_type),  # noqa: E501
+            'suppressed': (bool, none_type),  # noqa: E501
+            'suppression_date': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -161,7 +162,9 @@ class MessageSuppressionResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.message_id: str = None
+        self.suppressed: bool = None
+        self.suppression_date: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/message_user.py
+++ b/symphony/bdk/gen/pod_model/message_user.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,8 +73,8 @@ class MessageUser(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'id': (int,),  # noqa: E501
-            'name': (str,),  # noqa: E501
+            'id': (int, none_type),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -158,7 +159,8 @@ class MessageUser(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: int = None
+        self.name: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/name_value_pair.py
+++ b/symphony/bdk/gen/pod_model/name_value_pair.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,8 +73,8 @@ class NameValuePair(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'name': (str,),  # noqa: E501
-            'value': (str,),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
+            'value': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -158,7 +159,8 @@ class NameValuePair(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.name: str = None
+        self.value: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/pagination.py
+++ b/symphony/bdk/gen/pod_model/pagination.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.pagination_cursors import PaginationCursors
-    globals()['PaginationCursors'] = PaginationCursors
+from symphony.bdk.gen.pod_model.pagination_cursors import PaginationCursors
+globals()['PaginationCursors'] = PaginationCursors
 
 
 class Pagination(ModelNormal):
@@ -75,11 +75,10 @@ class Pagination(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'cursors': (PaginationCursors,),  # noqa: E501
-            'previous': (str,),  # noqa: E501
-            'next': (str,),  # noqa: E501
+            'previous': (str, none_type),  # noqa: E501
+            'next': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -168,8 +167,9 @@ class Pagination(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.cursors = cursors
+        self.cursors: PaginationCursors = cursors
+        self.previous: str = None
+        self.next: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/pagination_cursors.py
+++ b/symphony/bdk/gen/pod_model/pagination_cursors.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -73,7 +74,7 @@ class PaginationCursors(ModelNormal):
         """
         return {
             'before': (str,),  # noqa: E501
-            'after': (str,),  # noqa: E501
+            'after': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -160,8 +161,8 @@ class PaginationCursors(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.before = before
+        self.before: str = before
+        self.after: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/password.py
+++ b/symphony/bdk/gen/pod_model/password.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,10 +73,10 @@ class Password(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'h_salt': (str,),  # noqa: E501
-            'h_password': (str,),  # noqa: E501
-            'kh_salt': (str,),  # noqa: E501
-            'kh_password': (str,),  # noqa: E501
+            'h_salt': (str, none_type),  # noqa: E501
+            'h_password': (str, none_type),  # noqa: E501
+            'kh_salt': (str, none_type),  # noqa: E501
+            'kh_password': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -164,7 +165,10 @@ class Password(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.h_salt: str = None
+        self.h_password: str = None
+        self.kh_salt: str = None
+        self.kh_password: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/password_reset.py
+++ b/symphony/bdk/gen/pod_model/password_reset.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -75,7 +76,7 @@ class PasswordReset(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'type': (str,),  # noqa: E501
+            'type': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -158,7 +159,7 @@ class PasswordReset(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.type: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/pod_app_entitlement.py
+++ b/symphony/bdk/gen/pod_model/pod_app_entitlement.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -177,12 +178,11 @@ class PodAppEntitlement(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.app_id = app_id
-        self.app_name = app_name
-        self.enable = enable
-        self.listed = listed
-        self.install = install
+        self.app_id: str = app_id
+        self.app_name: str = app_name
+        self.enable: bool = enable
+        self.listed: bool = listed
+        self.install: bool = install
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/pod_app_entitlement_list.py
+++ b/symphony/bdk/gen/pod_model/pod_app_entitlement_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.pod_app_entitlement import PodAppEntitlement
-    globals()['PodAppEntitlement'] = PodAppEntitlement
+from symphony.bdk.gen.pod_model.pod_app_entitlement import PodAppEntitlement
+globals()['PodAppEntitlement'] = PodAppEntitlement
 
 
 class PodAppEntitlementList(ModelSimple):
@@ -71,7 +71,6 @@ class PodAppEntitlementList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([PodAppEntitlement],),
         }
@@ -136,6 +135,8 @@ class PodAppEntitlementList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -151,7 +152,6 @@ class PodAppEntitlementList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -171,7 +171,7 @@ class PodAppEntitlementList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[PodAppEntitlement] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/pod_certificate.py
+++ b/symphony/bdk/gen/pod_model/pod_certificate.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,7 +73,7 @@ class PodCertificate(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'certificate': (str,),  # noqa: E501
+            'certificate': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -155,7 +156,7 @@ class PodCertificate(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.certificate: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/policy.py
+++ b/symphony/bdk/gen/pod_model/policy.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -76,13 +77,13 @@ class Policy(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'id': (str,),  # noqa: E501
-            'policy_type': (str,),  # noqa: E501
-            'active': (bool,),  # noqa: E501
-            'member_count': (int,),  # noqa: E501
-            'groups': ([str],),  # noqa: E501
-            'created_date': (int,),  # noqa: E501
-            'modified_date': (int,),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
+            'policy_type': (str, none_type),  # noqa: E501
+            'active': (bool, none_type),  # noqa: E501
+            'member_count': (int, none_type),  # noqa: E501
+            'groups': ([str], none_type),  # noqa: E501
+            'created_date': (int, none_type),  # noqa: E501
+            'modified_date': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -177,7 +178,13 @@ class Policy(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: str = None
+        self.policy_type: str = None
+        self.active: bool = None
+        self.member_count: int = None
+        self.groups: List[str] = None
+        self.created_date: int = None
+        self.modified_date: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/policy_list.py
+++ b/symphony/bdk/gen/pod_model/policy_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.policy import Policy
-    globals()['Policy'] = Policy
+from symphony.bdk.gen.pod_model.policy import Policy
+globals()['Policy'] = Policy
 
 
 class PolicyList(ModelSimple):
@@ -71,7 +71,6 @@ class PolicyList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([Policy],),
         }
@@ -136,6 +135,8 @@ class PolicyList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -151,7 +152,6 @@ class PolicyList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -171,7 +171,7 @@ class PolicyList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[Policy] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/presence.py
+++ b/symphony/bdk/gen/pod_model/presence.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -82,7 +83,7 @@ class Presence(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'category': (str,),  # noqa: E501
+            'category': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -165,7 +166,7 @@ class Presence(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.category: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/product.py
+++ b/symphony/bdk/gen/pod_model/product.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -84,7 +85,7 @@ class Product(ModelNormal):
             'sku': (str,),  # noqa: E501
             'subscribed': (bool,),  # noqa: E501
             'type': (str,),  # noqa: E501
-            'app_id': (str,),  # noqa: E501
+            'app_id': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -177,11 +178,11 @@ class Product(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.name = name
-        self.sku = sku
-        self.subscribed = subscribed
-        self.type = type
+        self.name: str = name
+        self.sku: str = sku
+        self.subscribed: bool = subscribed
+        self.type: str = type
+        self.app_id: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/product_list.py
+++ b/symphony/bdk/gen/pod_model/product_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.product import Product
-    globals()['Product'] = Product
+from symphony.bdk.gen.pod_model.product import Product
+globals()['Product'] = Product
 
 
 class ProductList(ModelSimple):
@@ -71,7 +71,6 @@ class ProductList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([Product],),
         }
@@ -136,6 +135,8 @@ class ProductList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -151,7 +152,6 @@ class ProductList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -171,7 +171,7 @@ class ProductList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[Product] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/protocol.py
+++ b/symphony/bdk/gen/pod_model/protocol.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -157,8 +158,7 @@ class Protocol(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.scheme = scheme
+        self.scheme: str = scheme
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/role.py
+++ b/symphony/bdk/gen/pod_model/role.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,9 +73,9 @@ class Role(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'id': (int,),  # noqa: E501
-            'name': (str,),  # noqa: E501
-            'description': (str,),  # noqa: E501
+            'id': (int, none_type),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
+            'description': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -161,7 +162,9 @@ class Role(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: int = None
+        self.name: str = None
+        self.description: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/role_detail.py
+++ b/symphony/bdk/gen/pod_model/role_detail.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,10 +73,10 @@ class RoleDetail(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'id': (str,),  # noqa: E501
-            'name': (str,),  # noqa: E501
-            'user_types': ([str],),  # noqa: E501
-            'optional_actions': ([str],),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
+            'user_types': ([str], none_type),  # noqa: E501
+            'optional_actions': ([str], none_type),  # noqa: E501
         }
 
     @cached_property
@@ -164,7 +165,10 @@ class RoleDetail(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: str = None
+        self.name: str = None
+        self.user_types: List[str] = None
+        self.optional_actions: List[str] = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/role_detail_list.py
+++ b/symphony/bdk/gen/pod_model/role_detail_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.role_detail import RoleDetail
-    globals()['RoleDetail'] = RoleDetail
+from symphony.bdk.gen.pod_model.role_detail import RoleDetail
+globals()['RoleDetail'] = RoleDetail
 
 
 class RoleDetailList(ModelSimple):
@@ -71,7 +71,6 @@ class RoleDetailList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([RoleDetail],),
         }
@@ -136,6 +135,8 @@ class RoleDetailList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -151,7 +152,6 @@ class RoleDetailList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -171,7 +171,7 @@ class RoleDetailList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[RoleDetail] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/role_list.py
+++ b/symphony/bdk/gen/pod_model/role_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.role import Role
-    globals()['Role'] = Role
+from symphony.bdk.gen.pod_model.role import Role
+globals()['Role'] = Role
 
 
 class RoleList(ModelSimple):
@@ -71,7 +71,6 @@ class RoleList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([Role],),
         }
@@ -136,6 +135,8 @@ class RoleList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -151,7 +152,6 @@ class RoleList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -171,7 +171,7 @@ class RoleList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[Role] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/room_attributes.py
+++ b/symphony/bdk/gen/pod_model/room_attributes.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,10 +73,10 @@ class RoomAttributes(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'name': (str,),  # noqa: E501
-            'description': (str,),  # noqa: E501
-            'members_can_invite': (bool,),  # noqa: E501
-            'discoverable': (bool,),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
+            'description': (str, none_type),  # noqa: E501
+            'members_can_invite': (bool, none_type),  # noqa: E501
+            'discoverable': (bool, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -164,7 +165,10 @@ class RoomAttributes(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.name: str = None
+        self.description: str = None
+        self.members_can_invite: bool = None
+        self.discoverable: bool = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/room_create.py
+++ b/symphony/bdk/gen/pod_model/room_create.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.immutable_room_attributes import ImmutableRoomAttributes
-    from symphony.bdk.gen.pod_model.room_attributes import RoomAttributes
-    globals()['ImmutableRoomAttributes'] = ImmutableRoomAttributes
-    globals()['RoomAttributes'] = RoomAttributes
+from symphony.bdk.gen.pod_model.immutable_room_attributes import ImmutableRoomAttributes
+from symphony.bdk.gen.pod_model.room_attributes import RoomAttributes
+globals()['ImmutableRoomAttributes'] = ImmutableRoomAttributes
+globals()['RoomAttributes'] = RoomAttributes
 
 
 class RoomCreate(ModelNormal):
@@ -77,10 +77,9 @@ class RoomCreate(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'room_attributes': (RoomAttributes,),  # noqa: E501
-            'immutable_room_attributes': (ImmutableRoomAttributes,),  # noqa: E501
+            'room_attributes': (RoomAttributes, none_type),  # noqa: E501
+            'immutable_room_attributes': (ImmutableRoomAttributes, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -165,7 +164,8 @@ class RoomCreate(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.room_attributes: RoomAttributes = None
+        self.immutable_room_attributes: ImmutableRoomAttributes = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/room_detail.py
+++ b/symphony/bdk/gen/pod_model/room_detail.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,13 +27,12 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.immutable_room_attributes import ImmutableRoomAttributes
-    from symphony.bdk.gen.pod_model.room_attributes import RoomAttributes
-    from symphony.bdk.gen.pod_model.room_system_info import RoomSystemInfo
-    globals()['ImmutableRoomAttributes'] = ImmutableRoomAttributes
-    globals()['RoomAttributes'] = RoomAttributes
-    globals()['RoomSystemInfo'] = RoomSystemInfo
+from symphony.bdk.gen.pod_model.immutable_room_attributes import ImmutableRoomAttributes
+from symphony.bdk.gen.pod_model.room_attributes import RoomAttributes
+from symphony.bdk.gen.pod_model.room_system_info import RoomSystemInfo
+globals()['ImmutableRoomAttributes'] = ImmutableRoomAttributes
+globals()['RoomAttributes'] = RoomAttributes
+globals()['RoomSystemInfo'] = RoomSystemInfo
 
 
 class RoomDetail(ModelNormal):
@@ -79,11 +79,10 @@ class RoomDetail(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'room_attributes': (RoomAttributes,),  # noqa: E501
-            'room_system_info': (RoomSystemInfo,),  # noqa: E501
-            'immutable_room_attributes': (ImmutableRoomAttributes,),  # noqa: E501
+            'room_attributes': (RoomAttributes, none_type),  # noqa: E501
+            'room_system_info': (RoomSystemInfo, none_type),  # noqa: E501
+            'immutable_room_attributes': (ImmutableRoomAttributes, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -170,7 +169,9 @@ class RoomDetail(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.room_attributes: RoomAttributes = None
+        self.room_system_info: RoomSystemInfo = None
+        self.immutable_room_attributes: ImmutableRoomAttributes = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/room_search_criteria.py
+++ b/symphony/bdk/gen/pod_model/room_search_criteria.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.user_id import UserId
-    globals()['UserId'] = UserId
+from symphony.bdk.gen.pod_model.user_id import UserId
+globals()['UserId'] = UserId
 
 
 class RoomSearchCriteria(ModelNormal):
@@ -79,16 +79,15 @@ class RoomSearchCriteria(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'query': (str,),  # noqa: E501
-            'labels': ([str],),  # noqa: E501
-            'active': (bool,),  # noqa: E501
-            'private': (bool,),  # noqa: E501
-            'owner': (UserId,),  # noqa: E501
-            'creator': (UserId,),  # noqa: E501
-            'member': (UserId,),  # noqa: E501
-            'sort_order': (str,),  # noqa: E501
+            'labels': ([str], none_type),  # noqa: E501
+            'active': (bool, none_type),  # noqa: E501
+            'private': (bool, none_type),  # noqa: E501
+            'owner': (UserId, none_type),  # noqa: E501
+            'creator': (UserId, none_type),  # noqa: E501
+            'member': (UserId, none_type),  # noqa: E501
+            'sort_order': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -187,8 +186,14 @@ class RoomSearchCriteria(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.query = query
+        self.query: str = query
+        self.labels: List[str] = None
+        self.active: bool = None
+        self.private: bool = None
+        self.owner: UserId = None
+        self.creator: UserId = None
+        self.member: UserId = None
+        self.sort_order: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/room_search_results.py
+++ b/symphony/bdk/gen/pod_model/room_search_results.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,13 +27,12 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.faceted_match_count import FacetedMatchCount
-    from symphony.bdk.gen.pod_model.room_search_criteria import RoomSearchCriteria
-    from symphony.bdk.gen.pod_model.v2_room_detail import V2RoomDetail
-    globals()['FacetedMatchCount'] = FacetedMatchCount
-    globals()['RoomSearchCriteria'] = RoomSearchCriteria
-    globals()['V2RoomDetail'] = V2RoomDetail
+from symphony.bdk.gen.pod_model.faceted_match_count import FacetedMatchCount
+from symphony.bdk.gen.pod_model.room_search_criteria import RoomSearchCriteria
+from symphony.bdk.gen.pod_model.v2_room_detail import V2RoomDetail
+globals()['FacetedMatchCount'] = FacetedMatchCount
+globals()['RoomSearchCriteria'] = RoomSearchCriteria
+globals()['V2RoomDetail'] = V2RoomDetail
 
 
 class RoomSearchResults(ModelNormal):
@@ -79,14 +79,13 @@ class RoomSearchResults(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'count': (int,),  # noqa: E501
-            'skip': (int,),  # noqa: E501
-            'limit': (int,),  # noqa: E501
-            'query': (RoomSearchCriteria,),  # noqa: E501
-            'rooms': ([V2RoomDetail],),  # noqa: E501
-            'faceted_match_count': ([FacetedMatchCount],),  # noqa: E501
+            'count': (int, none_type),  # noqa: E501
+            'skip': (int, none_type),  # noqa: E501
+            'limit': (int, none_type),  # noqa: E501
+            'query': (RoomSearchCriteria, none_type),  # noqa: E501
+            'rooms': ([V2RoomDetail], none_type),  # noqa: E501
+            'faceted_match_count': ([FacetedMatchCount], none_type),  # noqa: E501
         }
 
     @cached_property
@@ -179,7 +178,12 @@ class RoomSearchResults(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.count: int = None
+        self.skip: int = None
+        self.limit: int = None
+        self.query: RoomSearchCriteria = None
+        self.rooms: List[V2RoomDetail] = None
+        self.faceted_match_count: List[FacetedMatchCount] = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/room_specific_stream_attributes.py
+++ b/symphony/bdk/gen/pod_model/room_specific_stream_attributes.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,7 +73,7 @@ class RoomSpecificStreamAttributes(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'name': (str,),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -155,7 +156,7 @@ class RoomSpecificStreamAttributes(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.name: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/room_system_info.py
+++ b/symphony/bdk/gen/pod_model/room_system_info.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,10 +73,10 @@ class RoomSystemInfo(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'id': (str,),  # noqa: E501
-            'creation_date': (int,),  # noqa: E501
-            'created_by_user_id': (int,),  # noqa: E501
-            'active': (bool,),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
+            'creation_date': (int, none_type),  # noqa: E501
+            'created_by_user_id': (int, none_type),  # noqa: E501
+            'active': (bool, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -164,7 +165,10 @@ class RoomSystemInfo(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: str = None
+        self.creation_date: int = None
+        self.created_by_user_id: int = None
+        self.active: bool = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/room_tag.py
+++ b/symphony/bdk/gen/pod_model/room_tag.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -160,9 +161,8 @@ class RoomTag(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.key = key
-        self.value = value
+        self.key: str = key
+        self.value: str = value
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/session_info.py
+++ b/symphony/bdk/gen/pod_model/session_info.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,7 +73,7 @@ class SessionInfo(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'user_id': (int,),  # noqa: E501
+            'user_id': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -155,7 +156,7 @@ class SessionInfo(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.user_id: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/stream.py
+++ b/symphony/bdk/gen/pod_model/stream.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,7 +73,7 @@ class Stream(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'id': (str,),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -155,7 +156,7 @@ class Stream(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/stream_attachment_item.py
+++ b/symphony/bdk/gen/pod_model/stream_attachment_item.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.attachment_preview import AttachmentPreview
-    globals()['AttachmentPreview'] = AttachmentPreview
+from symphony.bdk.gen.pod_model.attachment_preview import AttachmentPreview
+globals()['AttachmentPreview'] = AttachmentPreview
 
 
 class StreamAttachmentItem(ModelNormal):
@@ -75,16 +75,15 @@ class StreamAttachmentItem(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'message_id': (str,),  # noqa: E501
-            'ingestion_date': (int,),  # noqa: E501
-            'user_id': (int,),  # noqa: E501
-            'file_id': (str,),  # noqa: E501
-            'name': (str,),  # noqa: E501
-            'size': (int,),  # noqa: E501
-            'content_type': (str,),  # noqa: E501
-            'previews': ([AttachmentPreview],),  # noqa: E501
+            'message_id': (str, none_type),  # noqa: E501
+            'ingestion_date': (int, none_type),  # noqa: E501
+            'user_id': (int, none_type),  # noqa: E501
+            'file_id': (str, none_type),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
+            'size': (int, none_type),  # noqa: E501
+            'content_type': (str, none_type),  # noqa: E501
+            'previews': ([AttachmentPreview], none_type),  # noqa: E501
         }
 
     @cached_property
@@ -181,7 +180,14 @@ class StreamAttachmentItem(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.message_id: str = None
+        self.ingestion_date: int = None
+        self.user_id: int = None
+        self.file_id: str = None
+        self.name: str = None
+        self.size: int = None
+        self.content_type: str = None
+        self.previews: List[AttachmentPreview] = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/stream_attachment_response.py
+++ b/symphony/bdk/gen/pod_model/stream_attachment_response.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.stream_attachment_item import StreamAttachmentItem
-    globals()['StreamAttachmentItem'] = StreamAttachmentItem
+from symphony.bdk.gen.pod_model.stream_attachment_item import StreamAttachmentItem
+globals()['StreamAttachmentItem'] = StreamAttachmentItem
 
 
 class StreamAttachmentResponse(ModelSimple):
@@ -71,7 +71,6 @@ class StreamAttachmentResponse(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([StreamAttachmentItem],),
         }
@@ -136,6 +135,8 @@ class StreamAttachmentResponse(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -151,7 +152,6 @@ class StreamAttachmentResponse(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -171,7 +171,7 @@ class StreamAttachmentResponse(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[StreamAttachmentItem] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/stream_attributes.py
+++ b/symphony/bdk/gen/pod_model/stream_attributes.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,13 +27,12 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.conversation_specific_stream_attributes import ConversationSpecificStreamAttributes
-    from symphony.bdk.gen.pod_model.room_specific_stream_attributes import RoomSpecificStreamAttributes
-    from symphony.bdk.gen.pod_model.stream_type import StreamType
-    globals()['ConversationSpecificStreamAttributes'] = ConversationSpecificStreamAttributes
-    globals()['RoomSpecificStreamAttributes'] = RoomSpecificStreamAttributes
-    globals()['StreamType'] = StreamType
+from symphony.bdk.gen.pod_model.conversation_specific_stream_attributes import ConversationSpecificStreamAttributes
+from symphony.bdk.gen.pod_model.room_specific_stream_attributes import RoomSpecificStreamAttributes
+from symphony.bdk.gen.pod_model.stream_type import StreamType
+globals()['ConversationSpecificStreamAttributes'] = ConversationSpecificStreamAttributes
+globals()['RoomSpecificStreamAttributes'] = RoomSpecificStreamAttributes
+globals()['StreamType'] = StreamType
 
 
 class StreamAttributes(ModelNormal):
@@ -79,14 +79,13 @@ class StreamAttributes(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'id': (str,),  # noqa: E501
-            'cross_pod': (bool,),  # noqa: E501
-            'active': (bool,),  # noqa: E501
-            'stream_type': (StreamType,),  # noqa: E501
-            'stream_attributes': (ConversationSpecificStreamAttributes,),  # noqa: E501
-            'room_attributes': (RoomSpecificStreamAttributes,),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
+            'cross_pod': (bool, none_type),  # noqa: E501
+            'active': (bool, none_type),  # noqa: E501
+            'stream_type': (StreamType, none_type),  # noqa: E501
+            'stream_attributes': (ConversationSpecificStreamAttributes, none_type),  # noqa: E501
+            'room_attributes': (RoomSpecificStreamAttributes, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -179,7 +178,12 @@ class StreamAttributes(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: str = None
+        self.cross_pod: bool = None
+        self.active: bool = None
+        self.stream_type: StreamType = None
+        self.stream_attributes: ConversationSpecificStreamAttributes = None
+        self.room_attributes: RoomSpecificStreamAttributes = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/stream_filter.py
+++ b/symphony/bdk/gen/pod_model/stream_filter.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.stream_type import StreamType
-    globals()['StreamType'] = StreamType
+from symphony.bdk.gen.pod_model.stream_type import StreamType
+globals()['StreamType'] = StreamType
 
 
 class StreamFilter(ModelNormal):
@@ -75,10 +75,9 @@ class StreamFilter(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'stream_types': ([StreamType],),  # noqa: E501
-            'include_inactive_streams': (bool,),  # noqa: E501
+            'stream_types': ([StreamType], none_type),  # noqa: E501
+            'include_inactive_streams': (bool, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -163,7 +162,8 @@ class StreamFilter(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.stream_types: List[StreamType] = None
+        self.include_inactive_streams: bool = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/stream_list.py
+++ b/symphony/bdk/gen/pod_model/stream_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.stream_attributes import StreamAttributes
-    globals()['StreamAttributes'] = StreamAttributes
+from symphony.bdk.gen.pod_model.stream_attributes import StreamAttributes
+globals()['StreamAttributes'] = StreamAttributes
 
 
 class StreamList(ModelSimple):
@@ -71,7 +71,6 @@ class StreamList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([StreamAttributes],),
         }
@@ -136,6 +135,8 @@ class StreamList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -151,7 +152,6 @@ class StreamList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -171,7 +171,7 @@ class StreamList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[StreamAttributes] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/stream_type.py
+++ b/symphony/bdk/gen/pod_model/stream_type.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -78,7 +79,7 @@ class StreamType(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'type': (str,),  # noqa: E501
+            'type': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -161,7 +162,7 @@ class StreamType(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.type: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/string_id.py
+++ b/symphony/bdk/gen/pod_model/string_id.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,7 +73,7 @@ class StringId(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'id': (str,),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -155,7 +156,7 @@ class StringId(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/string_list.py
+++ b/symphony/bdk/gen/pod_model/string_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -131,6 +132,8 @@ class StringList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -146,7 +149,6 @@ class StringList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -166,7 +168,7 @@ class StringList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[str] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/success_response.py
+++ b/symphony/bdk/gen/pod_model/success_response.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -76,8 +77,8 @@ class SuccessResponse(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'format': (str,),  # noqa: E501
-            'message': (str,),  # noqa: E501
+            'format': (str, none_type),  # noqa: E501
+            'message': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -162,7 +163,8 @@ class SuccessResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.format: str = None
+        self.message: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user.py
+++ b/symphony/bdk/gen/pod_model/user.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,8 +73,8 @@ class User(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'id': (int,),  # noqa: E501
-            'email_address': (str,),  # noqa: E501
+            'id': (int, none_type),  # noqa: E501
+            'email_address': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -158,7 +159,8 @@ class User(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: int = None
+        self.email_address: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_app_entitlement.py
+++ b/symphony/bdk/gen/pod_model/user_app_entitlement.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.product_list import ProductList
-    globals()['ProductList'] = ProductList
+from symphony.bdk.gen.pod_model.product_list import ProductList
+globals()['ProductList'] = ProductList
 
 
 class UserAppEntitlement(ModelNormal):
@@ -83,13 +83,12 @@ class UserAppEntitlement(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'app_id': (str,),  # noqa: E501
             'listed': (bool,),  # noqa: E501
             'install': (bool,),  # noqa: E501
-            'app_name': (str,),  # noqa: E501
-            'products': (ProductList,),  # noqa: E501
+            'app_name': (str, none_type),  # noqa: E501
+            'products': (ProductList, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -182,10 +181,11 @@ class UserAppEntitlement(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.app_id = app_id
-        self.listed = listed
-        self.install = install
+        self.app_id: str = app_id
+        self.listed: bool = listed
+        self.install: bool = install
+        self.app_name: str = None
+        self.products: ProductList = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_app_entitlement_list.py
+++ b/symphony/bdk/gen/pod_model/user_app_entitlement_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.user_app_entitlement import UserAppEntitlement
-    globals()['UserAppEntitlement'] = UserAppEntitlement
+from symphony.bdk.gen.pod_model.user_app_entitlement import UserAppEntitlement
+globals()['UserAppEntitlement'] = UserAppEntitlement
 
 
 class UserAppEntitlementList(ModelSimple):
@@ -71,7 +71,6 @@ class UserAppEntitlementList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([UserAppEntitlement],),
         }
@@ -136,6 +135,8 @@ class UserAppEntitlementList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -151,7 +152,6 @@ class UserAppEntitlementList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -171,7 +171,7 @@ class UserAppEntitlementList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[UserAppEntitlement] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/user_attributes.py
+++ b/symphony/bdk/gen/pod_model/user_attributes.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -76,23 +77,23 @@ class UserAttributes(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'email_address': (str,),  # noqa: E501
-            'first_name': (str,),  # noqa: E501
-            'last_name': (str,),  # noqa: E501
-            'user_name': (str,),  # noqa: E501
-            'display_name': (str,),  # noqa: E501
-            'company_name': (str,),  # noqa: E501
-            'department': (str,),  # noqa: E501
-            'division': (str,),  # noqa: E501
-            'title': (str,),  # noqa: E501
-            'work_phone_number': (str,),  # noqa: E501
-            'mobile_phone_number': (str,),  # noqa: E501
-            'sms_number': (str,),  # noqa: E501
-            'account_type': (str,),  # noqa: E501
-            'location': (str,),  # noqa: E501
-            'job_function': (str,),  # noqa: E501
-            'asset_classes': ([str],),  # noqa: E501
-            'industries': ([str],),  # noqa: E501
+            'email_address': (str, none_type),  # noqa: E501
+            'first_name': (str, none_type),  # noqa: E501
+            'last_name': (str, none_type),  # noqa: E501
+            'user_name': (str, none_type),  # noqa: E501
+            'display_name': (str, none_type),  # noqa: E501
+            'company_name': (str, none_type),  # noqa: E501
+            'department': (str, none_type),  # noqa: E501
+            'division': (str, none_type),  # noqa: E501
+            'title': (str, none_type),  # noqa: E501
+            'work_phone_number': (str, none_type),  # noqa: E501
+            'mobile_phone_number': (str, none_type),  # noqa: E501
+            'sms_number': (str, none_type),  # noqa: E501
+            'account_type': (str, none_type),  # noqa: E501
+            'location': (str, none_type),  # noqa: E501
+            'job_function': (str, none_type),  # noqa: E501
+            'asset_classes': ([str], none_type),  # noqa: E501
+            'industries': ([str], none_type),  # noqa: E501
         }
 
     @cached_property
@@ -207,7 +208,23 @@ class UserAttributes(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.email_address: str = None
+        self.first_name: str = None
+        self.last_name: str = None
+        self.user_name: str = None
+        self.display_name: str = None
+        self.company_name: str = None
+        self.department: str = None
+        self.division: str = None
+        self.title: str = None
+        self.work_phone_number: str = None
+        self.mobile_phone_number: str = None
+        self.sms_number: str = None
+        self.account_type: str = None
+        self.location: str = None
+        self.job_function: str = None
+        self.asset_classes: List[str] = None
+        self.industries: List[str] = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_compp.py
+++ b/symphony/bdk/gen/pod_model/user_compp.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,11 +73,11 @@ class UserCompp(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'id': (int,),  # noqa: E501
-            'username': (str,),  # noqa: E501
-            'first_name': (str,),  # noqa: E501
-            'last_name': (str,),  # noqa: E501
-            'email_address': (str,),  # noqa: E501
+            'id': (int, none_type),  # noqa: E501
+            'username': (str, none_type),  # noqa: E501
+            'first_name': (str, none_type),  # noqa: E501
+            'last_name': (str, none_type),  # noqa: E501
+            'email_address': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -167,7 +168,11 @@ class UserCompp(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: int = None
+        self.username: str = None
+        self.first_name: str = None
+        self.last_name: str = None
+        self.email_address: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_connection.py
+++ b/symphony/bdk/gen/pod_model/user_connection.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -78,11 +79,11 @@ class UserConnection(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'user_id': (int,),  # noqa: E501
-            'status': (str,),  # noqa: E501
-            'first_requested_at': (int,),  # noqa: E501
-            'updated_at': (int,),  # noqa: E501
-            'request_counter': (int,),  # noqa: E501
+            'user_id': (int, none_type),  # noqa: E501
+            'status': (str, none_type),  # noqa: E501
+            'first_requested_at': (int, none_type),  # noqa: E501
+            'updated_at': (int, none_type),  # noqa: E501
+            'request_counter': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -173,7 +174,11 @@ class UserConnection(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.user_id: int = None
+        self.status: str = None
+        self.first_requested_at: int = None
+        self.updated_at: int = None
+        self.request_counter: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_connection_list.py
+++ b/symphony/bdk/gen/pod_model/user_connection_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.user_connection import UserConnection
-    globals()['UserConnection'] = UserConnection
+from symphony.bdk.gen.pod_model.user_connection import UserConnection
+globals()['UserConnection'] = UserConnection
 
 
 class UserConnectionList(ModelSimple):
@@ -71,7 +71,6 @@ class UserConnectionList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([UserConnection],),
         }
@@ -136,6 +135,8 @@ class UserConnectionList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -151,7 +152,6 @@ class UserConnectionList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -171,7 +171,7 @@ class UserConnectionList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[UserConnection] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/user_connection_request.py
+++ b/symphony/bdk/gen/pod_model/user_connection_request.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,7 +73,7 @@ class UserConnectionRequest(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'user_id': (int,),  # noqa: E501
+            'user_id': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -155,7 +156,7 @@ class UserConnectionRequest(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.user_id: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_create.py
+++ b/symphony/bdk/gen/pod_model/user_create.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.password import Password
-    from symphony.bdk.gen.pod_model.user_attributes import UserAttributes
-    globals()['Password'] = Password
-    globals()['UserAttributes'] = UserAttributes
+from symphony.bdk.gen.pod_model.password import Password
+from symphony.bdk.gen.pod_model.user_attributes import UserAttributes
+globals()['Password'] = Password
+globals()['UserAttributes'] = UserAttributes
 
 
 class UserCreate(ModelNormal):
@@ -77,11 +77,10 @@ class UserCreate(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'user_attributes': (UserAttributes,),  # noqa: E501
-            'password': (Password,),  # noqa: E501
-            'roles': ([str],),  # noqa: E501
+            'user_attributes': (UserAttributes, none_type),  # noqa: E501
+            'password': (Password, none_type),  # noqa: E501
+            'roles': ([str], none_type),  # noqa: E501
         }
 
     @cached_property
@@ -168,7 +167,9 @@ class UserCreate(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.user_attributes: UserAttributes = None
+        self.password: Password = None
+        self.roles: List[str] = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_data.py
+++ b/symphony/bdk/gen/pod_model/user_data.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,11 +73,11 @@ class UserData(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'id': (int,),  # noqa: E501
-            'username': (str,),  # noqa: E501
-            'first_name': (str,),  # noqa: E501
-            'last_name': (str,),  # noqa: E501
-            'email_address': (str,),  # noqa: E501
+            'id': (int, none_type),  # noqa: E501
+            'username': (str, none_type),  # noqa: E501
+            'first_name': (str, none_type),  # noqa: E501
+            'last_name': (str, none_type),  # noqa: E501
+            'email_address': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -167,7 +168,11 @@ class UserData(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: int = None
+        self.username: str = None
+        self.first_name: str = None
+        self.last_name: str = None
+        self.email_address: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_detail.py
+++ b/symphony/bdk/gen/pod_model/user_detail.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,17 +27,16 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.avatar import Avatar
-    from symphony.bdk.gen.pod_model.integer_list import IntegerList
-    from symphony.bdk.gen.pod_model.string_list import StringList
-    from symphony.bdk.gen.pod_model.user_attributes import UserAttributes
-    from symphony.bdk.gen.pod_model.user_system_info import UserSystemInfo
-    globals()['Avatar'] = Avatar
-    globals()['IntegerList'] = IntegerList
-    globals()['StringList'] = StringList
-    globals()['UserAttributes'] = UserAttributes
-    globals()['UserSystemInfo'] = UserSystemInfo
+from symphony.bdk.gen.pod_model.avatar import Avatar
+from symphony.bdk.gen.pod_model.integer_list import IntegerList
+from symphony.bdk.gen.pod_model.string_list import StringList
+from symphony.bdk.gen.pod_model.user_attributes import UserAttributes
+from symphony.bdk.gen.pod_model.user_system_info import UserSystemInfo
+globals()['Avatar'] = Avatar
+globals()['IntegerList'] = IntegerList
+globals()['StringList'] = StringList
+globals()['UserAttributes'] = UserAttributes
+globals()['UserSystemInfo'] = UserSystemInfo
 
 
 class UserDetail(ModelNormal):
@@ -83,16 +83,15 @@ class UserDetail(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'user_attributes': (UserAttributes,),  # noqa: E501
-            'user_system_info': (UserSystemInfo,),  # noqa: E501
-            'features': (IntegerList,),  # noqa: E501
-            'apps': (IntegerList,),  # noqa: E501
-            'groups': (IntegerList,),  # noqa: E501
-            'roles': (StringList,),  # noqa: E501
-            'disclaimers': (IntegerList,),  # noqa: E501
-            'avatar': (Avatar,),  # noqa: E501
+            'user_attributes': (UserAttributes, none_type),  # noqa: E501
+            'user_system_info': (UserSystemInfo, none_type),  # noqa: E501
+            'features': (IntegerList, none_type),  # noqa: E501
+            'apps': (IntegerList, none_type),  # noqa: E501
+            'groups': (IntegerList, none_type),  # noqa: E501
+            'roles': (StringList, none_type),  # noqa: E501
+            'disclaimers': (IntegerList, none_type),  # noqa: E501
+            'avatar': (Avatar, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -189,7 +188,14 @@ class UserDetail(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.user_attributes: UserAttributes = None
+        self.user_system_info: UserSystemInfo = None
+        self.features: IntegerList = None
+        self.apps: IntegerList = None
+        self.groups: IntegerList = None
+        self.roles: StringList = None
+        self.disclaimers: IntegerList = None
+        self.avatar: Avatar = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_detail_list.py
+++ b/symphony/bdk/gen/pod_model/user_detail_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.user_detail import UserDetail
-    globals()['UserDetail'] = UserDetail
+from symphony.bdk.gen.pod_model.user_detail import UserDetail
+globals()['UserDetail'] = UserDetail
 
 
 class UserDetailList(ModelSimple):
@@ -71,7 +71,6 @@ class UserDetailList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([UserDetail],),
         }
@@ -136,6 +135,8 @@ class UserDetailList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -151,7 +152,6 @@ class UserDetailList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -171,7 +171,7 @@ class UserDetailList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[UserDetail] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/user_error.py
+++ b/symphony/bdk/gen/pod_model/user_error.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,9 +73,9 @@ class UserError(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'error': (str,),  # noqa: E501
-            'email': (str,),  # noqa: E501
-            'id': (str,),  # noqa: E501
+            'error': (str, none_type),  # noqa: E501
+            'email': (str, none_type),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -161,7 +162,9 @@ class UserError(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.error: str = None
+        self.email: str = None
+        self.id: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_filter.py
+++ b/symphony/bdk/gen/pod_model/user_filter.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -76,9 +77,9 @@ class UserFilter(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'role': (str,),  # noqa: E501
-            'feature': (str,),  # noqa: E501
-            'status': (str,),  # noqa: E501
+            'role': (str, none_type),  # noqa: E501
+            'feature': (str, none_type),  # noqa: E501
+            'status': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -165,7 +166,9 @@ class UserFilter(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.role: str = None
+        self.feature: str = None
+        self.status: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_group_assignee.py
+++ b/symphony/bdk/gen/pod_model/user_group_assignee.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.group_role_scope import GroupRoleScope
-    from symphony.bdk.gen.pod_model.user_compp import UserCompp
-    globals()['GroupRoleScope'] = GroupRoleScope
-    globals()['UserCompp'] = UserCompp
+from symphony.bdk.gen.pod_model.group_role_scope import GroupRoleScope
+from symphony.bdk.gen.pod_model.user_compp import UserCompp
+globals()['GroupRoleScope'] = GroupRoleScope
+globals()['UserCompp'] = UserCompp
 
 
 class UserGroupAssignee(ModelNormal):
@@ -77,17 +77,16 @@ class UserGroupAssignee(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'id': (str,),  # noqa: E501
-            'group_id': (str,),  # noqa: E501
-            'group': (GroupRoleScope,),  # noqa: E501
-            'user_id': (int,),  # noqa: E501
-            'user': (UserCompp,),  # noqa: E501
-            'user_roles': ([str],),  # noqa: E501
-            'active': (bool,),  # noqa: E501
-            'last_added_date': (int,),  # noqa: E501
-            'last_removed_date': (int,),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
+            'group_id': (str, none_type),  # noqa: E501
+            'group': (GroupRoleScope, none_type),  # noqa: E501
+            'user_id': (int, none_type),  # noqa: E501
+            'user': (UserCompp, none_type),  # noqa: E501
+            'user_roles': ([str], none_type),  # noqa: E501
+            'active': (bool, none_type),  # noqa: E501
+            'last_added_date': (int, none_type),  # noqa: E501
+            'last_removed_date': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -186,7 +185,15 @@ class UserGroupAssignee(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: str = None
+        self.group_id: str = None
+        self.group: GroupRoleScope = None
+        self.user_id: int = None
+        self.user: UserCompp = None
+        self.user_roles: List[str] = None
+        self.active: bool = None
+        self.last_added_date: int = None
+        self.last_removed_date: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_group_assignee_response.py
+++ b/symphony/bdk/gen/pod_model/user_group_assignee_response.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.pagination import Pagination
-    from symphony.bdk.gen.pod_model.user_group_assignee import UserGroupAssignee
-    globals()['Pagination'] = Pagination
-    globals()['UserGroupAssignee'] = UserGroupAssignee
+from symphony.bdk.gen.pod_model.pagination import Pagination
+from symphony.bdk.gen.pod_model.user_group_assignee import UserGroupAssignee
+globals()['Pagination'] = Pagination
+globals()['UserGroupAssignee'] = UserGroupAssignee
 
 
 class UserGroupAssigneeResponse(ModelNormal):
@@ -77,10 +77,9 @@ class UserGroupAssigneeResponse(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'data': ([UserGroupAssignee],),  # noqa: E501
-            'pagination': (Pagination,),  # noqa: E501
+            'data': ([UserGroupAssignee], none_type),  # noqa: E501
+            'pagination': (Pagination, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -165,7 +164,8 @@ class UserGroupAssigneeResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.data: List[UserGroupAssignee] = None
+        self.pagination: Pagination = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_group_assignee_update.py
+++ b/symphony/bdk/gen/pod_model/user_group_assignee_update.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -157,8 +158,7 @@ class UserGroupAssigneeUpdate(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.current = current
+        self.current: bool = current
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_group_assignment_response.py
+++ b/symphony/bdk/gen/pod_model/user_group_assignment_response.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.group_role_scope import GroupRoleScope
-    from symphony.bdk.gen.pod_model.user_compp import UserCompp
-    globals()['GroupRoleScope'] = GroupRoleScope
-    globals()['UserCompp'] = UserCompp
+from symphony.bdk.gen.pod_model.group_role_scope import GroupRoleScope
+from symphony.bdk.gen.pod_model.user_compp import UserCompp
+globals()['GroupRoleScope'] = GroupRoleScope
+globals()['UserCompp'] = UserCompp
 
 
 class UserGroupAssignmentResponse(ModelNormal):
@@ -77,17 +77,16 @@ class UserGroupAssignmentResponse(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'id': (str,),  # noqa: E501
-            'group_id': (str,),  # noqa: E501
-            'group': (GroupRoleScope,),  # noqa: E501
-            'user_id': (int,),  # noqa: E501
-            'user': (UserCompp,),  # noqa: E501
-            'user_roles': ([str],),  # noqa: E501
-            'active': (bool,),  # noqa: E501
-            'last_added_date': (int,),  # noqa: E501
-            'last_removed_date': (int,),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
+            'group_id': (str, none_type),  # noqa: E501
+            'group': (GroupRoleScope, none_type),  # noqa: E501
+            'user_id': (int, none_type),  # noqa: E501
+            'user': (UserCompp, none_type),  # noqa: E501
+            'user_roles': ([str], none_type),  # noqa: E501
+            'active': (bool, none_type),  # noqa: E501
+            'last_added_date': (int, none_type),  # noqa: E501
+            'last_removed_date': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -186,7 +185,15 @@ class UserGroupAssignmentResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: str = None
+        self.group_id: str = None
+        self.group: GroupRoleScope = None
+        self.user_id: int = None
+        self.user: UserCompp = None
+        self.user_roles: List[str] = None
+        self.active: bool = None
+        self.last_added_date: int = None
+        self.last_removed_date: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_group_create.py
+++ b/symphony/bdk/gen/pod_model/user_group_create.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -74,8 +75,8 @@ class UserGroupCreate(ModelNormal):
         return {
             'name': (str,),  # noqa: E501
             'type': (str,),  # noqa: E501
-            'area': (str,),  # noqa: E501
-            'description': (str,),  # noqa: E501
+            'area': (str, none_type),  # noqa: E501
+            'description': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -166,9 +167,10 @@ class UserGroupCreate(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.name = name
-        self.type = type
+        self.name: str = name
+        self.type: str = type
+        self.area: str = None
+        self.description: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_group_data.py
+++ b/symphony/bdk/gen/pod_model/user_group_data.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,11 +73,11 @@ class UserGroupData(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'id': (str,),  # noqa: E501
-            'name': (str,),  # noqa: E501
-            'area': (str,),  # noqa: E501
-            'type': (str,),  # noqa: E501
-            'active': (bool,),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
+            'area': (str, none_type),  # noqa: E501
+            'type': (str, none_type),  # noqa: E501
+            'active': (bool, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -167,7 +168,11 @@ class UserGroupData(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: str = None
+        self.name: str = None
+        self.area: str = None
+        self.type: str = None
+        self.active: bool = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_group_membership_data.py
+++ b/symphony/bdk/gen/pod_model/user_group_membership_data.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.membership_data import MembershipData
-    from symphony.bdk.gen.pod_model.user_group_data import UserGroupData
-    globals()['MembershipData'] = MembershipData
-    globals()['UserGroupData'] = UserGroupData
+from symphony.bdk.gen.pod_model.membership_data import MembershipData
+from symphony.bdk.gen.pod_model.user_group_data import UserGroupData
+globals()['MembershipData'] = MembershipData
+globals()['UserGroupData'] = UserGroupData
 
 
 class UserGroupMembershipData(ModelNormal):
@@ -77,16 +77,15 @@ class UserGroupMembershipData(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'id': (str,),  # noqa: E501
-            'group_id': (str,),  # noqa: E501
-            'user_id': (int,),  # noqa: E501
-            'group': (UserGroupData,),  # noqa: E501
-            'user': (MembershipData,),  # noqa: E501
-            'active': (bool,),  # noqa: E501
-            'last_added_date': (int,),  # noqa: E501
-            'last_removed_date': (int,),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
+            'group_id': (str, none_type),  # noqa: E501
+            'user_id': (int, none_type),  # noqa: E501
+            'group': (UserGroupData, none_type),  # noqa: E501
+            'user': (MembershipData, none_type),  # noqa: E501
+            'active': (bool, none_type),  # noqa: E501
+            'last_added_date': (int, none_type),  # noqa: E501
+            'last_removed_date': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -183,7 +182,14 @@ class UserGroupMembershipData(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: str = None
+        self.group_id: str = None
+        self.user_id: int = None
+        self.group: UserGroupData = None
+        self.user: MembershipData = None
+        self.active: bool = None
+        self.last_added_date: int = None
+        self.last_removed_date: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_group_membership_request.py
+++ b/symphony/bdk/gen/pod_model/user_group_membership_request.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,7 +73,7 @@ class UserGroupMembershipRequest(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'active': (bool,),  # noqa: E501
+            'active': (bool, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -155,7 +156,7 @@ class UserGroupMembershipRequest(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.active: bool = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_group_membership_response.py
+++ b/symphony/bdk/gen/pod_model/user_group_membership_response.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.pagination import Pagination
-    from symphony.bdk.gen.pod_model.user_group_membership_response_data import UserGroupMembershipResponseData
-    globals()['Pagination'] = Pagination
-    globals()['UserGroupMembershipResponseData'] = UserGroupMembershipResponseData
+from symphony.bdk.gen.pod_model.pagination import Pagination
+from symphony.bdk.gen.pod_model.user_group_membership_response_data import UserGroupMembershipResponseData
+globals()['Pagination'] = Pagination
+globals()['UserGroupMembershipResponseData'] = UserGroupMembershipResponseData
 
 
 class UserGroupMembershipResponse(ModelNormal):
@@ -77,10 +77,9 @@ class UserGroupMembershipResponse(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'data': ([UserGroupMembershipResponseData],),  # noqa: E501
-            'pagination': (Pagination,),  # noqa: E501
+            'data': ([UserGroupMembershipResponseData], none_type),  # noqa: E501
+            'pagination': (Pagination, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -165,7 +164,8 @@ class UserGroupMembershipResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.data: List[UserGroupMembershipResponseData] = None
+        self.pagination: Pagination = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_group_membership_response_data.py
+++ b/symphony/bdk/gen/pod_model/user_group_membership_response_data.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.group_role_scope import GroupRoleScope
-    from symphony.bdk.gen.pod_model.user_compp import UserCompp
-    globals()['GroupRoleScope'] = GroupRoleScope
-    globals()['UserCompp'] = UserCompp
+from symphony.bdk.gen.pod_model.group_role_scope import GroupRoleScope
+from symphony.bdk.gen.pod_model.user_compp import UserCompp
+globals()['GroupRoleScope'] = GroupRoleScope
+globals()['UserCompp'] = UserCompp
 
 
 class UserGroupMembershipResponseData(ModelNormal):
@@ -77,16 +77,15 @@ class UserGroupMembershipResponseData(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'id': (str,),  # noqa: E501
-            'group_id': (str,),  # noqa: E501
-            'group': (GroupRoleScope,),  # noqa: E501
-            'user_id': (int,),  # noqa: E501
-            'user': (UserCompp,),  # noqa: E501
-            'active': (bool,),  # noqa: E501
-            'last_added_date': (int,),  # noqa: E501
-            'last_removed_date': (int,),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
+            'group_id': (str, none_type),  # noqa: E501
+            'group': (GroupRoleScope, none_type),  # noqa: E501
+            'user_id': (int, none_type),  # noqa: E501
+            'user': (UserCompp, none_type),  # noqa: E501
+            'active': (bool, none_type),  # noqa: E501
+            'last_added_date': (int, none_type),  # noqa: E501
+            'last_removed_date': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -183,7 +182,14 @@ class UserGroupMembershipResponseData(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: str = None
+        self.group_id: str = None
+        self.group: GroupRoleScope = None
+        self.user_id: int = None
+        self.user: UserCompp = None
+        self.active: bool = None
+        self.last_added_date: int = None
+        self.last_removed_date: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_group_membership_update.py
+++ b/symphony/bdk/gen/pod_model/user_group_membership_update.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,7 +73,7 @@ class UserGroupMembershipUpdate(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'active': (bool,),  # noqa: E501
+            'active': (bool, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -155,7 +156,7 @@ class UserGroupMembershipUpdate(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.active: bool = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_group_response.py
+++ b/symphony/bdk/gen/pod_model/user_group_response.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,16 +73,16 @@ class UserGroupResponse(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'id': (str,),  # noqa: E501
-            'name': (str,),  # noqa: E501
-            'area': (str,),  # noqa: E501
-            'description': (str,),  # noqa: E501
-            'type': (str,),  # noqa: E501
-            'active': (bool,),  # noqa: E501
-            'created_date': (int,),  # noqa: E501
-            'modified_date': (int,),  # noqa: E501
-            'member_count': (int,),  # noqa: E501
-            'assignee_count': (int,),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
+            'area': (str, none_type),  # noqa: E501
+            'description': (str, none_type),  # noqa: E501
+            'type': (str, none_type),  # noqa: E501
+            'active': (bool, none_type),  # noqa: E501
+            'created_date': (int, none_type),  # noqa: E501
+            'modified_date': (int, none_type),  # noqa: E501
+            'member_count': (int, none_type),  # noqa: E501
+            'assignee_count': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -182,7 +183,16 @@ class UserGroupResponse(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: str = None
+        self.name: str = None
+        self.area: str = None
+        self.description: str = None
+        self.type: str = None
+        self.active: bool = None
+        self.created_date: int = None
+        self.modified_date: int = None
+        self.member_count: int = None
+        self.assignee_count: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_group_response_list.py
+++ b/symphony/bdk/gen/pod_model/user_group_response_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.pagination import Pagination
-    from symphony.bdk.gen.pod_model.user_group_response import UserGroupResponse
-    globals()['Pagination'] = Pagination
-    globals()['UserGroupResponse'] = UserGroupResponse
+from symphony.bdk.gen.pod_model.pagination import Pagination
+from symphony.bdk.gen.pod_model.user_group_response import UserGroupResponse
+globals()['Pagination'] = Pagination
+globals()['UserGroupResponse'] = UserGroupResponse
 
 
 class UserGroupResponseList(ModelNormal):
@@ -77,10 +77,9 @@ class UserGroupResponseList(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'data': ([UserGroupResponse],),  # noqa: E501
-            'pagination': (Pagination,),  # noqa: E501
+            'data': ([UserGroupResponse], none_type),  # noqa: E501
+            'pagination': (Pagination, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -165,7 +164,8 @@ class UserGroupResponseList(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.data: List[UserGroupResponse] = None
+        self.pagination: Pagination = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_group_update.py
+++ b/symphony/bdk/gen/pod_model/user_group_update.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,10 +73,10 @@ class UserGroupUpdate(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'name': (str,),  # noqa: E501
-            'area': (str,),  # noqa: E501
-            'description': (str,),  # noqa: E501
-            'active': (bool,),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
+            'area': (str, none_type),  # noqa: E501
+            'description': (str, none_type),  # noqa: E501
+            'active': (bool, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -164,7 +165,10 @@ class UserGroupUpdate(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.name: str = None
+        self.area: str = None
+        self.description: str = None
+        self.active: bool = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_id.py
+++ b/symphony/bdk/gen/pod_model/user_id.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,7 +73,7 @@ class UserId(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'id': (int,),  # noqa: E501
+            'id': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -155,7 +156,7 @@ class UserId(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_id_list.py
+++ b/symphony/bdk/gen/pod_model/user_id_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -131,6 +132,8 @@ class UserIdList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -146,7 +149,6 @@ class UserIdList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -166,7 +168,7 @@ class UserIdList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[int] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/user_info.py
+++ b/symphony/bdk/gen/pod_model/user_info.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.user_attributes import UserAttributes
-    from symphony.bdk.gen.pod_model.user_system_info import UserSystemInfo
-    globals()['UserAttributes'] = UserAttributes
-    globals()['UserSystemInfo'] = UserSystemInfo
+from symphony.bdk.gen.pod_model.user_attributes import UserAttributes
+from symphony.bdk.gen.pod_model.user_system_info import UserSystemInfo
+globals()['UserAttributes'] = UserAttributes
+globals()['UserSystemInfo'] = UserSystemInfo
 
 
 class UserInfo(ModelNormal):
@@ -77,10 +77,9 @@ class UserInfo(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'user': (UserAttributes,),  # noqa: E501
-            'user_system_info': (UserSystemInfo,),  # noqa: E501
+            'user': (UserAttributes, none_type),  # noqa: E501
+            'user_system_info': (UserSystemInfo, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -165,7 +164,8 @@ class UserInfo(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.user: UserAttributes = None
+        self.user_system_info: UserSystemInfo = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_name.py
+++ b/symphony/bdk/gen/pod_model/user_name.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,7 +73,7 @@ class UserName(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'username': (str,),  # noqa: E501
+            'username': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -155,7 +156,7 @@ class UserName(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.username: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_name_list.py
+++ b/symphony/bdk/gen/pod_model/user_name_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.user_name import UserName
-    globals()['UserName'] = UserName
+from symphony.bdk.gen.pod_model.user_name import UserName
+globals()['UserName'] = UserName
 
 
 class UserNameList(ModelSimple):
@@ -71,7 +71,6 @@ class UserNameList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([UserName],),
         }
@@ -136,6 +135,8 @@ class UserNameList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -151,7 +152,6 @@ class UserNameList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -171,7 +171,7 @@ class UserNameList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[UserName] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/user_search_filter.py
+++ b/symphony/bdk/gen/pod_model/user_search_filter.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,13 +73,13 @@ class UserSearchFilter(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'title': (str,),  # noqa: E501
-            'company': (str,),  # noqa: E501
-            'location': (str,),  # noqa: E501
-            'market_coverage': (str,),  # noqa: E501
-            'responsibility': (str,),  # noqa: E501
-            'function': (str,),  # noqa: E501
-            'instrument': (str,),  # noqa: E501
+            'title': (str, none_type),  # noqa: E501
+            'company': (str, none_type),  # noqa: E501
+            'location': (str, none_type),  # noqa: E501
+            'market_coverage': (str, none_type),  # noqa: E501
+            'responsibility': (str, none_type),  # noqa: E501
+            'function': (str, none_type),  # noqa: E501
+            'instrument': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -173,7 +174,13 @@ class UserSearchFilter(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.title: str = None
+        self.company: str = None
+        self.location: str = None
+        self.market_coverage: str = None
+        self.responsibility: str = None
+        self.function: str = None
+        self.instrument: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_search_query.py
+++ b/symphony/bdk/gen/pod_model/user_search_query.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.user_search_filter import UserSearchFilter
-    globals()['UserSearchFilter'] = UserSearchFilter
+from symphony.bdk.gen.pod_model.user_search_filter import UserSearchFilter
+globals()['UserSearchFilter'] = UserSearchFilter
 
 
 class UserSearchQuery(ModelNormal):
@@ -75,10 +75,9 @@ class UserSearchQuery(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'query': (str,),  # noqa: E501
-            'filters': (UserSearchFilter,),  # noqa: E501
+            'query': (str, none_type),  # noqa: E501
+            'filters': (UserSearchFilter, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -163,7 +162,8 @@ class UserSearchQuery(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.query: str = None
+        self.filters: UserSearchFilter = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_search_results.py
+++ b/symphony/bdk/gen/pod_model/user_search_results.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.user_search_query import UserSearchQuery
-    from symphony.bdk.gen.pod_model.user_v2 import UserV2
-    globals()['UserSearchQuery'] = UserSearchQuery
-    globals()['UserV2'] = UserV2
+from symphony.bdk.gen.pod_model.user_search_query import UserSearchQuery
+from symphony.bdk.gen.pod_model.user_v2 import UserV2
+globals()['UserSearchQuery'] = UserSearchQuery
+globals()['UserV2'] = UserV2
 
 
 class UserSearchResults(ModelNormal):
@@ -77,13 +77,12 @@ class UserSearchResults(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'count': (int,),  # noqa: E501
-            'skip': (int,),  # noqa: E501
-            'limit': (int,),  # noqa: E501
-            'search_query': (UserSearchQuery,),  # noqa: E501
-            'users': ([UserV2],),  # noqa: E501
+            'count': (int, none_type),  # noqa: E501
+            'skip': (int, none_type),  # noqa: E501
+            'limit': (int, none_type),  # noqa: E501
+            'search_query': (UserSearchQuery, none_type),  # noqa: E501
+            'users': ([UserV2], none_type),  # noqa: E501
         }
 
     @cached_property
@@ -174,7 +173,11 @@ class UserSearchResults(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.count: int = None
+        self.skip: int = None
+        self.limit: int = None
+        self.search_query: UserSearchQuery = None
+        self.users: List[UserV2] = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_status.py
+++ b/symphony/bdk/gen/pod_model/user_status.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -76,7 +77,7 @@ class UserStatus(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'status': (str,),  # noqa: E501
+            'status': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -159,7 +160,7 @@ class UserStatus(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.status: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_suspension.py
+++ b/symphony/bdk/gen/pod_model/user_suspension.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,9 +73,9 @@ class UserSuspension(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'suspended': (bool,),  # noqa: E501
-            'suspended_until': (int,),  # noqa: E501
-            'suspension_reason': (str,),  # noqa: E501
+            'suspended': (bool, none_type),  # noqa: E501
+            'suspended_until': (int, none_type),  # noqa: E501
+            'suspension_reason': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -161,7 +162,9 @@ class UserSuspension(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.suspended: bool = None
+        self.suspended_until: int = None
+        self.suspension_reason: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_system_info.py
+++ b/symphony/bdk/gen/pod_model/user_system_info.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -76,14 +77,14 @@ class UserSystemInfo(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'id': (int,),  # noqa: E501
-            'status': (str,),  # noqa: E501
-            'created_date': (int,),  # noqa: E501
-            'created_by': (str,),  # noqa: E501
-            'last_updated_date': (int,),  # noqa: E501
-            'last_login_date': (int,),  # noqa: E501
-            'last_password_reset': (int,),  # noqa: E501
-            'deactivated_date': (int,),  # noqa: E501
+            'id': (int, none_type),  # noqa: E501
+            'status': (str, none_type),  # noqa: E501
+            'created_date': (int, none_type),  # noqa: E501
+            'created_by': (str, none_type),  # noqa: E501
+            'last_updated_date': (int, none_type),  # noqa: E501
+            'last_login_date': (int, none_type),  # noqa: E501
+            'last_password_reset': (int, none_type),  # noqa: E501
+            'deactivated_date': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -180,7 +181,14 @@ class UserSystemInfo(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: int = None
+        self.status: str = None
+        self.created_date: int = None
+        self.created_by: str = None
+        self.last_updated_date: int = None
+        self.last_login_date: int = None
+        self.last_password_reset: int = None
+        self.deactivated_date: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_v2.py
+++ b/symphony/bdk/gen/pod_model/user_v2.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.avatar_list import AvatarList
-    from symphony.bdk.gen.pod_model.string_list import StringList
-    globals()['AvatarList'] = AvatarList
-    globals()['StringList'] = StringList
+from symphony.bdk.gen.pod_model.avatar_list import AvatarList
+from symphony.bdk.gen.pod_model.string_list import StringList
+globals()['AvatarList'] = AvatarList
+globals()['StringList'] = StringList
 
 
 class UserV2(ModelNormal):
@@ -81,25 +81,24 @@ class UserV2(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'id': (int,),  # noqa: E501
-            'email_address': (str,),  # noqa: E501
-            'first_name': (str,),  # noqa: E501
-            'last_name': (str,),  # noqa: E501
-            'display_name': (str,),  # noqa: E501
-            'title': (str,),  # noqa: E501
-            'company': (str,),  # noqa: E501
-            'username': (str,),  # noqa: E501
-            'location': (str,),  # noqa: E501
-            'account_type': (str,),  # noqa: E501
-            'avatars': (AvatarList,),  # noqa: E501
-            'work_phone_number': (str,),  # noqa: E501
-            'mobile_phone_number': (str,),  # noqa: E501
-            'job_function': (str,),  # noqa: E501
-            'department': (str,),  # noqa: E501
-            'division': (str,),  # noqa: E501
-            'roles': (StringList,),  # noqa: E501
+            'id': (int, none_type),  # noqa: E501
+            'email_address': (str, none_type),  # noqa: E501
+            'first_name': (str, none_type),  # noqa: E501
+            'last_name': (str, none_type),  # noqa: E501
+            'display_name': (str, none_type),  # noqa: E501
+            'title': (str, none_type),  # noqa: E501
+            'company': (str, none_type),  # noqa: E501
+            'username': (str, none_type),  # noqa: E501
+            'location': (str, none_type),  # noqa: E501
+            'account_type': (str, none_type),  # noqa: E501
+            'avatars': (AvatarList, none_type),  # noqa: E501
+            'work_phone_number': (str, none_type),  # noqa: E501
+            'mobile_phone_number': (str, none_type),  # noqa: E501
+            'job_function': (str, none_type),  # noqa: E501
+            'department': (str, none_type),  # noqa: E501
+            'division': (str, none_type),  # noqa: E501
+            'roles': (StringList, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -214,7 +213,23 @@ class UserV2(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: int = None
+        self.email_address: str = None
+        self.first_name: str = None
+        self.last_name: str = None
+        self.display_name: str = None
+        self.title: str = None
+        self.company: str = None
+        self.username: str = None
+        self.location: str = None
+        self.account_type: str = None
+        self.avatars: AvatarList = None
+        self.work_phone_number: str = None
+        self.mobile_phone_number: str = None
+        self.job_function: str = None
+        self.department: str = None
+        self.division: str = None
+        self.roles: StringList = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/v2_admin_stream_attributes.py
+++ b/symphony/bdk/gen/pod_model/v2_admin_stream_attributes.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,16 +73,16 @@ class V2AdminStreamAttributes(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'room_name': (str,),  # noqa: E501
-            'room_description': (str,),  # noqa: E501
-            'members': ([int],),  # noqa: E501
-            'created_by_user_id': (int,),  # noqa: E501
-            'created_date': (int,),  # noqa: E501
-            'last_modified_date': (int,),  # noqa: E501
-            'origin_company': (str,),  # noqa: E501
-            'origin_company_id': (int,),  # noqa: E501
-            'members_count': (int,),  # noqa: E501
-            'last_message_date': (int,),  # noqa: E501
+            'room_name': (str, none_type),  # noqa: E501
+            'room_description': (str, none_type),  # noqa: E501
+            'members': ([int], none_type),  # noqa: E501
+            'created_by_user_id': (int, none_type),  # noqa: E501
+            'created_date': (int, none_type),  # noqa: E501
+            'last_modified_date': (int, none_type),  # noqa: E501
+            'origin_company': (str, none_type),  # noqa: E501
+            'origin_company_id': (int, none_type),  # noqa: E501
+            'members_count': (int, none_type),  # noqa: E501
+            'last_message_date': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -182,7 +183,16 @@ class V2AdminStreamAttributes(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.room_name: str = None
+        self.room_description: str = None
+        self.members: List[int] = None
+        self.created_by_user_id: int = None
+        self.created_date: int = None
+        self.last_modified_date: int = None
+        self.origin_company: str = None
+        self.origin_company_id: int = None
+        self.members_count: int = None
+        self.last_message_date: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/v2_admin_stream_filter.py
+++ b/symphony/bdk/gen/pod_model/v2_admin_stream_filter.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.v2_admin_stream_type import V2AdminStreamType
-    globals()['V2AdminStreamType'] = V2AdminStreamType
+from symphony.bdk.gen.pod_model.v2_admin_stream_type import V2AdminStreamType
+globals()['V2AdminStreamType'] = V2AdminStreamType
 
 
 class V2AdminStreamFilter(ModelNormal):
@@ -75,15 +75,14 @@ class V2AdminStreamFilter(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'stream_types': ([V2AdminStreamType],),  # noqa: E501
-            'scope': (str,),  # noqa: E501
-            'origin': (str,),  # noqa: E501
-            'status': (str,),  # noqa: E501
-            'privacy': (str,),  # noqa: E501
-            'start_date': (int,),  # noqa: E501
-            'end_date': (int,),  # noqa: E501
+            'stream_types': ([V2AdminStreamType], none_type),  # noqa: E501
+            'scope': (str, none_type),  # noqa: E501
+            'origin': (str, none_type),  # noqa: E501
+            'status': (str, none_type),  # noqa: E501
+            'privacy': (str, none_type),  # noqa: E501
+            'start_date': (int, none_type),  # noqa: E501
+            'end_date': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -178,7 +177,13 @@ class V2AdminStreamFilter(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.stream_types: List[V2AdminStreamType] = None
+        self.scope: str = None
+        self.origin: str = None
+        self.status: str = None
+        self.privacy: str = None
+        self.start_date: int = None
+        self.end_date: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/v2_admin_stream_info.py
+++ b/symphony/bdk/gen/pod_model/v2_admin_stream_info.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.v2_admin_stream_attributes import V2AdminStreamAttributes
-    globals()['V2AdminStreamAttributes'] = V2AdminStreamAttributes
+from symphony.bdk.gen.pod_model.v2_admin_stream_attributes import V2AdminStreamAttributes
+globals()['V2AdminStreamAttributes'] = V2AdminStreamAttributes
 
 
 class V2AdminStreamInfo(ModelNormal):
@@ -75,16 +75,15 @@ class V2AdminStreamInfo(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'id': (str,),  # noqa: E501
-            'is_external': (bool,),  # noqa: E501
-            'is_active': (bool,),  # noqa: E501
-            'is_public': (bool,),  # noqa: E501
-            'type': (str,),  # noqa: E501
-            'cross_pod': (bool,),  # noqa: E501
-            'origin': (str,),  # noqa: E501
-            'attributes': (V2AdminStreamAttributes,),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
+            'is_external': (bool, none_type),  # noqa: E501
+            'is_active': (bool, none_type),  # noqa: E501
+            'is_public': (bool, none_type),  # noqa: E501
+            'type': (str, none_type),  # noqa: E501
+            'cross_pod': (bool, none_type),  # noqa: E501
+            'origin': (str, none_type),  # noqa: E501
+            'attributes': (V2AdminStreamAttributes, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -181,7 +180,14 @@ class V2AdminStreamInfo(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: str = None
+        self.is_external: bool = None
+        self.is_active: bool = None
+        self.is_public: bool = None
+        self.type: str = None
+        self.cross_pod: bool = None
+        self.origin: str = None
+        self.attributes: V2AdminStreamAttributes = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/v2_admin_stream_info_list.py
+++ b/symphony/bdk/gen/pod_model/v2_admin_stream_info_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.v2_admin_stream_info import V2AdminStreamInfo
-    globals()['V2AdminStreamInfo'] = V2AdminStreamInfo
+from symphony.bdk.gen.pod_model.v2_admin_stream_info import V2AdminStreamInfo
+globals()['V2AdminStreamInfo'] = V2AdminStreamInfo
 
 
 class V2AdminStreamInfoList(ModelSimple):
@@ -71,7 +71,6 @@ class V2AdminStreamInfoList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([V2AdminStreamInfo],),
         }
@@ -136,6 +135,8 @@ class V2AdminStreamInfoList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -151,7 +152,6 @@ class V2AdminStreamInfoList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -171,7 +171,7 @@ class V2AdminStreamInfoList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[V2AdminStreamInfo] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/v2_admin_stream_list.py
+++ b/symphony/bdk/gen/pod_model/v2_admin_stream_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.v2_admin_stream_filter import V2AdminStreamFilter
-    from symphony.bdk.gen.pod_model.v2_admin_stream_info_list import V2AdminStreamInfoList
-    globals()['V2AdminStreamFilter'] = V2AdminStreamFilter
-    globals()['V2AdminStreamInfoList'] = V2AdminStreamInfoList
+from symphony.bdk.gen.pod_model.v2_admin_stream_filter import V2AdminStreamFilter
+from symphony.bdk.gen.pod_model.v2_admin_stream_info_list import V2AdminStreamInfoList
+globals()['V2AdminStreamFilter'] = V2AdminStreamFilter
+globals()['V2AdminStreamInfoList'] = V2AdminStreamInfoList
 
 
 class V2AdminStreamList(ModelNormal):
@@ -77,13 +77,12 @@ class V2AdminStreamList(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'count': (int,),  # noqa: E501
-            'skip': (int,),  # noqa: E501
-            'limit': (int,),  # noqa: E501
-            'filter': (V2AdminStreamFilter,),  # noqa: E501
-            'streams': (V2AdminStreamInfoList,),  # noqa: E501
+            'count': (int, none_type),  # noqa: E501
+            'skip': (int, none_type),  # noqa: E501
+            'limit': (int, none_type),  # noqa: E501
+            'filter': (V2AdminStreamFilter, none_type),  # noqa: E501
+            'streams': (V2AdminStreamInfoList, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -174,7 +173,11 @@ class V2AdminStreamList(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.count: int = None
+        self.skip: int = None
+        self.limit: int = None
+        self.filter: V2AdminStreamFilter = None
+        self.streams: V2AdminStreamInfoList = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/v2_admin_stream_type.py
+++ b/symphony/bdk/gen/pod_model/v2_admin_stream_type.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,7 +73,7 @@ class V2AdminStreamType(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'type': (str,),  # noqa: E501
+            'type': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -155,7 +156,7 @@ class V2AdminStreamType(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.type: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/v2_conversation_specific_stream_attributes.py
+++ b/symphony/bdk/gen/pod_model/v2_conversation_specific_stream_attributes.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.user_id_list import UserIdList
-    globals()['UserIdList'] = UserIdList
+from symphony.bdk.gen.pod_model.user_id_list import UserIdList
+globals()['UserIdList'] = UserIdList
 
 
 class V2ConversationSpecificStreamAttributes(ModelNormal):
@@ -75,9 +75,8 @@ class V2ConversationSpecificStreamAttributes(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'members': (UserIdList,),  # noqa: E501
+            'members': (UserIdList, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -160,7 +159,7 @@ class V2ConversationSpecificStreamAttributes(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.members: UserIdList = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/v2_member_info.py
+++ b/symphony/bdk/gen/pod_model/v2_member_info.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.v2_member_user_detail import V2MemberUserDetail
-    globals()['V2MemberUserDetail'] = V2MemberUserDetail
+from symphony.bdk.gen.pod_model.v2_member_user_detail import V2MemberUserDetail
+globals()['V2MemberUserDetail'] = V2MemberUserDetail
 
 
 class V2MemberInfo(ModelNormal):
@@ -75,12 +75,11 @@ class V2MemberInfo(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'user': (V2MemberUserDetail,),  # noqa: E501
-            'is_owner': (bool,),  # noqa: E501
-            'is_creator': (bool,),  # noqa: E501
-            'join_date': (int,),  # noqa: E501
+            'user': (V2MemberUserDetail, none_type),  # noqa: E501
+            'is_owner': (bool, none_type),  # noqa: E501
+            'is_creator': (bool, none_type),  # noqa: E501
+            'join_date': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -169,7 +168,10 @@ class V2MemberInfo(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.user: V2MemberUserDetail = None
+        self.is_owner: bool = None
+        self.is_creator: bool = None
+        self.join_date: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/v2_member_info_list.py
+++ b/symphony/bdk/gen/pod_model/v2_member_info_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.v2_member_info import V2MemberInfo
-    globals()['V2MemberInfo'] = V2MemberInfo
+from symphony.bdk.gen.pod_model.v2_member_info import V2MemberInfo
+globals()['V2MemberInfo'] = V2MemberInfo
 
 
 class V2MemberInfoList(ModelSimple):
@@ -71,7 +71,6 @@ class V2MemberInfoList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([V2MemberInfo],),
         }
@@ -136,6 +135,8 @@ class V2MemberInfoList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -151,7 +152,6 @@ class V2MemberInfoList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -171,7 +171,7 @@ class V2MemberInfoList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[V2MemberInfo] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/v2_member_user_detail.py
+++ b/symphony/bdk/gen/pod_model/v2_member_user_detail.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,14 +73,14 @@ class V2MemberUserDetail(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'user_id': (int,),  # noqa: E501
-            'email': (str,),  # noqa: E501
-            'first_name': (str,),  # noqa: E501
-            'last_name': (str,),  # noqa: E501
-            'display_name': (str,),  # noqa: E501
-            'company': (str,),  # noqa: E501
-            'company_id': (int,),  # noqa: E501
-            'is_external': (bool,),  # noqa: E501
+            'user_id': (int, none_type),  # noqa: E501
+            'email': (str, none_type),  # noqa: E501
+            'first_name': (str, none_type),  # noqa: E501
+            'last_name': (str, none_type),  # noqa: E501
+            'display_name': (str, none_type),  # noqa: E501
+            'company': (str, none_type),  # noqa: E501
+            'company_id': (int, none_type),  # noqa: E501
+            'is_external': (bool, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -176,7 +177,14 @@ class V2MemberUserDetail(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.user_id: int = None
+        self.email: str = None
+        self.first_name: str = None
+        self.last_name: str = None
+        self.display_name: str = None
+        self.company: str = None
+        self.company_id: int = None
+        self.is_external: bool = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/v2_membership_list.py
+++ b/symphony/bdk/gen/pod_model/v2_membership_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.v2_member_info_list import V2MemberInfoList
-    globals()['V2MemberInfoList'] = V2MemberInfoList
+from symphony.bdk.gen.pod_model.v2_member_info_list import V2MemberInfoList
+globals()['V2MemberInfoList'] = V2MemberInfoList
 
 
 class V2MembershipList(ModelNormal):
@@ -75,12 +75,11 @@ class V2MembershipList(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'count': (int,),  # noqa: E501
-            'skip': (int,),  # noqa: E501
-            'limit': (int,),  # noqa: E501
-            'members': (V2MemberInfoList,),  # noqa: E501
+            'count': (int, none_type),  # noqa: E501
+            'skip': (int, none_type),  # noqa: E501
+            'limit': (int, none_type),  # noqa: E501
+            'members': (V2MemberInfoList, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -169,7 +168,10 @@ class V2MembershipList(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.count: int = None
+        self.skip: int = None
+        self.limit: int = None
+        self.members: V2MemberInfoList = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/v2_presence.py
+++ b/symphony/bdk/gen/pod_model/v2_presence.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.v2_presence_all_of import V2PresenceAllOf
-    from symphony.bdk.gen.pod_model.v2_user_presence import V2UserPresence
-    globals()['V2PresenceAllOf'] = V2PresenceAllOf
-    globals()['V2UserPresence'] = V2UserPresence
+from symphony.bdk.gen.pod_model.v2_presence_all_of import V2PresenceAllOf
+from symphony.bdk.gen.pod_model.v2_user_presence import V2UserPresence
+globals()['V2PresenceAllOf'] = V2PresenceAllOf
+globals()['V2UserPresence'] = V2UserPresence
 
 
 class V2Presence(ModelComposed):
@@ -69,7 +69,6 @@ class V2Presence(ModelComposed):
         This must be a method because a pod_model may have properties that are
         of type self, this must run after the class is loaded
         """
-        lazy_import()
         return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
 
     _nullable = False
@@ -84,11 +83,10 @@ class V2Presence(ModelComposed):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'category': (str,),  # noqa: E501
-            'user_id': (int,),  # noqa: E501
-            'timestamp': (int,),  # noqa: E501
+            'user_id': (int, none_type),  # noqa: E501
+            'timestamp': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -198,9 +196,9 @@ class V2Presence(ModelComposed):
         self._var_name_to_model_instances = composed_info[1]
         self._additional_properties_model_instances = composed_info[2]
         unused_args = composed_info[3]
-
-        for var_name, var_value in required_args.items():
-            setattr(self, var_name, var_value)
+        self.category: str = category
+        self.user_id: int = None
+        self.timestamp: int = None
         for var_name, var_value in kwargs.items():
             if var_name in unused_args and \
                         self._configuration is not None and \
@@ -219,7 +217,6 @@ class V2Presence(ModelComposed):
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        lazy_import()
         return {
           'anyOf': [
           ],

--- a/symphony/bdk/gen/pod_model/v2_presence_all_of.py
+++ b/symphony/bdk/gen/pod_model/v2_presence_all_of.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,7 +73,7 @@ class V2PresenceAllOf(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'timestamp': (int,),  # noqa: E501
+            'timestamp': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -155,7 +156,7 @@ class V2PresenceAllOf(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.timestamp: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/v2_presence_list.py
+++ b/symphony/bdk/gen/pod_model/v2_presence_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.v2_presence import V2Presence
-    globals()['V2Presence'] = V2Presence
+from symphony.bdk.gen.pod_model.v2_presence import V2Presence
+globals()['V2Presence'] = V2Presence
 
 
 class V2PresenceList(ModelSimple):
@@ -71,7 +71,6 @@ class V2PresenceList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([V2Presence],),
         }
@@ -136,6 +135,8 @@ class V2PresenceList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -151,7 +152,6 @@ class V2PresenceList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -171,7 +171,7 @@ class V2PresenceList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[V2Presence] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/v2_presence_status.py
+++ b/symphony/bdk/gen/pod_model/v2_presence_status.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -157,8 +158,7 @@ class V2PresenceStatus(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
-        self.category = category
+        self.category: str = category
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/v2_room_attributes.py
+++ b/symphony/bdk/gen/pod_model/v2_room_attributes.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.room_tag import RoomTag
-    globals()['RoomTag'] = RoomTag
+from symphony.bdk.gen.pod_model.room_tag import RoomTag
+globals()['RoomTag'] = RoomTag
 
 
 class V2RoomAttributes(ModelNormal):
@@ -75,16 +75,15 @@ class V2RoomAttributes(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'name': (str,),  # noqa: E501
-            'keywords': ([RoomTag],),  # noqa: E501
-            'description': (str,),  # noqa: E501
-            'members_can_invite': (bool,),  # noqa: E501
-            'discoverable': (bool,),  # noqa: E501
-            'public': (bool,),  # noqa: E501
-            'read_only': (bool,),  # noqa: E501
-            'copy_protected': (bool,),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
+            'keywords': ([RoomTag], none_type),  # noqa: E501
+            'description': (str, none_type),  # noqa: E501
+            'members_can_invite': (bool, none_type),  # noqa: E501
+            'discoverable': (bool, none_type),  # noqa: E501
+            'public': (bool, none_type),  # noqa: E501
+            'read_only': (bool, none_type),  # noqa: E501
+            'copy_protected': (bool, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -181,7 +180,14 @@ class V2RoomAttributes(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.name: str = None
+        self.keywords: List[RoomTag] = None
+        self.description: str = None
+        self.members_can_invite: bool = None
+        self.discoverable: bool = None
+        self.public: bool = None
+        self.read_only: bool = None
+        self.copy_protected: bool = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/v2_room_detail.py
+++ b/symphony/bdk/gen/pod_model/v2_room_detail.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.room_system_info import RoomSystemInfo
-    from symphony.bdk.gen.pod_model.v2_room_attributes import V2RoomAttributes
-    globals()['RoomSystemInfo'] = RoomSystemInfo
-    globals()['V2RoomAttributes'] = V2RoomAttributes
+from symphony.bdk.gen.pod_model.room_system_info import RoomSystemInfo
+from symphony.bdk.gen.pod_model.v2_room_attributes import V2RoomAttributes
+globals()['RoomSystemInfo'] = RoomSystemInfo
+globals()['V2RoomAttributes'] = V2RoomAttributes
 
 
 class V2RoomDetail(ModelNormal):
@@ -77,10 +77,9 @@ class V2RoomDetail(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'room_attributes': (V2RoomAttributes,),  # noqa: E501
-            'room_system_info': (RoomSystemInfo,),  # noqa: E501
+            'room_attributes': (V2RoomAttributes, none_type),  # noqa: E501
+            'room_system_info': (RoomSystemInfo, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -165,7 +164,8 @@ class V2RoomDetail(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.room_attributes: V2RoomAttributes = None
+        self.room_system_info: RoomSystemInfo = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/v2_room_search_criteria.py
+++ b/symphony/bdk/gen/pod_model/v2_room_search_criteria.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,13 +27,12 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.room_search_criteria import RoomSearchCriteria
-    from symphony.bdk.gen.pod_model.user_id import UserId
-    from symphony.bdk.gen.pod_model.v2_room_search_criteria_all_of import V2RoomSearchCriteriaAllOf
-    globals()['RoomSearchCriteria'] = RoomSearchCriteria
-    globals()['UserId'] = UserId
-    globals()['V2RoomSearchCriteriaAllOf'] = V2RoomSearchCriteriaAllOf
+from symphony.bdk.gen.pod_model.room_search_criteria import RoomSearchCriteria
+from symphony.bdk.gen.pod_model.user_id import UserId
+from symphony.bdk.gen.pod_model.v2_room_search_criteria_all_of import V2RoomSearchCriteriaAllOf
+globals()['RoomSearchCriteria'] = RoomSearchCriteria
+globals()['UserId'] = UserId
+globals()['V2RoomSearchCriteriaAllOf'] = V2RoomSearchCriteriaAllOf
 
 
 class V2RoomSearchCriteria(ModelComposed):
@@ -75,7 +75,6 @@ class V2RoomSearchCriteria(ModelComposed):
         This must be a method because a pod_model may have properties that are
         of type self, this must run after the class is loaded
         """
-        lazy_import()
         return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
 
     _nullable = False
@@ -90,17 +89,16 @@ class V2RoomSearchCriteria(ModelComposed):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'query': (str,),  # noqa: E501
-            'labels': ([str],),  # noqa: E501
-            'active': (bool,),  # noqa: E501
-            'private': (bool,),  # noqa: E501
-            'owner': (UserId,),  # noqa: E501
-            'creator': (UserId,),  # noqa: E501
-            'member': (UserId,),  # noqa: E501
-            'sort_order': (str,),  # noqa: E501
-            'sub_type': (str,),  # noqa: E501
+            'labels': ([str], none_type),  # noqa: E501
+            'active': (bool, none_type),  # noqa: E501
+            'private': (bool, none_type),  # noqa: E501
+            'owner': (UserId, none_type),  # noqa: E501
+            'creator': (UserId, none_type),  # noqa: E501
+            'member': (UserId, none_type),  # noqa: E501
+            'sort_order': (str, none_type),  # noqa: E501
+            'sub_type': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -222,9 +220,15 @@ class V2RoomSearchCriteria(ModelComposed):
         self._var_name_to_model_instances = composed_info[1]
         self._additional_properties_model_instances = composed_info[2]
         unused_args = composed_info[3]
-
-        for var_name, var_value in required_args.items():
-            setattr(self, var_name, var_value)
+        self.query: str = query
+        self.labels: List[str] = None
+        self.active: bool = None
+        self.private: bool = None
+        self.owner: UserId = None
+        self.creator: UserId = None
+        self.member: UserId = None
+        self.sort_order: str = None
+        self.sub_type: str = None
         for var_name, var_value in kwargs.items():
             if var_name in unused_args and \
                         self._configuration is not None and \
@@ -243,7 +247,6 @@ class V2RoomSearchCriteria(ModelComposed):
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        lazy_import()
         return {
           'anyOf': [
           ],

--- a/symphony/bdk/gen/pod_model/v2_room_search_criteria_all_of.py
+++ b/symphony/bdk/gen/pod_model/v2_room_search_criteria_all_of.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,7 +73,7 @@ class V2RoomSearchCriteriaAllOf(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'sub_type': (str,),  # noqa: E501
+            'sub_type': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -155,7 +156,7 @@ class V2RoomSearchCriteriaAllOf(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.sub_type: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/v2_room_specific_stream_attributes.py
+++ b/symphony/bdk/gen/pod_model/v2_room_specific_stream_attributes.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,7 +73,7 @@ class V2RoomSpecificStreamAttributes(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'name': (str,),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -155,7 +156,7 @@ class V2RoomSpecificStreamAttributes(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.name: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/v2_stream_attributes.py
+++ b/symphony/bdk/gen/pod_model/v2_stream_attributes.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,13 +27,12 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.v2_conversation_specific_stream_attributes import V2ConversationSpecificStreamAttributes
-    from symphony.bdk.gen.pod_model.v2_room_specific_stream_attributes import V2RoomSpecificStreamAttributes
-    from symphony.bdk.gen.pod_model.v2_stream_type import V2StreamType
-    globals()['V2ConversationSpecificStreamAttributes'] = V2ConversationSpecificStreamAttributes
-    globals()['V2RoomSpecificStreamAttributes'] = V2RoomSpecificStreamAttributes
-    globals()['V2StreamType'] = V2StreamType
+from symphony.bdk.gen.pod_model.v2_conversation_specific_stream_attributes import V2ConversationSpecificStreamAttributes
+from symphony.bdk.gen.pod_model.v2_room_specific_stream_attributes import V2RoomSpecificStreamAttributes
+from symphony.bdk.gen.pod_model.v2_stream_type import V2StreamType
+globals()['V2ConversationSpecificStreamAttributes'] = V2ConversationSpecificStreamAttributes
+globals()['V2RoomSpecificStreamAttributes'] = V2RoomSpecificStreamAttributes
+globals()['V2StreamType'] = V2StreamType
 
 
 class V2StreamAttributes(ModelNormal):
@@ -79,16 +79,15 @@ class V2StreamAttributes(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'id': (str,),  # noqa: E501
-            'cross_pod': (bool,),  # noqa: E501
-            'origin': (str,),  # noqa: E501
-            'active': (bool,),  # noqa: E501
-            'last_message_date': (int,),  # noqa: E501
-            'stream_type': (V2StreamType,),  # noqa: E501
-            'stream_attributes': (V2ConversationSpecificStreamAttributes,),  # noqa: E501
-            'room_attributes': (V2RoomSpecificStreamAttributes,),  # noqa: E501
+            'id': (str, none_type),  # noqa: E501
+            'cross_pod': (bool, none_type),  # noqa: E501
+            'origin': (str, none_type),  # noqa: E501
+            'active': (bool, none_type),  # noqa: E501
+            'last_message_date': (int, none_type),  # noqa: E501
+            'stream_type': (V2StreamType, none_type),  # noqa: E501
+            'stream_attributes': (V2ConversationSpecificStreamAttributes, none_type),  # noqa: E501
+            'room_attributes': (V2RoomSpecificStreamAttributes, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -185,7 +184,14 @@ class V2StreamAttributes(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.id: str = None
+        self.cross_pod: bool = None
+        self.origin: str = None
+        self.active: bool = None
+        self.last_message_date: int = None
+        self.stream_type: V2StreamType = None
+        self.stream_attributes: V2ConversationSpecificStreamAttributes = None
+        self.room_attributes: V2RoomSpecificStreamAttributes = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/v2_stream_type.py
+++ b/symphony/bdk/gen/pod_model/v2_stream_type.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,7 +73,7 @@ class V2StreamType(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'type': (str,),  # noqa: E501
+            'type': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -155,7 +156,7 @@ class V2StreamType(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.type: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/v2_user_attributes.py
+++ b/symphony/bdk/gen/pod_model/v2_user_attributes.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.v2_user_key_request import V2UserKeyRequest
-    globals()['V2UserKeyRequest'] = V2UserKeyRequest
+from symphony.bdk.gen.pod_model.v2_user_key_request import V2UserKeyRequest
+globals()['V2UserKeyRequest'] = V2UserKeyRequest
 
 
 class V2UserAttributes(ModelNormal):
@@ -79,33 +79,32 @@ class V2UserAttributes(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'email_address': (str,),  # noqa: E501
-            'first_name': (str,),  # noqa: E501
-            'last_name': (str,),  # noqa: E501
-            'user_name': (str,),  # noqa: E501
-            'display_name': (str,),  # noqa: E501
-            'company_name': (str,),  # noqa: E501
-            'department': (str,),  # noqa: E501
-            'division': (str,),  # noqa: E501
-            'title': (str,),  # noqa: E501
-            'work_phone_number': (str,),  # noqa: E501
-            'mobile_phone_number': (str,),  # noqa: E501
-            'two_factor_auth_phone': (str,),  # noqa: E501
-            'sms_number': (str,),  # noqa: E501
-            'account_type': (str,),  # noqa: E501
-            'location': (str,),  # noqa: E501
-            'recommended_language': (str,),  # noqa: E501
-            'job_function': (str,),  # noqa: E501
-            'asset_classes': ([str],),  # noqa: E501
-            'industries': ([str],),  # noqa: E501
-            'market_coverage': ([str],),  # noqa: E501
-            'responsibility': ([str],),  # noqa: E501
-            'function': ([str],),  # noqa: E501
-            'instrument': ([str],),  # noqa: E501
-            'current_key': (V2UserKeyRequest,),  # noqa: E501
-            'previous_key': (V2UserKeyRequest,),  # noqa: E501
+            'email_address': (str, none_type),  # noqa: E501
+            'first_name': (str, none_type),  # noqa: E501
+            'last_name': (str, none_type),  # noqa: E501
+            'user_name': (str, none_type),  # noqa: E501
+            'display_name': (str, none_type),  # noqa: E501
+            'company_name': (str, none_type),  # noqa: E501
+            'department': (str, none_type),  # noqa: E501
+            'division': (str, none_type),  # noqa: E501
+            'title': (str, none_type),  # noqa: E501
+            'work_phone_number': (str, none_type),  # noqa: E501
+            'mobile_phone_number': (str, none_type),  # noqa: E501
+            'two_factor_auth_phone': (str, none_type),  # noqa: E501
+            'sms_number': (str, none_type),  # noqa: E501
+            'account_type': (str, none_type),  # noqa: E501
+            'location': (str, none_type),  # noqa: E501
+            'recommended_language': (str, none_type),  # noqa: E501
+            'job_function': (str, none_type),  # noqa: E501
+            'asset_classes': ([str], none_type),  # noqa: E501
+            'industries': ([str], none_type),  # noqa: E501
+            'market_coverage': ([str], none_type),  # noqa: E501
+            'responsibility': ([str], none_type),  # noqa: E501
+            'function': ([str], none_type),  # noqa: E501
+            'instrument': ([str], none_type),  # noqa: E501
+            'current_key': (V2UserKeyRequest, none_type),  # noqa: E501
+            'previous_key': (V2UserKeyRequest, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -236,7 +235,31 @@ class V2UserAttributes(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.email_address: str = None
+        self.first_name: str = None
+        self.last_name: str = None
+        self.user_name: str = None
+        self.display_name: str = None
+        self.company_name: str = None
+        self.department: str = None
+        self.division: str = None
+        self.title: str = None
+        self.work_phone_number: str = None
+        self.mobile_phone_number: str = None
+        self.two_factor_auth_phone: str = None
+        self.sms_number: str = None
+        self.account_type: str = None
+        self.location: str = None
+        self.recommended_language: str = None
+        self.job_function: str = None
+        self.asset_classes: List[str] = None
+        self.industries: List[str] = None
+        self.market_coverage: List[str] = None
+        self.responsibility: List[str] = None
+        self.function: List[str] = None
+        self.instrument: List[str] = None
+        self.current_key: V2UserKeyRequest = None
+        self.previous_key: V2UserKeyRequest = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/v2_user_create.py
+++ b/symphony/bdk/gen/pod_model/v2_user_create.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.password import Password
-    from symphony.bdk.gen.pod_model.v2_user_attributes import V2UserAttributes
-    globals()['Password'] = Password
-    globals()['V2UserAttributes'] = V2UserAttributes
+from symphony.bdk.gen.pod_model.password import Password
+from symphony.bdk.gen.pod_model.v2_user_attributes import V2UserAttributes
+globals()['Password'] = Password
+globals()['V2UserAttributes'] = V2UserAttributes
 
 
 class V2UserCreate(ModelNormal):
@@ -77,11 +77,10 @@ class V2UserCreate(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'user_attributes': (V2UserAttributes,),  # noqa: E501
-            'password': (Password,),  # noqa: E501
-            'roles': ([str],),  # noqa: E501
+            'user_attributes': (V2UserAttributes, none_type),  # noqa: E501
+            'password': (Password, none_type),  # noqa: E501
+            'roles': ([str], none_type),  # noqa: E501
         }
 
     @cached_property
@@ -168,7 +167,9 @@ class V2UserCreate(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.user_attributes: V2UserAttributes = None
+        self.password: Password = None
+        self.roles: List[str] = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/v2_user_detail.py
+++ b/symphony/bdk/gen/pod_model/v2_user_detail.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,17 +27,16 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.avatar import Avatar
-    from symphony.bdk.gen.pod_model.integer_list import IntegerList
-    from symphony.bdk.gen.pod_model.string_list import StringList
-    from symphony.bdk.gen.pod_model.user_system_info import UserSystemInfo
-    from symphony.bdk.gen.pod_model.v2_user_attributes import V2UserAttributes
-    globals()['Avatar'] = Avatar
-    globals()['IntegerList'] = IntegerList
-    globals()['StringList'] = StringList
-    globals()['UserSystemInfo'] = UserSystemInfo
-    globals()['V2UserAttributes'] = V2UserAttributes
+from symphony.bdk.gen.pod_model.avatar import Avatar
+from symphony.bdk.gen.pod_model.integer_list import IntegerList
+from symphony.bdk.gen.pod_model.string_list import StringList
+from symphony.bdk.gen.pod_model.user_system_info import UserSystemInfo
+from symphony.bdk.gen.pod_model.v2_user_attributes import V2UserAttributes
+globals()['Avatar'] = Avatar
+globals()['IntegerList'] = IntegerList
+globals()['StringList'] = StringList
+globals()['UserSystemInfo'] = UserSystemInfo
+globals()['V2UserAttributes'] = V2UserAttributes
 
 
 class V2UserDetail(ModelNormal):
@@ -83,16 +83,15 @@ class V2UserDetail(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'user_attributes': (V2UserAttributes,),  # noqa: E501
-            'user_system_info': (UserSystemInfo,),  # noqa: E501
-            'features': (IntegerList,),  # noqa: E501
-            'apps': (IntegerList,),  # noqa: E501
-            'groups': (IntegerList,),  # noqa: E501
-            'roles': (StringList,),  # noqa: E501
-            'disclaimers': (IntegerList,),  # noqa: E501
-            'avatar': (Avatar,),  # noqa: E501
+            'user_attributes': (V2UserAttributes, none_type),  # noqa: E501
+            'user_system_info': (UserSystemInfo, none_type),  # noqa: E501
+            'features': (IntegerList, none_type),  # noqa: E501
+            'apps': (IntegerList, none_type),  # noqa: E501
+            'groups': (IntegerList, none_type),  # noqa: E501
+            'roles': (StringList, none_type),  # noqa: E501
+            'disclaimers': (IntegerList, none_type),  # noqa: E501
+            'avatar': (Avatar, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -189,7 +188,14 @@ class V2UserDetail(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.user_attributes: V2UserAttributes = None
+        self.user_system_info: UserSystemInfo = None
+        self.features: IntegerList = None
+        self.apps: IntegerList = None
+        self.groups: IntegerList = None
+        self.roles: StringList = None
+        self.disclaimers: IntegerList = None
+        self.avatar: Avatar = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/v2_user_detail_list.py
+++ b/symphony/bdk/gen/pod_model/v2_user_detail_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.v2_user_detail import V2UserDetail
-    globals()['V2UserDetail'] = V2UserDetail
+from symphony.bdk.gen.pod_model.v2_user_detail import V2UserDetail
+globals()['V2UserDetail'] = V2UserDetail
 
 
 class V2UserDetailList(ModelSimple):
@@ -71,7 +71,6 @@ class V2UserDetailList(ModelSimple):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'value': ([V2UserDetail],),
         }
@@ -136,6 +135,8 @@ class V2UserDetailList(ModelSimple):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
         """
+        # required up here when default value is not given
+        _path_to_item = kwargs.pop('_path_to_item', ())
 
         if 'value' in kwargs:
             value = kwargs.pop('value')
@@ -151,7 +152,6 @@ class V2UserDetailList(ModelSimple):
 
         _check_type = kwargs.pop('_check_type', True)
         _spec_property_naming = kwargs.pop('_spec_property_naming', False)
-        _path_to_item = kwargs.pop('_path_to_item', ())
         _configuration = kwargs.pop('_configuration', None)
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
@@ -171,7 +171,7 @@ class V2UserDetailList(ModelSimple):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-        self.value = value
+        self.value: List[V2UserDetail] = value
         if kwargs:
             raise ApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (

--- a/symphony/bdk/gen/pod_model/v2_user_key_request.py
+++ b/symphony/bdk/gen/pod_model/v2_user_key_request.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,9 +73,9 @@ class V2UserKeyRequest(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'key': (str,),  # noqa: E501
-            'expiration_date': (int,),  # noqa: E501
-            'action': (str,),  # noqa: E501
+            'key': (str, none_type),  # noqa: E501
+            'expiration_date': (int, none_type),  # noqa: E501
+            'action': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -161,7 +162,9 @@ class V2UserKeyRequest(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.key: str = None
+        self.expiration_date: int = None
+        self.action: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/v2_user_list.py
+++ b/symphony/bdk/gen/pod_model/v2_user_list.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.user_error import UserError
-    from symphony.bdk.gen.pod_model.user_v2 import UserV2
-    globals()['UserError'] = UserError
-    globals()['UserV2'] = UserV2
+from symphony.bdk.gen.pod_model.user_error import UserError
+from symphony.bdk.gen.pod_model.user_v2 import UserV2
+globals()['UserError'] = UserError
+globals()['UserV2'] = UserV2
 
 
 class V2UserList(ModelNormal):
@@ -77,10 +77,9 @@ class V2UserList(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'users': ([UserV2],),  # noqa: E501
-            'errors': ([UserError],),  # noqa: E501
+            'users': ([UserV2], none_type),  # noqa: E501
+            'errors': ([UserError], none_type),  # noqa: E501
         }
 
     @cached_property
@@ -165,7 +164,8 @@ class V2UserList(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.users: List[UserV2] = None
+        self.errors: List[UserError] = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/v2_user_presence.py
+++ b/symphony/bdk/gen/pod_model/v2_user_presence.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.v2_presence_status import V2PresenceStatus
-    from symphony.bdk.gen.pod_model.v2_user_presence_all_of import V2UserPresenceAllOf
-    globals()['V2PresenceStatus'] = V2PresenceStatus
-    globals()['V2UserPresenceAllOf'] = V2UserPresenceAllOf
+from symphony.bdk.gen.pod_model.v2_presence_status import V2PresenceStatus
+from symphony.bdk.gen.pod_model.v2_user_presence_all_of import V2UserPresenceAllOf
+globals()['V2PresenceStatus'] = V2PresenceStatus
+globals()['V2UserPresenceAllOf'] = V2UserPresenceAllOf
 
 
 class V2UserPresence(ModelComposed):
@@ -69,7 +69,6 @@ class V2UserPresence(ModelComposed):
         This must be a method because a pod_model may have properties that are
         of type self, this must run after the class is loaded
         """
-        lazy_import()
         return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
 
     _nullable = False
@@ -84,10 +83,9 @@ class V2UserPresence(ModelComposed):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
             'category': (str,),  # noqa: E501
-            'user_id': (int,),  # noqa: E501
+            'user_id': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -195,9 +193,8 @@ class V2UserPresence(ModelComposed):
         self._var_name_to_model_instances = composed_info[1]
         self._additional_properties_model_instances = composed_info[2]
         unused_args = composed_info[3]
-
-        for var_name, var_value in required_args.items():
-            setattr(self, var_name, var_value)
+        self.category: str = category
+        self.user_id: int = None
         for var_name, var_value in kwargs.items():
             if var_name in unused_args and \
                         self._configuration is not None and \
@@ -216,7 +213,6 @@ class V2UserPresence(ModelComposed):
         # code would be run when this module is imported, and these composed
         # classes don't exist yet because their module has not finished
         # loading
-        lazy_import()
         return {
           'anyOf': [
           ],

--- a/symphony/bdk/gen/pod_model/v2_user_presence_all_of.py
+++ b/symphony/bdk/gen/pod_model/v2_user_presence_all_of.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -72,7 +73,7 @@ class V2UserPresenceAllOf(ModelNormal):
                 and the value is attribute type.
         """
         return {
-            'user_id': (int,),  # noqa: E501
+            'user_id': (int, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -155,7 +156,7 @@ class V2UserPresenceAllOf(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.user_id: int = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/v3_room_attributes.py
+++ b/symphony/bdk/gen/pod_model/v3_room_attributes.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,9 +27,8 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.room_tag import RoomTag
-    globals()['RoomTag'] = RoomTag
+from symphony.bdk.gen.pod_model.room_tag import RoomTag
+globals()['RoomTag'] = RoomTag
 
 
 class V3RoomAttributes(ModelNormal):
@@ -75,21 +75,20 @@ class V3RoomAttributes(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'name': (str,),  # noqa: E501
-            'keywords': ([RoomTag],),  # noqa: E501
-            'description': (str,),  # noqa: E501
-            'members_can_invite': (bool,),  # noqa: E501
-            'discoverable': (bool,),  # noqa: E501
-            'public': (bool,),  # noqa: E501
-            'read_only': (bool,),  # noqa: E501
-            'copy_protected': (bool,),  # noqa: E501
-            'cross_pod': (bool,),  # noqa: E501
-            'view_history': (bool,),  # noqa: E501
-            'multi_lateral_room': (bool,),  # noqa: E501
-            'scheduled_meeting': (bool,),  # noqa: E501
-            'sub_type': (str,),  # noqa: E501
+            'name': (str, none_type),  # noqa: E501
+            'keywords': ([RoomTag], none_type),  # noqa: E501
+            'description': (str, none_type),  # noqa: E501
+            'members_can_invite': (bool, none_type),  # noqa: E501
+            'discoverable': (bool, none_type),  # noqa: E501
+            'public': (bool, none_type),  # noqa: E501
+            'read_only': (bool, none_type),  # noqa: E501
+            'copy_protected': (bool, none_type),  # noqa: E501
+            'cross_pod': (bool, none_type),  # noqa: E501
+            'view_history': (bool, none_type),  # noqa: E501
+            'multi_lateral_room': (bool, none_type),  # noqa: E501
+            'scheduled_meeting': (bool, none_type),  # noqa: E501
+            'sub_type': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -196,7 +195,19 @@ class V3RoomAttributes(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.name: str = None
+        self.keywords: List[RoomTag] = None
+        self.description: str = None
+        self.members_can_invite: bool = None
+        self.discoverable: bool = None
+        self.public: bool = None
+        self.read_only: bool = None
+        self.copy_protected: bool = None
+        self.cross_pod: bool = None
+        self.view_history: bool = None
+        self.multi_lateral_room: bool = None
+        self.scheduled_meeting: bool = None
+        self.sub_type: str = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/v3_room_detail.py
+++ b/symphony/bdk/gen/pod_model/v3_room_detail.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,11 +27,10 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.room_system_info import RoomSystemInfo
-    from symphony.bdk.gen.pod_model.v3_room_attributes import V3RoomAttributes
-    globals()['RoomSystemInfo'] = RoomSystemInfo
-    globals()['V3RoomAttributes'] = V3RoomAttributes
+from symphony.bdk.gen.pod_model.room_system_info import RoomSystemInfo
+from symphony.bdk.gen.pod_model.v3_room_attributes import V3RoomAttributes
+globals()['RoomSystemInfo'] = RoomSystemInfo
+globals()['V3RoomAttributes'] = V3RoomAttributes
 
 
 class V3RoomDetail(ModelNormal):
@@ -77,10 +77,9 @@ class V3RoomDetail(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'room_attributes': (V3RoomAttributes,),  # noqa: E501
-            'room_system_info': (RoomSystemInfo,),  # noqa: E501
+            'room_attributes': (V3RoomAttributes, none_type),  # noqa: E501
+            'room_system_info': (RoomSystemInfo, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -165,7 +164,8 @@ class V3RoomDetail(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.room_attributes: V3RoomAttributes = None
+        self.room_system_info: RoomSystemInfo = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/v3_room_search_results.py
+++ b/symphony/bdk/gen/pod_model/v3_room_search_results.py
@@ -10,6 +10,7 @@
 
 import re  # noqa: F401
 import sys  # noqa: F401
+from typing import List
 
 from symphony.bdk.gen.model_utils import (  # noqa: F401
     ApiTypeError,
@@ -26,13 +27,12 @@ from symphony.bdk.gen.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 
-def lazy_import():
-    from symphony.bdk.gen.pod_model.faceted_match_count import FacetedMatchCount
-    from symphony.bdk.gen.pod_model.v2_room_search_criteria import V2RoomSearchCriteria
-    from symphony.bdk.gen.pod_model.v3_room_detail import V3RoomDetail
-    globals()['FacetedMatchCount'] = FacetedMatchCount
-    globals()['V2RoomSearchCriteria'] = V2RoomSearchCriteria
-    globals()['V3RoomDetail'] = V3RoomDetail
+from symphony.bdk.gen.pod_model.faceted_match_count import FacetedMatchCount
+from symphony.bdk.gen.pod_model.v2_room_search_criteria import V2RoomSearchCriteria
+from symphony.bdk.gen.pod_model.v3_room_detail import V3RoomDetail
+globals()['FacetedMatchCount'] = FacetedMatchCount
+globals()['V2RoomSearchCriteria'] = V2RoomSearchCriteria
+globals()['V3RoomDetail'] = V3RoomDetail
 
 
 class V3RoomSearchResults(ModelNormal):
@@ -79,14 +79,13 @@ class V3RoomSearchResults(ModelNormal):
             openapi_types (dict): The key is attribute name
                 and the value is attribute type.
         """
-        lazy_import()
         return {
-            'count': (int,),  # noqa: E501
-            'skip': (int,),  # noqa: E501
-            'limit': (int,),  # noqa: E501
-            'query': (V2RoomSearchCriteria,),  # noqa: E501
-            'rooms': ([V3RoomDetail],),  # noqa: E501
-            'faceted_match_count': ([FacetedMatchCount],),  # noqa: E501
+            'count': (int, none_type),  # noqa: E501
+            'skip': (int, none_type),  # noqa: E501
+            'limit': (int, none_type),  # noqa: E501
+            'query': (V2RoomSearchCriteria, none_type),  # noqa: E501
+            'rooms': ([V3RoomDetail], none_type),  # noqa: E501
+            'faceted_match_count': ([FacetedMatchCount], none_type),  # noqa: E501
         }
 
     @cached_property
@@ -179,7 +178,12 @@ class V3RoomSearchResults(ModelNormal):
         self._path_to_item = _path_to_item
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
-
+        self.count: int = None
+        self.skip: int = None
+        self.limit: int = None
+        self.query: V2RoomSearchCriteria = None
+        self.rooms: List[V3RoomDetail] = None
+        self.faceted_match_count: List[FacetedMatchCount] = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/templates/generate_client_api.sh
+++ b/templates/generate_client_api.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+template_dir=`pwd`
+project_root=$template_dir/..
+
+echo $template_dir
+
+generate_files() {
+  file_url=$1
+  file_name=${file_url##*/}
+  name=$2
+
+  echo $file_url
+  echo $file_name
+  echo $name
+
+  # download and generate files
+  cd $template_dir
+  wget $file_url
+  java -jar openapi-generator-cli.jar generate -g python -i $file_name --package-name symphony.bdk.gen -o output
+
+  # update api files
+  cd $template_dir/output/symphony/bdk/gen/api/
+  sed -i ".bak" "s/symphony\.bdk\.gen\.model\./symphony\.bdk\.gen\.${name}_model\./g" *.py
+  sed -i ".bak" "s/ api\./ ${name}_api\./g" *.py
+  rm __init__.py  # we don't care about __init__.py files
+  cp *.py $project_root/symphony/bdk/gen/${name}_api
+
+  # update model files
+  cd $template_dir/output/symphony/bdk/gen/model/
+  sed -i ".bak" "s/symphony\.bdk\.gen\.model\./symphony\.bdk\.gen\.${name}_model\./g" *.py
+  sed -i ".bak" "s/model /${name}_model /g" *.py
+  rm __init__.py  # we don't care about __init__.py files
+  cp *.py $project_root/symphony/bdk/gen/${name}_model
+
+  cd $template_dir
+  rm -r output
+  rm $file_name
+}
+
+generate_files https://raw.githubusercontent.com/symphonyoss/symphony-api-spec/master/agent/agent-api-public.yaml agent
+generate_files https://raw.githubusercontent.com/symphonyoss/symphony-api-spec/master/authenticator/authenticator-api-public.yaml auth
+generate_files https://raw.githubusercontent.com/symphonyoss/symphony-api-spec/master/login/login-api-public.yaml login
+generate_files https://raw.githubusercontent.com/symphonyoss/symphony-api-spec/master/pod/pod-api-public-deprecated.yaml pod


### PR DESCRIPTION
### Ticket
PLAT-10562

### Description
Regenerated all models to have fields declared with type hints in classes
First commit https://github.com/SymphonyPlatformSolutions/symphony-api-client-python/pull/162/commits/f8639831f9b6cbbd514ceefb7b3050db1f8f2c69 contains the updates on generated files
Second commit https://github.com/SymphonyPlatformSolutions/symphony-api-client-python/pull/162/commits/7d09bc58ae593ea148207e7af023086ddfa5ae40 contain the script file to generate the model and api files and the documentation on how to do that.
Last commit https://github.com/SymphonyPlatformSolutions/symphony-api-client-python/pull/162/commits/836ef156ec17bf4fcc1ac1047ce7f84a6633bc1b is a change in the ApiClient to ignore unknown fields.

### Dependencies
⚠️ Generated with a local version of the generator: https://github.com/symphony-elias/openapi-generator/compare/master...symphony-elias:PLAT-10652?expand=1

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [x] Docstrings added or updated
- [x] Updated the documentation in [docs folder](../docs)
