### PR TITLE
PLAT-10538: Minor improvements on extension app authenticator

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -27,7 +27,7 @@ python-versions = "*"
 
 [[package]]
 name = "astroid"
-version = "2.5.1"
+version = "2.5.2"
 description = "An abstract syntax tree for Python with inference support."
 category = "dev"
 optional = false
@@ -346,14 +346,14 @@ tests = ["pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)"]
 
 [[package]]
 name = "pylint"
-version = "2.7.2"
+version = "2.7.4"
 description = "python code static checker"
 category = "dev"
 optional = false
 python-versions = "~=3.6"
 
 [package.dependencies]
-astroid = ">=2.5.1,<2.6"
+astroid = ">=2.5.2,<2.7"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 isort = ">=4.2.5,<6"
 mccabe = ">=0.6,<0.7"
@@ -703,8 +703,8 @@ alabaster = [
     {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
 ]
 astroid = [
-    {file = "astroid-2.5.1-py3-none-any.whl", hash = "sha256:21d735aab248253531bb0f1e1e6d068f0ee23533e18ae8a6171ff892b98297cf"},
-    {file = "astroid-2.5.1.tar.gz", hash = "sha256:cfc35498ee64017be059ceffab0a25bedf7548ab76f2bea691c5565896e7128d"},
+    {file = "astroid-2.5.2-py3-none-any.whl", hash = "sha256:cd80bf957c49765dce6d92c43163ff9d2abc43132ce64d4b1b47717c6d2522df"},
+    {file = "astroid-2.5.2.tar.gz", hash = "sha256:6b0ed1af831570e500e2437625979eaa3b36011f66ddfc4ce930128610258ca9"},
 ]
 async-timeout = [
     {file = "async-timeout-3.0.1.tar.gz", hash = "sha256:0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f"},
@@ -1025,8 +1025,8 @@ pyjwt = [
     {file = "PyJWT-2.0.1.tar.gz", hash = "sha256:a5c70a06e1f33d81ef25eecd50d50bd30e34de1ca8b2b9fa3fe0daaabcf69bf7"},
 ]
 pylint = [
-    {file = "pylint-2.7.2-py3-none-any.whl", hash = "sha256:d09b0b07ba06bcdff463958f53f23df25e740ecd81895f7d2699ec04bbd8dc3b"},
-    {file = "pylint-2.7.2.tar.gz", hash = "sha256:0e21d3b80b96740909d77206d741aa3ce0b06b41be375d92e1f3244a274c1f8a"},
+    {file = "pylint-2.7.4-py3-none-any.whl", hash = "sha256:209d712ec870a0182df034ae19f347e725c1e615b2269519ab58a35b3fcbbe7a"},
+    {file = "pylint-2.7.4.tar.gz", hash = "sha256:bd38914c7731cdc518634a8d3c5585951302b6e2b6de60fbb3f7a0220e21eeee"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},

--- a/symphony/bdk/core/auth/ext_app_authenticator.py
+++ b/symphony/bdk/core/auth/ext_app_authenticator.py
@@ -93,7 +93,7 @@ class ExtensionAppAuthenticatorRsa(ExtensionAppAuthenticator):
 
     async def validate_jwt(self, jwt: str) -> dict:
         pod_certificate = await self.get_pod_certificate()
-        return validate_jwt(jwt, pod_certificate.certificate)
+        return validate_jwt(jwt, pod_certificate.certificate, self._app_id)
 
     async def is_token_pair_valid(self, app_token: str, symphony_token: str) -> bool:
         retrieved_sym_token = await self._tokens_repository.get(app_token)

--- a/symphony/bdk/core/auth/jwt_helper.py
+++ b/symphony/bdk/core/auth/jwt_helper.py
@@ -2,10 +2,10 @@
 """
 import datetime
 
+import jwt
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 from cryptography.x509 import load_pem_x509_certificate
 
-import jwt
 from symphony.bdk.core.auth.exception import AuthInitializationError
 from symphony.bdk.core.config.model.bdk_rsa_key_config import BdkRsaKeyConfig
 
@@ -45,7 +45,7 @@ def create_signed_jwt_with_claims(private_key: str, payload: dict) -> str:
     return jwt.encode(payload, private_key, algorithm=JWT_ENCRYPTION_ALGORITHM)
 
 
-def validate_jwt(jwt_token: str, certificate: str) -> dict:
+def validate_jwt(jwt_token: str, certificate: str, allowed_audience: str) -> dict:
     """Validate a jwt against a X509 certificate in pem format and returns the jwt claims.
 
     :param jwt_token: the token to be validated
@@ -55,7 +55,7 @@ def validate_jwt(jwt_token: str, certificate: str) -> dict:
     """
     try:
         return jwt.decode(jwt_token, _parse_public_key_from_x509_cert(certificate),
-                          algorithms=[JWT_ENCRYPTION_ALGORITHM])
+                          algorithms=[JWT_ENCRYPTION_ALGORITHM], audience=allowed_audience)
     except (jwt.DecodeError, jwt.ExpiredSignatureError) as exc:
         raise AuthInitializationError("Unable to validate the jwt") from exc
 


### PR DESCRIPTION
### Ticket
PLAT-10538

### Description
This is to prepare for the Python extension app in the yeoman generator.
* Added audience validation (otherwise `jwt.decode` fails)
* Improved exception handling in `ExtensionAppAuthenticatorRsa.validate_jwt` to only raise `AuthInitializationError` ao that we stay consistent to documentation

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [N/A] Docstrings added or updated
- [N/A] Updated the documentation in [docs folder](../docs)
