### PR TITLE
PLAT-11728 Documented how to achieve full concurrency across several DF events

### DIFF
--- a/docsrc/markdown/datafeed.md
+++ b/docsrc/markdown/datafeed.md
@@ -66,7 +66,7 @@ class HelloCommandActivity(CommandActivity):
         return context.text_content.startswith("@" + context.bot_display_name + " /command")
 
     async def on_activity(self, context: CommandContext):
-         # Create task to enable parallelism. Must be done for all listeners in order for the datafeed loop not to be blocked by listeners.
+        # Create task to enable parallelism. Must be done for all listeners in order for the datafeed loop not to be blocked by listeners.
         asyncio.create_task(self.actual_logic(context))
 
     async def actual_logic(self, context):


### PR DESCRIPTION
### Ticket
PLAT-11728

### Description
Documented how we could have listeners that do not block the DF loop

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Updated the documentation in [docs folder](../docs)
