### PR TITLE
Release Python BDK 2.1.0

### DIFF
--- a/docsrc/markdown/message_service.md
+++ b/docsrc/markdown/message_service.md
@@ -7,6 +7,7 @@ More precisely:
 * [Get message IDs by timestamp](https://developers.symphony.com/restapi/reference#get-message-ids-by-timestamp)
 * [Search messages](https://developers.symphony.com/restapi/reference#message-search-post)
 * [Send message](https://developers.symphony.com/restapi/reference#create-message-v4)
+* [Update message](https://developers.symphony.com/restapi/reference#update-message-v4)
 * [Import messages](https://developers.symphony.com/restapi/reference#import-message-v4)
 * [Get attachment](https://developers.symphony.com/restapi/reference#attachment)
 * [List attachments](https://developers.symphony.com/restapi/reference#list-attachments)

--- a/docsrc/markdown/migration.md
+++ b/docsrc/markdown/migration.md
@@ -1,6 +1,6 @@
 # Migration guide to Symphony BDK 2.0
 
-This guide provides information about how to migrate from Symphony BDK 1.0 to BDK 2.0. Migration for the following topics will be detailed here:
+This guide provides information about how to migrate from Symphony SDK 1.0 to BDK 2.0. Migration for the following topics will be detailed here:
 - Dependencies
 - Bot configuration
 - Symphony BDK entry point
@@ -8,12 +8,12 @@ This guide provides information about how to migrate from Symphony BDK 1.0 to BD
 - Event listeners
 
 ## Dependencies
-To use the Python BDK 1.x, you had to use the
+To use the Python SDK 1.x, you had to use the
 [`sym-api-client-python` Pypi package](https://pypi.org/project/sym-api-client-python/) in your `requirements.txt` file.
 For the Python BDK 2.0, package name has been changed to [`symphony-bdk-python`](https://pypi.org/project/symphony-bdk-python/).
 
 ## Bot configuration
-In order for bots to function, a configuration file is needed. Whereas Python BDK 1.x only supports JSON format,
+In order for bots to function, a configuration file is needed. Whereas Python SDK 1.x only supports JSON format,
 Python BDK 2.0 supports both JSON and YAML formats.
 
 Bot configuration for Python BDK 2.0 should have the following properties:
@@ -31,7 +31,7 @@ If your bot is deployed on premise, the following properties are required as wel
 
 ### Minimal configuration example
 
-#### Using the BDK 1.x
+#### Using the SDK 1.x
 ```json
 {
     "sessionAuthHost": "acme.symphony.com",
@@ -69,8 +69,8 @@ bot:
 
 ## Symphony BDK entry point
 
-For the BDK 1.x, `SymBotClient` object acts as an entry point for all services, whereas for the BDK 2.0, it is the `SymphonyBdk` object.
-Whereas the BDK 1.x exposes synchronous methods, the BDK 2.0 exposes most of the service methods as `async` methods.
+For the SDK 1.x, `SymBotClient` object acts as an entry point for all services, whereas for the BDK 2.0, it is the `SymphonyBdk` object.
+Whereas the SDK 1.x exposes synchronous methods, the BDK 2.0 exposes most of the service methods as `async` methods.
 Therefore, an `asyncio` loop is needed to use the BDK.
 
 Please check below for examples or check the [getting started](./getting_started.md) guide.
@@ -78,7 +78,7 @@ Please check below for examples or check the [getting started](./getting_started
 ## BDK services
 To illustrate the use of services, let's take an example of a bot reacting to *ping pong* messages.
 
-### Using the BDK 1.x
+### Using the SDK 1.x
 
 ```python
 from sym_api_client_python.auth.rsa_auth import SymBotRSAAuth
@@ -184,8 +184,8 @@ if __name__ == "__main__":
 
 ## Event listeners
 
-### Using the BDK 1.x
-In the Python BDK 1.x, we have three main types of listeners:
+### Using the SDK 1.x
+In the Python SDK 1.x, we have three main types of listeners:
 - for IM (1 to 1 conversation)
 - for MIM (room)
 - for Symphony elements
@@ -207,7 +207,7 @@ See the [dedicated page](./activity-api.md) on how to use it.
 
 ## Message parsing functions
 
-The Python BDK 1.x provides utility modules to parse elements and messages.
+The Python SDK 1.x provides utility modules to parse elements and messages.
 The [sym_elements_parser module](https://github.com/finos/symphony-bdk-python/blob/legacy/sym_api_client_python/processors/sym_elements_parser.py)
 has no replacement in the BDK 2.0 since method `on_symphony_elements_action` of
 [`RealTimeEventListener`](../_autosummary/symphony.bdk.core.service.datafeed.real_time_event_listener.RealTimeEventListener.html)
@@ -222,6 +222,6 @@ Models names have been changed in Python BDK 2.0. They actually follow the model
 [Symphony's public API](https://github.com/symphonyoss/symphony-api-spec). Field names in Python classes correspond to
 the field names in API's JSON payloads. This requires to change some variable types in your legacy bots.
 
-Whereas most of the objects used in the Python BDK 1.x are Python dictionaries, the Python BDK 2.0 leverages objects
+Whereas most of the objects used in the Python SDK 1.x are Python dictionaries, the Python BDK 2.0 leverages objects
 generated from the openapi specifications. All public methods exposed by the BDK have type hints so that you can easily
 know which types are used as parameters or returned. You can also check the generated documentation [here](../_autosummary/symphony.bdk.core.html).

--- a/examples/services/message_update.py
+++ b/examples/services/message_update.py
@@ -1,0 +1,34 @@
+import asyncio
+import logging.config
+from pathlib import Path
+
+from symphony.bdk.core.activity.command import CommandContext
+from symphony.bdk.core.config.loader import BdkConfigLoader
+from symphony.bdk.core.symphony_bdk import SymphonyBdk
+import time
+
+from symphony.bdk.gen.agent_model.v4_message import V4Message
+
+
+async def run():
+    async with SymphonyBdk(BdkConfigLoader.load_from_symphony_dir("config.yaml")) as bdk:
+        activities = bdk.activities()
+        messages = bdk.messages()
+
+        @activities.slash("/go")
+        async def on_hello(context: CommandContext):
+            pick_emoji = ["cat", "dromedary_camel", "dolphin", "dog", "hamster", "goat", "panda_face", "koala", "frog", "penguin"]
+
+            previous_message: V4Message = await messages.send_message(context.stream_id, "Let the show begin!")
+
+            for i in range(0, len(pick_emoji)):
+                time.sleep(1)
+                mml = "<emoji shortcode=\"{}\" /><br/><br/>Update <b>#{}</b>".format(pick_emoji[i], (i + 1))
+                previous_message = await messages.update_message(previous_message.stream.stream_id, previous_message.message_id, mml)
+
+        await bdk.datafeed().start()
+
+
+logging.config.fileConfig(Path(__file__).parent.parent / "logging.conf", disable_existing_loggers=False)
+
+asyncio.run(run())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "symphony_bdk_python"
-version = "2.0.1"
+version = "2.1.0"
 license = "Apache-2.0"
 description = "Symphony Bot Development Kit for Python"
 readme = "README.md"

--- a/symphony/bdk/core/service/message/message_service.py
+++ b/symphony/bdk/core/service/message/message_service.py
@@ -464,6 +464,36 @@ class MessageService(OboMessageService):
 
         return offset_based_pagination(search_messages_one_page, chunk_size, max_number)
 
+    @retry
+    async def update_message(self, stream_id: str, message_id: str, message: Union[str, Message], data=None,
+                             version: str = "") -> V4Message:
+        """Update an existing message. The existing message must be a valid social message, that has not been deleted.
+        See: `Update Message <https://developers.symphony.com/restapi/reference#update-message-v4>`_
+
+        :param stream_id: The ID of the stream where the message is being updated.
+        :param message_id: The ID of the message that is being updated.
+        :param message: a :py:class:`Message` instance or a string containing the MessageML content to be sent.
+          If it is a :py:class:`Message` instance, other parameters will be ignored.
+          If it is a string, ``<messageML>`` tags can be omitted.
+        :param data: an object (e.g. dict) that will be serialized into JSON using ``json.dumps``.
+        :param version: Optional message version in the format "major.minor".
+          If empty, defaults to the latest supported version.
+
+        :return: a V4Message object containing the details of the updated message.
+        """
+        message_object = message if isinstance(message, Message) else Message(content=message, data=data, version=version)
+
+        params = {
+            "sid": stream_id,
+            "mid": message_id,
+            "session_token": await self._auth_session.session_token,
+            "key_manager_token": await self._auth_session.key_manager_token,
+            "message": message_object.content,
+            "data": message_object.data,
+            "version": message_object.version
+        }
+        return await self._messages_api.v4_stream_sid_message_mid_update_post(**params)
+
     @staticmethod
     def _validate_message_search_query(query: MessageSearchQuery):
         # Check streamType value among accepted ones if specified

--- a/symphony/bdk/core/service/stream/stream_service.py
+++ b/symphony/bdk/core/service/stream/stream_service.py
@@ -17,6 +17,8 @@ from symphony.bdk.gen.pod_model.stream_filter import StreamFilter
 from symphony.bdk.gen.pod_model.stream_list import StreamList
 from symphony.bdk.gen.pod_model.user_id import UserId
 from symphony.bdk.gen.pod_model.user_id_list import UserIdList
+from symphony.bdk.gen.pod_model.v1_im_attributes import V1IMAttributes
+from symphony.bdk.gen.pod_model.v1_im_detail import V1IMDetail
 from symphony.bdk.gen.pod_model.v2_admin_stream_filter import V2AdminStreamFilter
 from symphony.bdk.gen.pod_model.v2_admin_stream_info import V2AdminStreamInfo
 from symphony.bdk.gen.pod_model.v2_admin_stream_list import V2AdminStreamList
@@ -233,6 +235,17 @@ class StreamService(OboStreamService):
                                                            session_token=await self._auth_session.session_token)
 
     @retry
+    async def get_im_info(self, im_id: str) -> V1IMDetail:
+        """Get information about a particular IM.
+        Wraps the `IM info <https://developers.symphony.com/restapi/reference#im-info> endpoint`
+
+        :param im_id: the id of the IM.
+        :return: the im details.
+        """
+        return await self._streams_api.v1_im_id_info_get(id=im_id,
+                                                         session_token=await self._auth_session.session_token)
+
+    @retry
     async def set_room_active(self, room_id: str, active: bool) -> RoomDetail:
         """Deactivates or reactivates a chatroom. At creation time, the chatroom is activated by default.
         Wraps the `De/Reactivate Room <https://developers.symphony.com/restapi/reference#de-or-re-activate-room>`_
@@ -256,6 +269,18 @@ class StreamService(OboStreamService):
         """
         return await self._streams_api.v3_room_id_update_post(id=room_id, payload=room_attributes,
                                                               session_token=await self._auth_session.session_token)
+
+    @retry
+    async def update_im(self, im_id: str, im_attributes: V1IMAttributes) -> V1IMDetail:
+        """Updates the attributes of an existing im.
+        Wraps the `Update IM <https://developers.symphony.com/restapi/reference#update-im>`_ endpoint.
+
+        :param im_id: the id of the im to be updated.
+        :param im_attributes: the attributes of the im to be updated.
+        :return: the details of the updated im.
+        """
+        return await self._streams_api.v1_im_id_update_post(id=im_id, payload=im_attributes,
+                                                            session_token=await self._auth_session.session_token)
 
     @retry
     async def create_im_admin(self, user_ids: [int]) -> Stream:
@@ -345,6 +370,7 @@ class StreamService(OboStreamService):
         :param max_number: the total maximum number of elements to retrieve.
         :return: an asynchronous generator of the stream members.
         """
+
         async def list_stream_members_one_page(skip, limit):
             members = await self.list_stream_members(stream_id, skip, limit)
             return members.members.value if members.members else None

--- a/tests/core/service/message/message_service_test.py
+++ b/tests/core/service/message/message_service_test.py
@@ -412,3 +412,13 @@ async def test_search_all_messages(mocked_api_client, message_service):
     assert messages[0].message_id == "test-message1"
 
     assert mocked_api_client.call_api.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_update_message(mocked_api_client, message_service):
+    mocked_api_client.call_api.return_value = \
+        get_deserialized_object_from_resource(V4Message, "message_response/update_message.json")
+    message = await message_service.update_message("stream_id", "message_id", "test_message")
+
+    assert message.message_id == "ikCBeVCgQT876veVzQzOV3___oNI6f8obQ"
+    assert message.user.user_id == 11338713662703

--- a/tests/core/service/stream/stream_service_test.py
+++ b/tests/core/service/stream/stream_service_test.py
@@ -17,6 +17,8 @@ from symphony.bdk.gen.pod_model.stream_filter import StreamFilter
 from symphony.bdk.gen.pod_model.stream_list import StreamList
 from symphony.bdk.gen.pod_model.user_id import UserId
 from symphony.bdk.gen.pod_model.user_id_list import UserIdList
+from symphony.bdk.gen.pod_model.v1_im_attributes import V1IMAttributes
+from symphony.bdk.gen.pod_model.v1_im_detail import V1IMDetail
 from symphony.bdk.gen.pod_model.v2_admin_stream_filter import V2AdminStreamFilter
 from symphony.bdk.gen.pod_model.v2_admin_stream_list import V2AdminStreamList
 from symphony.bdk.gen.pod_model.v2_membership_list import V2MembershipList
@@ -124,7 +126,6 @@ async def test_list_all_streams(mocked_api_client, stream_service, streams_api):
 
 @pytest.mark.asyncio
 async def test_add_member_to_room(stream_service, room_membership_api):
-
     user_id = 1234456
     room_id = "room_id"
     await stream_service.add_member_to_room(user_id, room_id)  # check no exception raised
@@ -135,7 +136,6 @@ async def test_add_member_to_room(stream_service, room_membership_api):
 
 @pytest.mark.asyncio
 async def test_remove_member_from_room(stream_service, room_membership_api):
-
     user_id = 1234456
     room_id = "room_id"
     await stream_service.remove_member_from_room(user_id, room_id)  # check no exception raised
@@ -161,7 +161,6 @@ async def test_share(mocked_api_client, stream_service, share_api):
 
 @pytest.mark.asyncio
 async def test_promote_user(stream_service, room_membership_api):
-
     user_id = 12345
     room_id = "room_id"
     await stream_service.promote_user_to_room_owner(user_id, room_id)  # check no exception raised
@@ -172,7 +171,6 @@ async def test_promote_user(stream_service, room_membership_api):
 
 @pytest.mark.asyncio
 async def test_demote_owner(stream_service, room_membership_api):
-
     user_id = 12345
     room_id = "room_id"
     await stream_service.demote_owner_to_room_participant(user_id, room_id)  # check no exception raised
@@ -255,6 +253,19 @@ async def test_get_room_info(mocked_api_client, stream_service, streams_api):
 
 
 @pytest.mark.asyncio
+async def test_get_im_info(mocked_api_client, stream_service, streams_api):
+    mocked_api_client.call_api.return_value = get_deserialized_object_from_resource(V1IMDetail,
+                                                                                    "stream/get_im_info.json")
+
+    im_id = "im_id"
+    im_details = await stream_service.get_im_info(im_id)
+
+    streams_api.v1_im_id_info_get.assert_called_once_with(id=im_id, session_token=SESSION_TOKEN)
+    assert im_details.v1_im_attributes.pinned_message_id == "vd7qwNb6hLoUV0BfXXPC43___oPIvkwJbQ"
+    assert im_details.im_system_info.id == "usnBKBkH_BVrGOiVpaupEH___okFfE7QdA"
+
+
+@pytest.mark.asyncio
 async def test_set_room_active(mocked_api_client, stream_service, streams_api):
     mocked_api_client.call_api.return_value = get_deserialized_object_from_resource(RoomDetail,
                                                                                     "stream/deactivate_room.json")
@@ -281,6 +292,21 @@ async def test_update_room(mocked_api_client, stream_service, streams_api):
                                                                session_token=SESSION_TOKEN)
     assert room_details.room_attributes.name == "Test bot room"
     assert room_details.room_system_info.id == "ubaSiuUsc_j-_lVQ8vhAz3___opSJdJZdA"
+
+
+@pytest.mark.asyncio
+async def test_update_im(mocked_api_client, stream_service, streams_api):
+    mocked_api_client.call_api.return_value = get_deserialized_object_from_resource(V1IMDetail,
+                                                                                    "stream/get_im_info.json")
+
+    im_id = "im_id"
+    im_attributes = V1IMAttributes()
+    im_details = await stream_service.update_im(im_id, im_attributes)
+
+    streams_api.v1_im_id_update_post.assert_called_once_with(id=im_id, payload=im_attributes,
+                                                             session_token=SESSION_TOKEN)
+    assert im_details.v1_im_attributes.pinned_message_id == "vd7qwNb6hLoUV0BfXXPC43___oPIvkwJbQ"
+    assert im_details.im_system_info.id == "usnBKBkH_BVrGOiVpaupEH___okFfE7QdA"
 
 
 @pytest.mark.asyncio

--- a/tests/resources/message_response/update_message.json
+++ b/tests/resources/message_response/update_message.json
@@ -1,0 +1,21 @@
+{
+    "messageId": "ikCBeVCgQT876veVzQzOV3___oNI6f8obQ",
+    "timestamp": 1635159245015,
+    "message": "<div data-format=\"PresentationML\" data-version=\"2.0\"> Update Message </div>",
+    "user": {
+        "userId": 11338713662703,
+        "displayName": "Bot",
+        "email": "bot@symphony.com",
+        "username": "bot"
+    },
+    "stream": {
+        "streamId": "6KShJiVLWG2WUjbzA2fKPX___oNhuDbOdA",
+        "streamType": "ROOM"
+    },
+    "userAgent": "Agent-20.13.0-SNAPSHOT-Linux-4.14.243-185.433.amzn2.x86_64",
+    "originalFormat": "com.symphony.messageml.v2",
+    "sid": "b10d692f-899e-4601-b946-879da15c0462",
+    "replacing": "PUQj2xA0eniBOfeNTbTu8X___oNdE9uDbQ",
+    "initialTimestamp": 1634820957308,
+    "initialMessageId": "PUQj2xA0eniBOfeNTbTu8X___oNdE9uDbQ"
+}

--- a/tests/resources/stream/get_im_info.json
+++ b/tests/resources/stream/get_im_info.json
@@ -1,0 +1,10 @@
+{
+  "V1IMAttributes": {
+    "pinnedMessageId": "vd7qwNb6hLoUV0BfXXPC43___oPIvkwJbQ"
+  },
+  "IMSystemInfo": {
+    "id": "usnBKBkH_BVrGOiVpaupEH___okFfE7QdA",
+    "creationDate": 1610520703317,
+    "active": true
+  }
+}


### PR DESCRIPTION
### Ticket
Backport of:
#239 
#240 
#241 

### Description
2.0.2 release of the Python BDK, mostly for:
* support for updateIM and getIMInfo endpoint
* support for update message endpoint

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [x] Docstrings added or updated
- [x] Updated the documentation in [docs folder](../docs)
