### PR TITLE
PLAT-11512 Adding support for updateIM and getIMInfo endpoint

### DIFF
--- a/symphony/bdk/core/service/stream/stream_service.py
+++ b/symphony/bdk/core/service/stream/stream_service.py
@@ -17,6 +17,8 @@ from symphony.bdk.gen.pod_model.stream_filter import StreamFilter
 from symphony.bdk.gen.pod_model.stream_list import StreamList
 from symphony.bdk.gen.pod_model.user_id import UserId
 from symphony.bdk.gen.pod_model.user_id_list import UserIdList
+from symphony.bdk.gen.pod_model.v1_im_attributes import V1IMAttributes
+from symphony.bdk.gen.pod_model.v1_im_detail import V1IMDetail
 from symphony.bdk.gen.pod_model.v2_admin_stream_filter import V2AdminStreamFilter
 from symphony.bdk.gen.pod_model.v2_admin_stream_info import V2AdminStreamInfo
 from symphony.bdk.gen.pod_model.v2_admin_stream_list import V2AdminStreamList
@@ -233,6 +235,17 @@ class StreamService(OboStreamService):
                                                            session_token=await self._auth_session.session_token)
 
     @retry
+    async def get_im_info(self, im_id: str) -> V1IMDetail:
+        """Get information about a particular IM.
+        Wraps the `IM info <https://developers.symphony.com/restapi/reference#im-info> endpoint`
+
+        :param im_id: the id of the IM.
+        :return: the im details.
+        """
+        return await self._streams_api.v1_im_id_info_get(id=im_id,
+                                                         session_token=await self._auth_session.session_token)
+
+    @retry
     async def set_room_active(self, room_id: str, active: bool) -> RoomDetail:
         """Deactivates or reactivates a chatroom. At creation time, the chatroom is activated by default.
         Wraps the `De/Reactivate Room <https://developers.symphony.com/restapi/reference#de-or-re-activate-room>`_
@@ -256,6 +269,18 @@ class StreamService(OboStreamService):
         """
         return await self._streams_api.v3_room_id_update_post(id=room_id, payload=room_attributes,
                                                               session_token=await self._auth_session.session_token)
+
+    @retry
+    async def update_im(self, im_id: str, im_attributes: V1IMAttributes) -> V1IMDetail:
+        """Updates the attributes of an existing im.
+        Wraps the `Update IM <https://developers.symphony.com/restapi/reference#update-im>`_ endpoint.
+
+        :param im_id: the id of the im to be updated.
+        :param im_attributes: the attributes of the im to be updated.
+        :return: the details of the updated im.
+        """
+        return await self._streams_api.v1_im_id_update_post(id=im_id, payload=im_attributes,
+                                                            session_token=await self._auth_session.session_token)
 
     @retry
     async def create_im_admin(self, user_ids: [int]) -> Stream:
@@ -345,6 +370,7 @@ class StreamService(OboStreamService):
         :param max_number: the total maximum number of elements to retrieve.
         :return: an asynchronous generator of the stream members.
         """
+
         async def list_stream_members_one_page(skip, limit):
             members = await self.list_stream_members(stream_id, skip, limit)
             return members.members.value if members.members else None

--- a/tests/core/service/stream/stream_service_test.py
+++ b/tests/core/service/stream/stream_service_test.py
@@ -17,6 +17,8 @@ from symphony.bdk.gen.pod_model.stream_filter import StreamFilter
 from symphony.bdk.gen.pod_model.stream_list import StreamList
 from symphony.bdk.gen.pod_model.user_id import UserId
 from symphony.bdk.gen.pod_model.user_id_list import UserIdList
+from symphony.bdk.gen.pod_model.v1_im_attributes import V1IMAttributes
+from symphony.bdk.gen.pod_model.v1_im_detail import V1IMDetail
 from symphony.bdk.gen.pod_model.v2_admin_stream_filter import V2AdminStreamFilter
 from symphony.bdk.gen.pod_model.v2_admin_stream_list import V2AdminStreamList
 from symphony.bdk.gen.pod_model.v2_membership_list import V2MembershipList
@@ -124,7 +126,6 @@ async def test_list_all_streams(mocked_api_client, stream_service, streams_api):
 
 @pytest.mark.asyncio
 async def test_add_member_to_room(stream_service, room_membership_api):
-
     user_id = 1234456
     room_id = "room_id"
     await stream_service.add_member_to_room(user_id, room_id)  # check no exception raised
@@ -135,7 +136,6 @@ async def test_add_member_to_room(stream_service, room_membership_api):
 
 @pytest.mark.asyncio
 async def test_remove_member_from_room(stream_service, room_membership_api):
-
     user_id = 1234456
     room_id = "room_id"
     await stream_service.remove_member_from_room(user_id, room_id)  # check no exception raised
@@ -161,7 +161,6 @@ async def test_share(mocked_api_client, stream_service, share_api):
 
 @pytest.mark.asyncio
 async def test_promote_user(stream_service, room_membership_api):
-
     user_id = 12345
     room_id = "room_id"
     await stream_service.promote_user_to_room_owner(user_id, room_id)  # check no exception raised
@@ -172,7 +171,6 @@ async def test_promote_user(stream_service, room_membership_api):
 
 @pytest.mark.asyncio
 async def test_demote_owner(stream_service, room_membership_api):
-
     user_id = 12345
     room_id = "room_id"
     await stream_service.demote_owner_to_room_participant(user_id, room_id)  # check no exception raised
@@ -255,6 +253,19 @@ async def test_get_room_info(mocked_api_client, stream_service, streams_api):
 
 
 @pytest.mark.asyncio
+async def test_get_im_info(mocked_api_client, stream_service, streams_api):
+    mocked_api_client.call_api.return_value = get_deserialized_object_from_resource(V1IMDetail,
+                                                                                    "stream/get_im_info.json")
+
+    im_id = "im_id"
+    im_details = await stream_service.get_im_info(im_id)
+
+    streams_api.v1_im_id_info_get.assert_called_once_with(id=im_id, session_token=SESSION_TOKEN)
+    assert im_details.v1_im_attributes.pinned_message_id == "vd7qwNb6hLoUV0BfXXPC43___oPIvkwJbQ"
+    assert im_details.im_system_info.id == "usnBKBkH_BVrGOiVpaupEH___okFfE7QdA"
+
+
+@pytest.mark.asyncio
 async def test_set_room_active(mocked_api_client, stream_service, streams_api):
     mocked_api_client.call_api.return_value = get_deserialized_object_from_resource(RoomDetail,
                                                                                     "stream/deactivate_room.json")
@@ -281,6 +292,21 @@ async def test_update_room(mocked_api_client, stream_service, streams_api):
                                                                session_token=SESSION_TOKEN)
     assert room_details.room_attributes.name == "Test bot room"
     assert room_details.room_system_info.id == "ubaSiuUsc_j-_lVQ8vhAz3___opSJdJZdA"
+
+
+@pytest.mark.asyncio
+async def test_update_im(mocked_api_client, stream_service, streams_api):
+    mocked_api_client.call_api.return_value = get_deserialized_object_from_resource(V1IMDetail,
+                                                                                    "stream/get_im_info.json")
+
+    im_id = "im_id"
+    im_attributes = V1IMAttributes()
+    im_details = await stream_service.update_im(im_id, im_attributes)
+
+    streams_api.v1_im_id_update_post.assert_called_once_with(id=im_id, payload=im_attributes,
+                                                             session_token=SESSION_TOKEN)
+    assert im_details.v1_im_attributes.pinned_message_id == "vd7qwNb6hLoUV0BfXXPC43___oPIvkwJbQ"
+    assert im_details.im_system_info.id == "usnBKBkH_BVrGOiVpaupEH___okFfE7QdA"
 
 
 @pytest.mark.asyncio

--- a/tests/resources/stream/get_im_info.json
+++ b/tests/resources/stream/get_im_info.json
@@ -1,0 +1,10 @@
+{
+  "V1IMAttributes": {
+    "pinnedMessageId": "vd7qwNb6hLoUV0BfXXPC43___oPIvkwJbQ"
+  },
+  "IMSystemInfo": {
+    "id": "usnBKBkH_BVrGOiVpaupEH___okFfE7QdA",
+    "creationDate": 1610520703317,
+    "active": true
+  }
+}


### PR DESCRIPTION
### Ticket [PLAT-11512](https://perzoinc.atlassian.net/browse/PLAT-11512)

Goal of this implementation is to add to support for two new endpoints:

- Update IM (https://developers.symphony.com/restapi/v20.13/reference#update-im) that can be used to pin/unpin a message inside an IM.
- Get IM Info (https://developers.symphony.com/restapi/v20.13/reference#im-info), used to retrieve the IM info including which message is pinned in the stream.
