### PR TITLE
#221: Release to update the Pypi landing page of legacy sym-api-client-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # symphony-api-client-python
 
+> **_INFO:_**  This is the legacy version of the BDK. We strongly recommend using the 2.0 version of the BDK delivered
+> under package name [symphony-bdk-python](https://pypi.org/project/symphony-bdk-python/) in Pypi.
+> Source code of the 2.0 BDK can be found in the main branch of the [symphony-bdk-python repository](https://github.com/finos/symphony-bdk-python).
+
 ## Overview
 This Symphony bot client is written in an event handler architecture. The client keeps polling a datafeed and responds to different types of [Real Time Events](https://rest-api.symphony.com/docs/real-time-events) it receives.
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme():
 setuptools.setup(
     name="sym_api_client_python",
 
-    version="1.3.6",
+    version="1.3.7",
     author="Symphony Platform Solutions",
     author_email="platformsolutions@symphony.com",
     description="Symphony REST API - Python Client",


### PR DESCRIPTION
### Ticket
#221

### Description
Release to update the Pypi landing page of legacy sym-api-client-python to warn about the release of BDK2.0 under new package name.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [N/A] Unit tests updated or added
- [N/A] Docstrings added or updated
- [N/A] Updated the documentation in [docs folder](../docs)
