### PR TITLE
PLAT-11208 Legacy Python BDK: Params missing in list attachments endpoint

### DIFF
--- a/sym_api_client_python/clients/message_client.py
+++ b/sym_api_client_python/clients/message_client.py
@@ -154,12 +154,13 @@ class MessageClient(APIClient):
         url = '/pod/v1/admin/messages/{0}/receipts'.format(msg_id)
         return self.bot_client.example('GET', url)
 
-    def list_stream_attachments(self, stream_id: str, since: int, to: int, limit: int = 50, sort_dir: str = "ASC"):
+    def list_stream_attachments(self, stream_id: str, since: int = None, to: int = None, limit: int = 50,
+                                sort_dir: str = "ASC"):
         """List attachments in a particular stream.
                 See: `List Attachments <https://developers.symphony.com/restapi/reference#list-attachments>`_
                 :param stream_id: The stream ID where to look for the attachments
-                :param since: Timestamp of the first required attachment.
-                :param to: Timestamp of the last required attachment.
+                :param since: Unix epoch timestamp of the first required attachment in milliseconds.
+                :param to: Unix epoch timestamp of the last required attachment in milliseconds.
                 :param limit: Maximum number of attachments to return.
                             This optional value defaults to 50 and should be between 0 and 100.
                 :param sort_dir: Attachment date sort direction : ASC or DESC. Default: ASC.
@@ -169,10 +170,13 @@ class MessageClient(APIClient):
         url = '/pod/v1/streams/{0}/attachments'.format(stream_id)
 
         params = {
-            'since': since,
-            'to': to,
             'limit': limit,
             'sortDir': sort_dir
         }
+
+        if since is not None:
+            params["since"] = since
+        if to is not None:
+            params["to"] = to
 
         return self.bot_client.execute_rest_call('GET', url, params=params)

--- a/sym_api_client_python/clients/message_client.py
+++ b/sym_api_client_python/clients/message_client.py
@@ -154,7 +154,15 @@ class MessageClient(APIClient):
         url = '/pod/v1/admin/messages/{0}/receipts'.format(msg_id)
         return self.bot_client.example('GET', url)
 
-    def list_stream_attachments(self, stream_id):
+    def list_stream_attachments(self, stream_id, since, to, limit=50, sort_dir="ASC"):
         logging.debug('MessageClient/list_msg_attachments()')
         url = '/pod/v1/streams/{0}/attachments'.format(stream_id)
-        return self.bot_client.execute_rest_call('GET', url)
+
+        params = {
+            'since': since,
+            'to': to,
+            'limit': limit,
+            'sortDir': sort_dir
+        }
+
+        return self.bot_client.execute_rest_call('GET', url, params=params)

--- a/sym_api_client_python/clients/message_client.py
+++ b/sym_api_client_python/clients/message_client.py
@@ -154,7 +154,17 @@ class MessageClient(APIClient):
         url = '/pod/v1/admin/messages/{0}/receipts'.format(msg_id)
         return self.bot_client.example('GET', url)
 
-    def list_stream_attachments(self, stream_id, since, to, limit=50, sort_dir="ASC"):
+    def list_stream_attachments(self, stream_id: str, since: int, to: int, limit: int = 50, sort_dir: str = "ASC"):
+        """List attachments in a particular stream.
+                See: `List Attachments <https://developers.symphony.com/restapi/reference#list-attachments>`_
+                :param stream_id: The stream ID where to look for the attachments
+                :param since: Timestamp of the first required attachment.
+                :param to: Timestamp of the last required attachment.
+                :param limit: Maximum number of attachments to return.
+                            This optional value defaults to 50 and should be between 0 and 100.
+                :param sort_dir: Attachment date sort direction : ASC or DESC. Default: ASC.
+                :return: the list of attachments in the stream.
+                """
         logging.debug('MessageClient/list_msg_attachments()')
         url = '/pod/v1/streams/{0}/attachments'.format(stream_id)
 


### PR DESCRIPTION
### Ticket
[PLAT-11208](https://perzoinc.atlassian.net/browse/PLAT-11208)

### Description
Stream attachments list method in Python Legacy BDK was missing parameters for pagination. They have been added in this PR.