### PR TITLE
Retry on client/timeout errors

### DIFF
--- a/symphony/bdk/core/retry/strategy.py
+++ b/symphony/bdk/core/retry/strategy.py
@@ -1,4 +1,5 @@
-from aiohttp import ClientConnectorError
+from aiohttp import ClientConnectionError
+from asyncio import TimeoutError
 from tenacity import RetryCallState
 
 from symphony.bdk.core.auth.exception import AuthUnauthorizedError
@@ -14,12 +15,12 @@ def is_client_error(exception: Exception) -> bool:
 
 
 def is_client_timeout_error(exception: Exception):
-    """Checks if the exception is a :py:class:`ClientConnectorError` with a :py:class:`TimeoutError` as cause
+    """Checks if the exception is a client timeout error
 
     :param exception: The exception to be checked
     :return: True if checks the predicate, False otherwise
     """
-    return isinstance(exception, ClientConnectorError) and isinstance(exception.__cause__, TimeoutError)
+    return isinstance(exception, ClientConnectionError) or isinstance(exception, TimeoutError)
 
 
 def can_authentication_be_retried(exception: Exception) -> bool:


### PR DESCRIPTION
### Ticket
#256 

### Description
It looks like the existing logic to retry on timeouts or client errors
was not working as expected. For instance the DF loop would exit on
timeouts.

The aiohttp client can raise different errors
(https://docs.aiohttp.org/en/stable/client_reference.html#client-exceptions)
and also asyncio.TimeoutError.

I tried locally by misconfiguring the hostname (it cannot be resolved)
and the port (triggers a timeout).

However this means that retries will be performed upon startup even if
the hostname cannot be resolved for instance. Which is not 100% like the
Java BDK who has a different logic for authentication and datafeed
retries. The problem is how sessions are refreshed, here lazily so we
have two nested @retry calls making it difficult to have different
strategies.

Fixes #256

### Dependencies
N/A
### Checklist
- [X] Referenced a ticket in the PR title and in the corresponding section
- [X] Filled properly the description and dependencies, if any
- [X] Unit tests updated or added
- [X] Docstrings added or updated
- [-] Updated the documentation in [docs folder](../docs)
