### PR TITLE
PLAT-10895-Implement built-in help command

### DIFF
--- a/docsrc/markdown/activity-api.md
+++ b/docsrc/markdown/activity-api.md
@@ -162,8 +162,7 @@ It can be triggered by using:
 ```
 $ @BotMention /help
 ```
-The help command can be instantiated by passing an `ActivityRegistry` and `MessageService` instances to the constructor,
-then added manually to the BDK activity registry
+The help command can be instantiated by passing a `SymphonyBdk` instance to the constructor and then added manually to the BDK activity registry
 ```python
 import logging
 from symphony.bdk.core.activity.command import CommandContext
@@ -175,13 +174,12 @@ async def run():
     
     async with SymphonyBdk(config) as bdk:
         activities = bdk.activities()
-        messages = bdk.messages()
         
         @activities.slash("/hello", True, "Command to say hello")
         async def callback(context: CommandContext):
             logging.debug("Hello slash command triggered by user %s", context.initiator.user.display_name)
         
-        bdk.activities().register(HelpCommand(activities, messages))
+        bdk.activities().register(HelpCommand(bdk))
         
         await bdk.datafeed().start()
 ```

--- a/docsrc/markdown/activity-api.md
+++ b/docsrc/markdown/activity-api.md
@@ -108,8 +108,9 @@ async def run():
     async with SymphonyBdk(config) as bdk:
         activities = bdk.activities()
 
-        @activities.slash("/hello",  # (1)
-                          True)      # (2)
+        @activities.slash("/hello",                     # (1)
+                          True,                         # (2)
+                          "This command says hello")    # (3)
         async def callback(context: CommandContext):
             logging.debug("Hello slash command triggered by user %s", context.initiator.user.display_name)
 
@@ -117,6 +118,7 @@ async def run():
 ```
 1. `/hello` is the command name 
 2. `True` means that the bot has to be mentioned
+3. `This command says hello` is the command description (optional)
 
 The decorated function will then be called if a message is sent in an `IM`, `MIM` or `Chatroom` with a matching text message.
 Please mind that, due to the mechanism inherent to decorators, the `@activities.slash` cannot be used when `activities`
@@ -153,6 +155,37 @@ class HelpCommandActivity(SlashCommandActivity):
     async def help_command(self, context: CommandContext):
         return await self._messages.send_message(context.stream_id, "<messageML>Help command triggered</messageML>")
 ```
+
+### Help Command
+The _help_ command is a BDK build-in command which lists all the commands registered in the ActivityRegistry of the BDK. 
+It can be triggered by using:
+```
+$ @BotMention /help
+```
+The help command can be instantiated by passing an `ActivityRegistry` and `MessageService` instances to the constructor,
+then added manually to the BDK activity registry
+```python
+import logging
+from symphony.bdk.core.activity.command import CommandContext
+from symphony.bdk.core.activity.help_command import HelpCommand
+from symphony.bdk.core.config.loader import BdkConfigLoader
+from symphony.bdk.core.symphony_bdk import SymphonyBdk
+async def run():
+    config = BdkConfigLoader.load_from_symphony_dir("config.yaml")
+    
+    async with SymphonyBdk(config) as bdk:
+        activities = bdk.activities()
+        messages = bdk.messages()
+        
+        @activities.slash("/hello", True, "Command to say hello")
+        async def callback(context: CommandContext):
+            logging.debug("Hello slash command triggered by user %s", context.initiator.user.display_name)
+        
+        bdk.activities().register(HelpCommand(activities, messages))
+        
+        await bdk.datafeed().start()
+```
+One can also override the default implementation of the help command by manually defining a new `SlashCommandActivity`.
 
 ## Form Activity
 A form activity is triggered when an end-user replies or submits an Elements form.

--- a/examples/activities/slash_command_activity.py
+++ b/examples/activities/slash_command_activity.py
@@ -3,6 +3,7 @@ import logging.config
 from pathlib import Path
 
 from symphony.bdk.core.activity.command import CommandContext
+from symphony.bdk.core.activity.help_command import HelpCommand
 from symphony.bdk.core.config.loader import BdkConfigLoader
 from symphony.bdk.core.symphony_bdk import SymphonyBdk
 
@@ -15,6 +16,8 @@ async def run():
         @activities.slash("/hello")
         async def on_hello(context: CommandContext):
             await messages.send_message(context.stream_id, "<messageML>Hello, World!</messageML>")
+
+        bdk.activities().register(HelpCommand(activities, messages))
 
         await bdk.datafeed().start()
 

--- a/examples/activities/slash_command_activity.py
+++ b/examples/activities/slash_command_activity.py
@@ -17,7 +17,7 @@ async def run():
         async def on_hello(context: CommandContext):
             await messages.send_message(context.stream_id, "<messageML>Hello, World!</messageML>")
 
-        bdk.activities().register(HelpCommand(activities, messages))
+        bdk.activities().register(HelpCommand(bdk))
 
         await bdk.datafeed().start()
 

--- a/symphony/bdk/core/activity/command.py
+++ b/symphony/bdk/core/activity/command.py
@@ -94,7 +94,3 @@ class SlashCommandActivity(CommandActivity):
         if isinstance(o, SlashCommandActivity):
             return self._name == o._name and self._requires_mention_bot == o._requires_mention_bot
         return False
-
-    def __hash__(self) -> int:
-        return super().__hash__()
-

--- a/symphony/bdk/core/activity/command.py
+++ b/symphony/bdk/core/activity/command.py
@@ -63,7 +63,7 @@ class SlashCommandActivity(CommandActivity):
       - "{name}" otherwise
     """
 
-    def __init__(self, name, requires_mention_bot, callback):
+    def __init__(self, name, requires_mention_bot, callback, description=""):
         """
         :param name: the command name
         :param requires_mention_bot: if the command requires the bot mention to trigger the slash command
@@ -72,6 +72,16 @@ class SlashCommandActivity(CommandActivity):
         self._name = name
         self._requires_mention_bot = requires_mention_bot
         self._callback = callback
+        self._description = description
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def build_command_description(self) -> str:
+        if self._requires_mention_bot:
+            return self._description + " (mention required)"
+        return self._description + " (mention not required)"
 
     def matches(self, context: CommandContext) -> bool:
         pattern = rf"@{context.bot_display_name} {self._name}" if self._requires_mention_bot else rf"{self._name}"

--- a/symphony/bdk/core/activity/command.py
+++ b/symphony/bdk/core/activity/command.py
@@ -79,9 +79,8 @@ class SlashCommandActivity(CommandActivity):
         return self._name
 
     def build_command_description(self) -> str:
-        if self._requires_mention_bot:
-            return self._description + " (mention required)"
-        return self._description + " (mention not required)"
+        return self._description + " (mention required)" if self._requires_mention_bot \
+            else self._description + " (mention not required)"
 
     def matches(self, context: CommandContext) -> bool:
         pattern = rf"@{context.bot_display_name} {self._name}" if self._requires_mention_bot else rf"{self._name}"

--- a/symphony/bdk/core/activity/help_command.py
+++ b/symphony/bdk/core/activity/help_command.py
@@ -1,29 +1,22 @@
 from symphony.bdk.core.activity.command import CommandContext, SlashCommandActivity
-from symphony.bdk.core.activity.registry import ActivityRegistry
-from symphony.bdk.core.service.message.message_service import MessageService
 from symphony.bdk.core.service.message.model import Message
+from symphony.bdk.core.symphony_bdk import SymphonyBdk
 
 
 class HelpCommand(SlashCommandActivity):
     """The help command is a particular CommandActivity which returns the list of all commands available for the
     specific bot
     The Slash command is triggered if we receive a MESSAGESENT event with message text:
-      - "@{bot_display name} {name}"
+      - "@{bot_display name} /help"
     """
 
-    def __init__(self, registry: ActivityRegistry, callback: MessageService):
-        super().__init__("/help", True, callback, "List available commands")
-        self._registry = registry
-
-    def matches(self, context: CommandContext) -> bool:
-        pattern = rf"@{context.bot_display_name} {self._name}"
-        return pattern == context.text_content
+    def __init__(self, bdk: SymphonyBdk):
+        super().__init__("/help", True, bdk.messages(), "List available commands")
+        self._bdk = bdk
 
     async def on_activity(self, context: CommandContext):
-        activity_list = self._registry.activity_list
+        activity_list = self._bdk.activities().activity_list
         help_message = ""
         for act in activity_list:
-            if not isinstance(act, HelpCommand):
-                help_message += "<li>" + act.name + " - " + act.build_command_description() + "</li>"
-        if not activity_list:
-            await self._callback.send_message(context.stream_id, Message("<ul>" + help_message + "</ul>"))
+            help_message += "<li>" + act.name + " - " + act.build_command_description() + "</li>"
+        await self._callback.send_message(context.stream_id, Message("<ul>" + help_message + "</ul>"))

--- a/symphony/bdk/core/activity/help_command.py
+++ b/symphony/bdk/core/activity/help_command.py
@@ -1,0 +1,29 @@
+from symphony.bdk.core.activity.command import CommandContext, SlashCommandActivity
+from symphony.bdk.core.activity.registry import ActivityRegistry
+from symphony.bdk.core.service.message.message_service import MessageService
+from symphony.bdk.core.service.message.model import Message
+
+
+class HelpCommand(SlashCommandActivity):
+    """The help command is a particular CommandActivity which returns the list of all commands available for the
+    specific bot
+    The Slash command is triggered if we receive a MESSAGESENT event with message text:
+      - "@{bot_display name} {name}"
+    """
+
+    def __init__(self, registry: ActivityRegistry, callback: MessageService):
+        super().__init__("/help", True, callback, "List available commands")
+        self._registry = registry
+
+    def matches(self, context: CommandContext) -> bool:
+        pattern = rf"@{context.bot_display_name} {self._name}"
+        return pattern == context.text_content
+
+    async def on_activity(self, context: CommandContext):
+        activity_list = self._registry.activity_list
+        help_message = ""
+        for act in activity_list:
+            if not isinstance(act, HelpCommand):
+                help_message += "<li>" + act.name + " - " + act.build_command_description() + "</li>"
+        if not activity_list:
+            await self._callback.send_message(context.stream_id, Message("<ul>" + help_message + "</ul>"))

--- a/symphony/bdk/core/activity/help_command.py
+++ b/symphony/bdk/core/activity/help_command.py
@@ -1,5 +1,4 @@
 from symphony.bdk.core.activity.command import CommandContext, SlashCommandActivity
-from symphony.bdk.core.service.message.model import Message
 from symphony.bdk.core.symphony_bdk import SymphonyBdk
 
 
@@ -11,7 +10,7 @@ class HelpCommand(SlashCommandActivity):
     """
 
     def __init__(self, bdk: SymphonyBdk):
-        super().__init__("/help", True, bdk.messages(), "List available commands")
+        super().__init__("/help", True, None, "List available commands")
         self._bdk = bdk
 
     async def on_activity(self, context: CommandContext):
@@ -19,4 +18,5 @@ class HelpCommand(SlashCommandActivity):
         help_message = ""
         for act in activity_list:
             help_message += "<li>" + act.name + " - " + act.build_command_description() + "</li>"
-        await self._callback.send_message(context.stream_id, Message("<ul>" + help_message + "</ul>"))
+        await self._bdk.messages().send_message(context.stream_id,
+                                                "<messageML><ul>" + help_message + "</ul></messageML>")

--- a/symphony/bdk/core/activity/registry.py
+++ b/symphony/bdk/core/activity/registry.py
@@ -41,6 +41,10 @@ class ActivityRegistry(RealTimeEventListener):
         self._session_service = session_service
         self._bot_display_name = None
 
+    @property
+    def activity_list(self):
+        return self._activity_list
+
     def register(self, activity: AbstractActivity):
         """Registers an activity.
 
@@ -56,7 +60,7 @@ class ActivityRegistry(RealTimeEventListener):
                 self._activity_list.remove(act)
                 logger.debug("Activity '%s' has been removed/unsubscribed in order to be replaced", act)
 
-    def slash(self, command: str, mention_bot: bool = True):
+    def slash(self, command: str, mention_bot: bool = True, description: str = ""):
         """Decorator around a listener callback coroutine which takes a
         :py:class:`~symphony.bdk.core.activity.command.CommandContext` as single parameter and returns nothing.
         This registers a new :py:class:`~symphony.bdk.core.activity.command.SlashCommandActivity`
@@ -64,11 +68,12 @@ class ActivityRegistry(RealTimeEventListener):
 
         :param command: the command name e.g. "/hello"
         :param mention_bot: if user should mention the bot to trigger the slash command
+        :param description: command description
         :return: None
         """
         def decorator(func):
             logger.debug("Registering slash command with command=%s, mention_bot=%s", command, mention_bot)
-            self.register(SlashCommandActivity(command, mention_bot, func))
+            self.register(SlashCommandActivity(command, mention_bot, func, description))
             return func
 
         return decorator

--- a/tests/core/activity/help_command_test.py
+++ b/tests/core/activity/help_command_test.py
@@ -1,0 +1,101 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from symphony.bdk.core.activity.command import SlashCommandActivity, CommandContext
+from symphony.bdk.core.activity.help_command import HelpCommand
+from symphony.bdk.core.activity.registry import ActivityRegistry
+from symphony.bdk.core.service.message.message_service import MessageService
+from symphony.bdk.core.service.session.session_service import SessionService
+from symphony.bdk.core.symphony_bdk import SymphonyBdk
+from symphony.bdk.gen.agent_model.v4_initiator import V4Initiator
+from symphony.bdk.gen.agent_model.v4_message import V4Message
+from symphony.bdk.gen.agent_model.v4_message_sent import V4MessageSent
+from symphony.bdk.gen.agent_model.v4_stream import V4Stream
+
+
+@pytest.fixture(name="session_service")
+def fixture_session_service():
+    session_service = MagicMock(SessionService)
+    session_service.get_session = AsyncMock()
+    return session_service
+
+
+@pytest.fixture(name="activity_registry")
+def fixture_activity_registry(session_service):
+    return ActivityRegistry(session_service)
+
+
+@pytest.fixture(name="bdk")
+def fixture_bdk(activity_registry):
+    bdk = MagicMock(SymphonyBdk)
+    bdk.activities.return_value = activity_registry
+    bdk.messages.return_value = MagicMock(MessageService)
+    bdk.messages.send_message = AsyncMock()
+    return bdk
+
+
+@pytest.fixture(name="command_context")
+def fixture_command_context():
+    message_content = "<messageML>@bot_name /help</messageML>"
+    message_sent = V4MessageSent(message=V4Message(message_id="message_id",
+                                                   message=message_content,
+                                                   stream=V4Stream(stream_id="stream_id")))
+    return CommandContext(V4Initiator(), message_sent, "bot_name")
+
+
+@pytest.mark.asyncio
+async def test_help_command(bdk, activity_registry, command_context):
+    listener = AsyncMock()
+
+    activity_registry.slash("/hello")(listener)
+    activity_registry.register(HelpCommand(bdk))
+
+    assert len(activity_registry.activity_list) == 2
+    help_activity = activity_registry.activity_list[1]
+    assert isinstance(help_activity, HelpCommand)
+    assert help_activity.matches(command_context)
+    await help_activity.on_activity(command_context)
+    help_activity._callback.send_message.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_help_command_no_other_commands_found(bdk, activity_registry, command_context):
+    activity_registry.register(HelpCommand(bdk))
+
+    assert len(activity_registry.activity_list) == 1
+    help_activity = activity_registry.activity_list[0]
+    assert isinstance(help_activity, HelpCommand)
+    assert help_activity.matches(command_context)
+    await help_activity.on_activity(command_context)
+    help_activity._callback.send_message.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_override_help_command_with_slash_help(bdk, activity_registry, command_context):
+    listener = AsyncMock()
+
+    activity_registry.slash("/help")(listener)
+    activity_registry.register(HelpCommand(bdk))
+
+    assert len(activity_registry.activity_list) == 1
+    help_activity = activity_registry.activity_list[0]
+    assert isinstance(help_activity, HelpCommand)
+    assert help_activity.matches(command_context)
+    await help_activity.on_activity(command_context)
+    help_activity._callback.send_message.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_override_slash_help_with_help_command(bdk, activity_registry, command_context):
+    listener = AsyncMock()
+
+    activity_registry.register(HelpCommand(bdk))
+    activity_registry.slash("/help")(listener)
+
+    assert len(activity_registry.activity_list) == 1
+    help_activity = activity_registry.activity_list[0]
+    assert isinstance(help_activity, SlashCommandActivity)
+    assert help_activity.matches(command_context)
+    await help_activity.on_activity(command_context)
+    help_activity._callback.assert_called_once_with(command_context)


### PR DESCRIPTION
### Ticket
[PLAT-10895](https://perzoinc.atlassian.net/browse/PLAT-10895)

### Description
Goal of this PR is to provide the implementation of a build-in help command with lists all the activity registered in the ActivityRegistry.
For each command found the following format will be used " - command_name - description (mention required/mention not required)" (example "/hello - command to say hello (mention required)")
This help command can also be overriden by manually implementing a new SlashCommandActivity, the code will make sure that any duplicates will be removed.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [x] Docstrings added or updated
- [x] Updated the documentation in [docs folder](../docs)
