### PR TITLE
Improve suspend user API

### DIFF
--- a/symphony/bdk/core/service/user/user_service.py
+++ b/symphony/bdk/core/service/user/user_service.py
@@ -815,3 +815,49 @@ class UserService(OboUserService):
         }
 
         await self._user_api.v1_admin_user_user_id_suspension_update_put(**params)
+
+    @retry
+    async def suspend(
+            self,
+            user_id: int,
+            reason: str = None,
+            until: int = None
+    ) -> None:
+        """Suspends a user account.
+        Calling this endpoint requires a service account with the User Provisioning role.
+        See: `Suspend User Account v1 <https://developers.symphony.com/restapi/v20.10/reference#suspend-user-v1>`_
+
+        :param user_id:         User id to suspend
+        :param user_suspension: User suspension payload.
+        :param reason:          Reason why the user has to be suspended
+        :param until:           Time till when the user should be suspended in millis
+        """
+
+        user_suspension = UserSuspension(suspended=True, suspended_until=until, suspension_reason=reason)
+        params = {
+            'user_id': user_id,
+            'payload': user_suspension,
+            'session_token': await self._auth_session.session_token
+        }
+
+        await self._user_api.v1_admin_user_user_id_suspension_update_put(**params)
+
+    @retry
+    async def unsuspend(
+            self,
+            user_id: int
+    ) -> None:
+        """Unsuspend (Re-activates) a user account.
+        Calling this endpoint requires a service account with the User Provisioning role.
+        See: `Suspend User Account v1 <https://developers.symphony.com/restapi/v20.10/reference#suspend-user-v1>`_
+
+        :param user_id:     user id to reactivate
+        """
+
+        params = {
+            'user_id': user_id,
+            'payload': UserSuspension(suspended=False),
+            'session_token': await self._auth_session.session_token
+        }
+
+        await self._user_api.v1_admin_user_user_id_suspension_update_put(**params)

--- a/tests/core/service/user/user_service_test.py
+++ b/tests/core/service/user/user_service_test.py
@@ -691,3 +691,31 @@ async def test_suspend_user(user_api, user_service):
         payload=user_suspension,
         session_token="session_token"
     )
+
+
+@pytest.mark.asyncio
+async def test_suspend(user_api, user_service):
+    user_api.v1_admin_user_user_id_suspension_update_put = AsyncMock()
+    user_suspension = UserSuspension(suspended=True, suspended_until=1601596799999, suspension_reason="testing")
+
+    await user_service.suspend(user_id=1234, reason="testing", until=1601596799999)
+
+    user_api.v1_admin_user_user_id_suspension_update_put.assert_called_with(
+        user_id=1234,
+        payload=user_suspension,
+        session_token="session_token"
+    )
+
+
+@pytest.mark.asyncio
+async def test_unsuspend(user_api, user_service):
+    user_api.v1_admin_user_user_id_suspension_update_put = AsyncMock()
+    user_suspension = UserSuspension(suspended=False)
+
+    await user_service.unsuspend(1234)
+
+    user_api.v1_admin_user_user_id_suspension_update_put.assert_called_with(
+        user_id=1234,
+        payload=user_suspension,
+        session_token="session_token"
+    )


### PR DESCRIPTION
Related to https://github.com/finos/symphony-bdk-java/issues/598, we decided to ease the usage of this endpoint by providing two different functions to suspend/unsuspend a user account.
- suspend(userId, reason, until)
- unsuspend(userId)

Closes https://github.com/finos/symphony-bdk-python/issues/248