### PR TITLE
Remove html entities before xml parsing messages (#208)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,9 @@ venv.bak/
 .idea
 *.iml
 
+# vscode
+.vscode
+
 # Credentials files
 sym_api_client_python/resources/certificates/*
 sym_api_client_python/resources/bot_private_key.pem

--- a/symphony/bdk/core/service/message/message_parser.py
+++ b/symphony/bdk/core/service/message/message_parser.py
@@ -3,6 +3,7 @@ extracting entities like Mentions, Hashtags, Cashtags, Emojis and extracting tex
 contained in the message.
 """
 import json
+import html
 
 from enum import Enum
 from json import JSONDecodeError
@@ -20,9 +21,8 @@ def get_text_content_from_message(message: V4Message) -> str:
     :param message: message containing the PresentationML to be parsed
     :return: the message text content extracted from the given PresentationML
     """
-
     try:
-        presentation_ml = message.message
+        presentation_ml = html.unescape(message.message)
         return tostring(fromstring(presentation_ml), method="text").decode().strip()
     except ParseError as exc:
         raise MessageParserError("Unable to parse the PresentationML, it is not in the correct format.") from exc

--- a/tests/core/service/message/message_parser_test.py
+++ b/tests/core/service/message/message_parser_test.py
@@ -26,9 +26,22 @@ def fixture_unparsable_message():
     return message
 
 
+@pytest.fixture(name="escaped_message")
+def fixture_escaped_message():
+    message = MagicMock(V4Message)
+    message.message = "<div data-format=\"PresentationML\" data-version=\"2.0\"> \n" \
+                      "This is some escaped text &nbsp;</div>"
+    return message
+
+
 def test_get_text_content_from_message(message):
     plain_text = get_text_content_from_message(message)
     assert plain_text == "This is a link to Symphony's Website"
+
+
+def test_get_escaped_text_content_from_message(escaped_message):
+    plain_text = get_text_content_from_message(escaped_message)
+    assert plain_text == "This is some escaped text &#160;"
 
 
 def test_get_text_content_from_message_unparsable(unparsable_message):


### PR DESCRIPTION
Backporting https://github.com/SymphonyPlatformSolutions/symphony-api-client-python/issues/207 to 2.0 branch
