### PR TITLE
Fix DF2 ID format regex pattern bug

### DIFF
--- a/symphony/bdk/core/service/datafeed/datafeed_loop_v2.py
+++ b/symphony/bdk/core/service/datafeed/datafeed_loop_v2.py
@@ -15,7 +15,7 @@ from symphony.bdk.gen.agent_model.v5_datafeed_create_body import V5DatafeedCreat
 
 # DFv2 API authorizes a maximum length for the tag parameter
 DATAFEED_TAG_MAX_LENGTH = 100
-DATAFEED_V2_ID_PATTERN = re.compile("^[^\\s_]+_f_[^\\s_]+$")
+DATAFEED_V2_ID_PATTERN = re.compile("^[^\\s_]+_f(_[^\\s_]+)?$")
 
 logger = logging.getLogger(__name__)
 

--- a/tests/core/service/datafeed/datafeed_loop_v2_test.py
+++ b/tests/core/service/datafeed/datafeed_loop_v2_test.py
@@ -151,6 +151,26 @@ async def test_start_already_started_datafeed_v2_loop_should_throw_error(datafee
 
 
 @pytest.mark.asyncio
+async def test_start_old_datafeed_format_exist(datafeed_loop, datafeed_api, read_df_side_effect):
+    datafeed_api.list_datafeed.return_value = [V5Datafeed(id="abc_f")]
+    datafeed_api.read_datafeed.side_effect = read_df_side_effect
+
+    await datafeed_loop.start()
+
+    datafeed_api.list_datafeed.assert_called_with(
+        session_token="session_token",
+        key_manager_token="km_token",
+        tag=BOT_USER
+    )
+    assert datafeed_api.read_datafeed.call_args_list[0].kwargs == {"session_token": "session_token",
+                                                                   "key_manager_token": "km_token",
+                                                                   "datafeed_id": "abc_f",
+                                                                   "ack_id": AckId(ack_id="")}
+    assert datafeed_loop._datafeed_id == "abc_f"
+    assert datafeed_loop._ack_id == "ack_id"
+
+
+@pytest.mark.asyncio
 async def test_start_datafeed_exist(datafeed_loop, datafeed_api, read_df_side_effect):
     datafeed_api.list_datafeed.return_value = [V5Datafeed(id="abc_f_def")]
     datafeed_api.read_datafeed.side_effect = read_df_side_effect


### PR DESCRIPTION
The existing feed id does not have the suffix after '_f',
which does not matche with the regex pattern.
With this commit, the regex pattern will match the existing
DF ID as well as the new DF ID value (haveing the suffix
after '_f').

### Description
Closes #[ISSUE NUMBER]

Please put here the intent of your pull request.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced an issue in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [ ] Docstrings added or updated
- [ ] Updated the documentation in [docsrc folder](../tree/main/docsrc)
