### PR TITLE
PLAT-10706: @slash decorator

### DIFF
--- a/docsrc/markdown/activity-api.md
+++ b/docsrc/markdown/activity-api.md
@@ -81,6 +81,45 @@ except KeyboardInterrupt:
 1. The `matches()` method allows the activity logic to be triggered when a message starts by a mention to the bot and the text `/hello` separated by a space. Ex: `@bot_name /hello`
 2. The activity logic. Here, we send a message: "Hello, World"
 
+### Slash Command
+A _Slash_ command can be used to directly define a very simple bot command such as: 
+```
+$ @BotMention /command
+$ /command
+```
+
+> Note: a Slash cannot have parameters
+
+One can define a slash command by decorating a callback function which must take one parameter of type
+[`CommandContext`](../_autosummary/symphony.bdk.core.activity.command.CommandContext.html)
+such as below:
+
+```python
+import logging
+
+from symphony.bdk.core.activity.command import CommandContext
+from symphony.bdk.core.config.loader import BdkConfigLoader
+from symphony.bdk.core.symphony_bdk import SymphonyBdk
+
+async def run():
+    config = BdkConfigLoader.load_from_symphony_dir("config.yaml")
+
+    async with SymphonyBdk(config) as bdk:
+        activities = bdk.activities()
+
+        @activities.slash("/hello",  # (1)
+                          True)      # (2)
+        async def callback(context: CommandContext):
+            logging.debug("Hello slash command triggered by user %s", context.initiator.user.display_name)
+
+        await bdk.datafeed().start()
+```
+1. `/hello` is the command name 
+2. `True` means that the bot has to be mentioned
+
+The decorated function will then be called if a message is sent in an `IM`, `MIM` or `Chatroom` with a matching text message.
+
+
 ## Form Activity
 A form activity is triggered when an end-user replies or submits an Elements form.
 

--- a/symphony/bdk/core/activity/api.py
+++ b/symphony/bdk/core/activity/api.py
@@ -51,7 +51,6 @@ class AbstractActivity(ABC, Generic[C]):
         :param context: an instance of :py:class:`ActivityContext`
         :return: True if activity has to be triggered, False otherwise.
         """
-        pass
 
     @abstractmethod
     def on_activity(self, context: C):
@@ -59,7 +58,6 @@ class AbstractActivity(ABC, Generic[C]):
 
         :param context: an instance of :py:class:`ActivityContext`
         """
-        pass
 
     def before_matcher(self, context: C):
         """ This callback can be used to prepare :py:class:`ActivityContext` before actually processing the `matches`
@@ -67,4 +65,3 @@ class AbstractActivity(ABC, Generic[C]):
 
         :param context: an instance of :py:class:`ActivityContext`
         """
-        pass

--- a/symphony/bdk/core/activity/registry.py
+++ b/symphony/bdk/core/activity/registry.py
@@ -3,7 +3,7 @@ import logging
 from symphony.bdk.gen.agent_model.v4_user_joined_room import V4UserJoinedRoom
 
 from symphony.bdk.core.activity.api import AbstractActivity
-from symphony.bdk.core.activity.command import CommandActivity, CommandContext
+from symphony.bdk.core.activity.command import CommandActivity, CommandContext, SlashCommandActivity
 from symphony.bdk.core.activity.form import FormReplyContext, FormReplyActivity
 from symphony.bdk.core.activity.user_joined_room import UserJoinedRoomContext, UserJoinedRoomActivity
 from symphony.bdk.core.service.datafeed.real_time_event_listener import RealTimeEventListener
@@ -13,6 +13,21 @@ from symphony.bdk.gen.agent_model.v4_message_sent import V4MessageSent
 from symphony.bdk.gen.agent_model.v4_symphony_elements_action import V4SymphonyElementsAction
 
 logger = logging.getLogger(__name__)
+
+
+def _initialize_display_name(func):
+    """Decorator around :py:class:`~ActivityRegistry` methods which calls
+    :py:meth:`~ActivityRegistry.fetch_bot_display_name` before actually executing the instance method.
+
+    :param func: the function to be decorated
+    :return: the decorated function
+    """
+    async def decorator(*args, **kwargs):
+        registry = args[0]
+        await registry.fetch_bot_display_name()
+        return await func(*args, **kwargs)
+
+    return decorator
 
 
 class ActivityRegistry(RealTimeEventListener):
@@ -26,21 +41,32 @@ class ActivityRegistry(RealTimeEventListener):
         self._session_service = session_service
         self._bot_display_name = None
 
-    async def register(self, activity: AbstractActivity):
+    def register(self, activity: AbstractActivity):
         """Registers an activity.
 
         :param activity: any object inheriting from base :class:`AbstractActivity`
         """
-
         logger.debug('Registering new activity %s', activity)
-
-        if self._bot_display_name is None:
-            session = await self._session_service.get_session()
-            self._bot_display_name = session.display_name
-            logger.debug('Bot display name is : %s', self._bot_display_name)
-
         self._activity_list.append(activity)
 
+    def slash(self, command: str, mention_bot: bool = True):
+        """Decorator around a listener callback coroutine wich takes a
+        :py:class:`~symphony.bdk.core.activity.command.CommandContext` as single parameter and returns nothing.
+        This registers a new :py:class:`~symphony.bdk.core.activity.command.SlashCommandActivity`
+        which executes the decorated coroutine if a message is matching.
+
+        :param command: the command name e.g. '/hello'
+        :param mention_bot: if user should mention the bot to trigger the slash command
+        :return: None
+        """
+        def decorator(func):
+            logger.debug("Registering slash command with command=%s, mention_bot=%s", command, mention_bot)
+            self.register(SlashCommandActivity(command, mention_bot, func))
+            return func
+
+        return decorator
+
+    @_initialize_display_name
     async def on_message_sent(self, initiator: V4Initiator, event: V4MessageSent):
         context = CommandContext(initiator, event, self._bot_display_name)
         for act in self._activity_list:
@@ -49,6 +75,7 @@ class ActivityRegistry(RealTimeEventListener):
                 if act.matches(context):
                     await act.on_activity(context)
 
+    @_initialize_display_name
     async def on_symphony_elements_action(self, initiator: V4Initiator, event: V4SymphonyElementsAction):
         context = FormReplyContext(initiator, event)
         for act in self._activity_list:
@@ -57,6 +84,7 @@ class ActivityRegistry(RealTimeEventListener):
                 if act.matches(context):
                     await act.on_activity(context)
 
+    @_initialize_display_name
     async def on_user_joined_room(self, initiator: V4Initiator, event: V4UserJoinedRoom):
         context = UserJoinedRoomContext(initiator, event)
         for act in self._activity_list:
@@ -64,3 +92,13 @@ class ActivityRegistry(RealTimeEventListener):
                 act.before_matcher(context)
                 if act.matches(context):
                     await act.on_activity(context)
+
+    async def fetch_bot_display_name(self):
+        """Fetches the bot display name if not already done.
+
+        :return: None
+        """
+        if self._bot_display_name is None:
+            session = await self._session_service.get_session()
+            self._bot_display_name = session.display_name
+            logger.debug('Bot display name is : %s', self._bot_display_name)

--- a/symphony/bdk/core/symphony_bdk.py
+++ b/symphony/bdk/core/symphony_bdk.py
@@ -221,7 +221,7 @@ class SymphonyBdk:
     def activities(self) -> ActivityRegistry:
         """Get the :class:`ActivityRegistry` from the BDK entry point.
 
-        :return: The :class:`ActivityRegistry instance.
+        :return: The :class:`ActivityRegistry` instance.
 
         """
         return self._activity_registry

--- a/tests/core/activity/command_test.py
+++ b/tests/core/activity/command_test.py
@@ -1,11 +1,19 @@
+from unittest.mock import AsyncMock
+
 import pytest
 
-from symphony.bdk.core.activity.command import CommandActivity, CommandContext
+from symphony.bdk.core.activity.command import CommandActivity, CommandContext, SlashCommandActivity
 from symphony.bdk.core.activity.exception import FatalActivityExecutionException
 from symphony.bdk.gen.agent_model.v4_initiator import V4Initiator
 from symphony.bdk.gen.agent_model.v4_message import V4Message
 from symphony.bdk.gen.agent_model.v4_message_sent import V4MessageSent
 from symphony.bdk.gen.agent_model.v4_stream import V4Stream
+
+BOT_NAME = "bot_name"
+
+STREAM_ID = "stream_id"
+MESSAGE_ID = "message_id"
+HELLO_WORLD_MESSAGE = "hello world"
 
 
 @pytest.fixture(name="activity")
@@ -17,12 +25,23 @@ def fixture_activity():
     return TestCommandActivity()
 
 
-def test_matcher(activity):
-    context = CommandContext(V4Initiator(),
-                             V4MessageSent(message=V4Message(message_id="message_id",
-                                                             message="<div><p><span>hello world</span></p></div>",
-                                                             stream=V4Stream(stream_id="stream_id"))),
-                             "bot_name")
+@pytest.fixture(name="message_sent")
+def fixture_message_sent():
+    return create_message_sent(f"<div><p><span>{HELLO_WORLD_MESSAGE}</span></p></div>")
+
+
+def create_command_context(message_sent):
+    return CommandContext(V4Initiator(), message_sent, BOT_NAME)
+
+
+def create_message_sent(message):
+    return V4MessageSent(message=V4Message(message_id=MESSAGE_ID,
+                                           message=message,
+                                           stream=V4Stream(stream_id=STREAM_ID)))
+
+
+def test_matcher(activity, message_sent):
+    context = create_command_context(message_sent)
 
     def dummy_matcher(passed_context: CommandContext):
         return passed_context.text_content.startswith("foobar")
@@ -36,21 +55,62 @@ def test_matcher(activity):
     assert not activity.matches(context)
 
 
-def test_context_with_valid_message(activity):
-    message = "<div><p><span>hello world</span></p></div>"
-    context = CommandContext(V4Initiator(),
-                             V4MessageSent(message=V4Message(message_id="message_id",
-                                                             message=message,
-                                                             stream=V4Stream(stream_id="stream_id"))),
-                             "bot_name")
+def test_context_with_valid_message(activity, message_sent):
+    context = create_command_context(message_sent)
     assert context.text_content == "hello world"
 
 
 def test_context_with_invalid_message(activity):
     message = "<div<p><span>hello world<span></p></div>"  # Bad xml format, missing chevron
     with pytest.raises(FatalActivityExecutionException):
-        CommandContext(V4Initiator(),
-                       V4MessageSent(message=V4Message(message_id="message_id",
-                                                       message=message,
-                                                       stream=V4Stream(stream_id="stream_id"))),
-                       "bot_name")
+        create_command_context(create_message_sent(message))
+
+
+def test_command_context(message_sent):
+    initiator = V4Initiator()
+    context = CommandContext(initiator, message_sent, BOT_NAME)
+
+    assert context.initiator == initiator
+    assert context.source_event == message_sent
+    assert context.bot_display_name == BOT_NAME
+    assert context.text_content == HELLO_WORLD_MESSAGE
+    assert context.message_id == MESSAGE_ID
+    assert context.stream_id == STREAM_ID
+
+
+def test_slash_command_matches_with_bot_mention():
+    command = "/command"
+    slash_command = SlashCommandActivity(command, True, AsyncMock())
+
+    context = create_command_context(create_message_sent(f"<div><p><span>@{BOT_NAME}</span> {command}</p></div>"))
+    assert slash_command.matches(context)
+
+    context = create_command_context(create_message_sent(f"<div><p><span>@{BOT_NAME}</span> /other_command</p></div>"))
+    assert not slash_command.matches(context)
+
+    context = create_command_context(create_message_sent(f"<div><p><span>@other-bot</span> {command}</p></div>"))
+    assert not slash_command.matches(context)
+
+
+def test_slash_command_matches_without_bot_mention():
+    command = "/command"
+    slash_command = SlashCommandActivity(command, False, AsyncMock())
+
+    context = create_command_context(create_message_sent(f"<div><p>{command}</p></div>"))
+    assert slash_command.matches(context)
+
+    context = create_command_context(create_message_sent(f"<div><p><span>@{BOT_NAME}</span> {command}</p></div>"))
+    assert not slash_command.matches(context)
+
+    context = create_command_context(create_message_sent(f"<div><p>/other_command</p></div>"))
+    assert not slash_command.matches(context)
+
+
+@pytest.mark.asyncio
+async def test_slash_command_on_activity_calls_callback(message_sent):
+    listener_callback = AsyncMock()
+    slash_command = SlashCommandActivity("/command", False, listener_callback)
+    context = create_command_context(message_sent)
+
+    await slash_command.on_activity(context)
+    listener_callback.assert_called_once_with(context)

--- a/tests/core/activity/registry_test.py
+++ b/tests/core/activity/registry_test.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, AsyncMock
 import pytest
 from symphony.bdk.gen.agent_model.v4_user import V4User
 
-from symphony.bdk.core.activity.command import CommandActivity
+from symphony.bdk.core.activity.command import CommandActivity, SlashCommandActivity
 from symphony.bdk.core.activity.form import FormReplyActivity
 from symphony.bdk.core.activity.registry import ActivityRegistry
 from symphony.bdk.core.service.session.session_service import SessionService
@@ -61,16 +61,14 @@ def fixture_activity_registry(session_service):
 
 
 @pytest.mark.asyncio
-async def test_register(activity_registry, session_service):
-    # add first activity
-    await activity_registry.register(CommandActivity())
-    assert len(activity_registry._activity_list) == 1
+async def test_register(activity_registry, session_service, message_sent):
+    # call on_message_sent a first time
+    await activity_registry.on_message_sent(V4Initiator(), message_sent)
     session_service.get_session.assert_called_once()
 
     session_service.get_session.reset_mock()
-    # add second activity, get_session() is not performed twice
-    await activity_registry.register(CommandActivity())
-    assert len(activity_registry._activity_list) == 2
+    # call on_message_sent a second time, get_session() is not performed twice
+    await activity_registry.on_message_sent(V4Initiator(), message_sent)
     session_service.get_session.assert_not_called()
 
 
@@ -81,9 +79,9 @@ async def test_register_different_activities_instance(activity_registry, command
     form.on_activity = AsyncMock()
     user.on_activity = AsyncMock()
 
-    await activity_registry.register(command)
-    await activity_registry.register(form)
-    await activity_registry.register(user)
+    activity_registry.register(command)
+    activity_registry.register(form)
+    activity_registry.register(user)
 
     assert len(activity_registry._activity_list) == 3
 
@@ -118,7 +116,7 @@ async def test_register_different_activities_instance(activity_registry, command
 async def test_on_message_sent(activity_registry, message_sent, command):
     command.on_activity = AsyncMock()
 
-    await activity_registry.register(command)
+    activity_registry.register(command)
     await activity_registry.on_message_sent(V4Initiator(), message_sent)
 
     assert len(activity_registry._activity_list) == 1
@@ -134,7 +132,7 @@ async def test_on_message_sent_false_match(activity_registry, message_sent, comm
 
     command.matches.return_value = False
 
-    await activity_registry.register(command)
+    activity_registry.register(command)
     await activity_registry.on_message_sent(V4Initiator(), message_sent)
 
     command.before_matcher.assert_called_once()
@@ -146,7 +144,7 @@ async def test_on_message_sent_false_match(activity_registry, message_sent, comm
 async def test_on_symphony_elements_action(activity_registry, elements_action, form):
     form.on_activity = AsyncMock()
 
-    await activity_registry.register(form)
+    activity_registry.register(form)
     await activity_registry.on_symphony_elements_action(V4Initiator(), elements_action)
 
     assert len(activity_registry._activity_list) == 1
@@ -161,7 +159,7 @@ async def test_on_symphony_elements_action_false_match(activity_registry, elemen
     form.on_activity = AsyncMock()
     form.matches.return_value = False
 
-    await activity_registry.register(form)
+    activity_registry.register(form)
     await activity_registry.on_symphony_elements_action(V4Initiator(), elements_action)
 
     form.before_matcher.assert_called_once()
@@ -173,7 +171,7 @@ async def test_on_symphony_elements_action_false_match(activity_registry, elemen
 async def test_on_user_joined_room(activity_registry, user_joined_room, user):
     user.on_activity = AsyncMock()
 
-    await activity_registry.register(user)
+    activity_registry.register(user)
     await activity_registry.on_user_joined_room(V4UserJoinedRoom, user_joined_room)
 
     assert len(activity_registry._activity_list) == 1
@@ -189,9 +187,36 @@ async def test_on_user_joined_room_false_match(activity_registry, user_joined_ro
 
     user.matches.return_value = False
 
-    await activity_registry.register(user)
+    activity_registry.register(user)
     await activity_registry.on_user_joined_room(V4Initiator(), user_joined_room)
 
     user.before_matcher.assert_called_once()
     user.matches.assert_called_once()
     user.on_activity.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_slash_command_decorator(activity_registry, message_sent):
+    @activity_registry.slash("/command")
+    async def listener(context):
+        pass
+
+    assert len(activity_registry._activity_list) == 1
+    assert isinstance(activity_registry._activity_list[0], SlashCommandActivity)
+
+
+@pytest.mark.asyncio
+async def test_slash_command(activity_registry, message_sent):
+    listener = AsyncMock()
+    mention_bot = False
+    command_name = "/command"
+
+    activity_registry.slash(command_name, mention_bot)(listener)
+
+    assert len(activity_registry._activity_list) == 1
+
+    slash_activity = activity_registry._activity_list[0]
+    assert isinstance(slash_activity, SlashCommandActivity)
+    assert slash_activity._name == command_name
+    assert slash_activity._requires_mention_bot == mention_bot
+    assert slash_activity._callback == listener


### PR DESCRIPTION
### Ticket
PLAT-10706

### Description
Created a slash decorator to register new slash commands.

Made `bdk.activities().register(command)` synchronous because I could not have the desired effect with an async `register` method. 

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [x] Docstrings added or updated
- [x] Updated the documentation in [docs folder](../docs)
