### PR TITLE
PLAT-10652: replaced wget with curl when downloading swagger specs

### DIFF
--- a/templates/generate_client_api.sh
+++ b/templates/generate_client_api.sh
@@ -10,13 +10,9 @@ generate_files() {
   file_name=${file_url##*/}
   name=$2
 
-  echo $file_url
-  echo $file_name
-  echo $name
-
   # download and generate files
   cd $template_dir
-  wget $file_url
+  curl $file_url -o $file_name
   java -jar openapi-generator-cli.jar generate -g python -i $file_name --package-name symphony.bdk.gen -o output
 
   # update api files


### PR DESCRIPTION
### Ticket
PLAT-10652

### Description
Replaced wget with curl when downloading swagger specs in script generating api client files.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [N/A] Unit tests updated or added
- [N/A] Docstrings added or updated
- [N/A] Updated the documentation in [docs folder](../docs)
