### PR TITLE
PLAT-10936: Fix typo in markdown  

### DIFF
--- a/docsrc/markdown/authentication.md
+++ b/docsrc/markdown/authentication.md
@@ -38,10 +38,17 @@ bot:
     certificate:
       path: /path/to/certificate.pem
 ```
-
 To know more about the format of the certificate file, check [SSLContext.load_cert_chain](https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_cert_chain).
 The certificate path will be passed to the `certfile` parameter of the `load_cert_chain_method`. We do not pass anything
 to `keyfile` and `password` parameters, which means certificate and decrypted private key should be put in the same file.
+
+The certificate path should lead to a single file in PEM format containing the certificate and the decrypted private key. 
+We do not support password encrypted private keys.
+
+Alternatively, if you have a `.pfx` file, you can use the OpenSSL Command line tool to convert it to `.pem` format:
+```bash
+openssl pkcs12 -in .\certificate.pfx -out certificate.pem -nodes
+```
 
 
 ### Bot authentication deep-dive

--- a/docsrc/markdown/authentication.md
+++ b/docsrc/markdown/authentication.md
@@ -47,7 +47,7 @@ We do not support password encrypted private keys.
 
 Alternatively, if you have a `.pfx` file, you can use the OpenSSL Command line tool to convert it to `.pem` format:
 ```bash
-openssl pkcs12 -in .\certificate.pfx -out certificate.pem -nodes
+openssl pkcs12 -in certificate.pfx -out certificate.pem -nodes
 ```
 
 


### PR DESCRIPTION
### Ticket
[PLAT-10936](https://perzoinc.atlassian.net/browse/PLAT-10936)

Removing a backslash from the command as it is windows specific. 
