### PR TITLE
Remove unsupported Datahose events from documentation

### DIFF
--- a/docsrc/markdown/datafeed.md
+++ b/docsrc/markdown/datafeed.md
@@ -205,11 +205,8 @@ datahose:
 The minimal configuration for the datahose service is the `filters` field. It should contain at least one value chosen
 among the following:
 * SOCIALMESSAGE
-* CHANNEL_CREATE
-* CHANNEL_UPDATE
 * CREATE_ROOM
 * UPDATE_ROOM
-* UPDATE_STREAM
 
 :warning: If you want to use `SOCIALMESSAGE` filter (i.e. consume message sent events), `ceservice` credentials must be
 configured in your Symphony agent.

--- a/tests/core/config/models/bdk_datahose_config_test.py
+++ b/tests/core/config/models/bdk_datahose_config_test.py
@@ -13,13 +13,13 @@ def test_empty_datahose_config():
 
 
 def test_datahose_config_with_retry():
-    config_with_tag = {"tag": "TAG", "filters": ["CHANNEL_CREATE", "CREATE_ROOM"]}
+    config_with_tag = {"tag": "TAG", "filters": ["SOCIALMESSAGE", "CREATE_ROOM"]}
     config_retry = {"maxAttempts": 10, "multiplier": 1.51, "maxIntervalMillis": 10000, "initialIntervalMillis": 2000}
     config_with_tag["retry"] = config_retry
 
     datahose_config = BdkDatahoseConfig(config_with_tag)
     assert datahose_config.tag == "TAG"
-    assert datahose_config.filters == ["CHANNEL_CREATE", "CREATE_ROOM"]
+    assert datahose_config.filters == ["SOCIALMESSAGE", "CREATE_ROOM"]
     assert datahose_config.retry.max_attempts == 10
     assert datahose_config.retry.multiplier == 1.51
     assert datahose_config.retry.max_interval.seconds == 10
@@ -27,10 +27,10 @@ def test_datahose_config_with_retry():
 
 
 def test_datahose_config_without_retry():
-    config_with_tag = {"tag": "TAG", "filters": ["CHANNEL_CREATE", "CREATE_ROOM"]}
+    config_with_tag = {"tag": "TAG", "filters": ["SOCIALMESSAGE", "CREATE_ROOM"]}
 
     datahose_config = BdkDatahoseConfig(config_with_tag)
     assert datahose_config.tag == "TAG"
-    assert datahose_config.filters == ["CHANNEL_CREATE", "CREATE_ROOM"]
+    assert datahose_config.filters == ["SOCIALMESSAGE", "CREATE_ROOM"]
     assert datahose_config.retry.max_attempts == sys.maxsize
     assert datahose_config.retry.multiplier == BdkRetryConfig.DEFAULT_MULTIPLIER


### PR DESCRIPTION
Those events are not yet handled by the Agent so avoid mentioning them
in the documentation.
