### PR TITLE
Extract the escaped content and then unescape characters in message_parser

### DIFF
--- a/symphony/bdk/core/service/message/message_parser.py
+++ b/symphony/bdk/core/service/message/message_parser.py
@@ -22,8 +22,8 @@ def get_text_content_from_message(message: V4Message) -> str:
     :return: the message text content extracted from the given PresentationML
     """
     try:
-        presentation_ml = html.unescape(message.message)
-        return tostring(fromstring(presentation_ml), method="text").decode().strip()
+        escaped_text_content = tostring(fromstring(message.message), method="text").decode().strip()
+        return html.unescape(escaped_text_content)
     except ParseError as exc:
         raise MessageParserError("Unable to parse the PresentationML, it is not in the correct format.") from exc
 

--- a/tests/core/service/message/message_parser_test.py
+++ b/tests/core/service/message/message_parser_test.py
@@ -9,71 +9,83 @@ from symphony.bdk.gen.agent_model.v4_message import V4Message
 from tests.utils.resource_utils import get_resource_content
 
 
-@pytest.fixture(name="message")
-def fixture_message():
-    message = MagicMock(V4Message)
-    message.data = get_resource_content("utils/message_entity_data.json")
-    message.message = "<div data-format=\"PresentationML\" data-version=\"2.0\"> \n" \
-                      "<a href=\"http://www.symphony.com\">This is a link to Symphony's Website</a> \n </div>"
-    return message
+def create_v4_message(message, data=None):
+    v4_message = MagicMock(V4Message)
+    v4_message.data = data
+    v4_message.message = message
+    return v4_message
 
 
-@pytest.fixture(name="unparsable_message")
-def fixture_unparsable_message():
-    message = MagicMock(V4Message)
-    message.data = "unparsable json data"
-    message.message = "<div data-format=\"PresentationML\" data-version=\"2.0\"> \n"
-    return message
+def assert_message_has_text_content(actual_message, expected_text_content):
+    assert get_text_content_from_message(actual_message) == expected_text_content
 
 
-@pytest.fixture(name="escaped_message")
-def fixture_escaped_message():
-    message = MagicMock(V4Message)
-    message.message = "<div data-format=\"PresentationML\" data-version=\"2.0\"> \n" \
-                      "This is some escaped text &nbsp;</div>"
-    return message
+@pytest.fixture(name="message_with_data")
+def fixture_message_with_data():
+    return create_v4_message("<div data-format=\"PresentationML\" data-version=\"2.0\"> \n" \
+                             "<a href=\"http://www.symphony.com\">This is a link to Symphony's Website</a> \n </div>",
+                             get_resource_content("utils/message_entity_data.json"))
 
 
-def test_get_text_content_from_message(message):
-    plain_text = get_text_content_from_message(message)
-    assert plain_text == "This is a link to Symphony's Website"
+@pytest.fixture(name="message_with_invalid_data")
+def fixture_message_with_invalid_data():
+    return create_v4_message("<div data-format=\"PresentationML\" data-version=\"2.0\"> \n", "unparsable json data")
 
 
-def test_get_escaped_text_content_from_message(escaped_message):
-    plain_text = get_text_content_from_message(escaped_message)
-    assert plain_text == "This is some escaped text &#160;"
+def test_get_text_content_from_message():
+    message = create_v4_message("<div data-format=\"PresentationML\" data-version=\"2.0\"> \n"
+                                "<a href=\"http://www.symphony.com\">This is a link to Symphony's Website</a> \n </div>")
+    assert_message_has_text_content(message, "This is a link to Symphony's Website")
 
 
-def test_get_text_content_from_message_unparsable(unparsable_message):
+def test_get_text_content_from_escaped_message_ampersand():
+    escaped_message_ampersand = create_v4_message("<div data-format=\"PresentationML\" data-version=\"2.0\"> \n"
+                                                  "This is some escaped text &amp;</div>")
+    assert_message_has_text_content(escaped_message_ampersand, "This is some escaped text &")
+
+
+def test_get_text_content_from_escaped_message_lt():
+    escaped_message_lt = create_v4_message("<div data-format=\"PresentationML\" data-version=\"2.0\"> \n"
+                                           "This is some escaped text &lt;</div>")
+    assert_message_has_text_content(escaped_message_lt, "This is some escaped text <")
+
+
+def test_get_text_content_from_message_with_html_entities():
+    message_with_nbsp = create_v4_message("<div data-format=\"PresentationML\" data-version=\"2.0\"> \n"
+                                          "This is some escaped text &nbsp;</div>")
     with pytest.raises(MessageParserError):
-        get_text_content_from_message(unparsable_message)
+        get_text_content_from_message(message_with_nbsp)
 
 
-def test_get_mentions(message):
-    mentions = get_mentions(message)
+def test_get_text_content_from_message_invalid_json_data(message_with_invalid_data):
+    with pytest.raises(MessageParserError):
+        get_text_content_from_message(message_with_invalid_data)
+
+
+def test_get_mentions(message_with_data):
+    mentions = get_mentions(message_with_data)
     assert len(mentions) == 2
     assert mentions[0] == 13056700580915
     assert mentions[1] == 1305690252351
 
 
-def test_get_hashtags(message):
-    hashtags = get_hashtags(message)
+def test_get_hashtags(message_with_data):
+    hashtags = get_hashtags(message_with_data)
     assert len(hashtags) == 1
     assert hashtags[0] == "bot"
 
 
-def test_get_cashtags(message):
-    cashtags = get_cashtags(message)
+def test_get_cashtags(message_with_data):
+    cashtags = get_cashtags(message_with_data)
     assert len(cashtags) == 1
     assert cashtags[0] == "hello"
 
 
-def test_get_emojis(message):
-    emojis = get_emojis(message)
+def test_get_emojis(message_with_data):
+    emojis = get_emojis(message_with_data)
     assert emojis == {"grinning": "😀"}
 
 
-def test_get_tags_unparsable_data(unparsable_message):
-    unparsable_message.data = "unparsable_json"
+def test_get_tags_unparsable_data(message_with_invalid_data):
     with pytest.raises(MessageParserError):
-        get_emojis(unparsable_message)
+        get_emojis(message_with_invalid_data)


### PR DESCRIPTION
Closes #236 

### Description
When getting text content, we now extract the escaped content and then unescape characters

This means we will not support html entities in the presentationML like `&nbsp;`.
According to the presentationML renderer, it seems we never supported them.
And presentationML content should always have standard escaped xml entities

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [n/a] Docstrings added or updated
- [n/a] Updated the documentation in [docs folder](../docs)
