### PR TITLE
Broken documentation generation

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -224,7 +224,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "docutils"
-version = "0.18.1"
+version = "0.16"
 description = "Docutils -- Python Documentation Utilities"
 category = "main"
 optional = false
@@ -815,7 +815,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "978d0494045fd644364402c61ce8a2e1c6213b7ab77ef9af8ba4b0514cbecf00"
+content-hash = "c60118a56ee98e6cb7bcc12fff8fb213e6ee954a36f410c5fe10f775f0226d19"
 
 [metadata.files]
 aiohttp = [
@@ -1077,8 +1077,8 @@ defusedxml = [
     {file = "defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"},
 ]
 docutils = [
-    {file = "docutils-0.18.1-py2.py3-none-any.whl", hash = "sha256:23010f129180089fbcd3bc08cfefccb3b890b0050e1ca00c867036e9d161b98c"},
-    {file = "docutils-0.18.1.tar.gz", hash = "sha256:679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06"},
+    {file = "docutils-0.16-py2.py3-none-any.whl", hash = "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af"},
+    {file = "docutils-0.16.tar.gz", hash = "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"},
 ]
 dparse = [
     {file = "dparse-0.5.1-py3-none-any.whl", hash = "sha256:e953a25e44ebb60a5c6efc2add4420c177f1d8404509da88da9729202f306994"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ PyJWT = "^2.3.0"
 cryptography = "^36.0.0"
 tenacity = "^8.0.1"
 defusedxml = "^0.7.1"
-docutils = "^0.18.1"
+docutils = "0.16"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2"


### PR DESCRIPTION
After #246, documentation generation is broken because of
https://github.com/sphinx-doc/sphinx/issues/9049

Putting back docutils to 0.16
