### PR TITLE
#295 Bug fix: presence not working with DF2

### DIFF
--- a/symphony/bdk/gen/agent_model/ack_id.py
+++ b/symphony/bdk/gen/agent_model/ack_id.py
@@ -247,7 +247,7 @@ class AckId(ModelNormal):
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
 
         self.ack_id: str = None
-        self.update_presence: bool = None
+        self.update_presence: bool = True
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/group_model/interaction_control.py
+++ b/symphony/bdk/gen/group_model/interaction_control.py
@@ -265,7 +265,7 @@ class InteractionControl(ModelNormal):
         self.allow_rooms: bool = None
         self.interaction_transfer: InteractionTransfer = None
         self.tag_stream: str = None
-        self.can_have_interaction: bool = None
+        self.can_have_interaction: bool = True
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/group_model/membership_control.py
+++ b/symphony/bdk/gen/group_model/membership_control.py
@@ -269,7 +269,7 @@ class MembershipControl(ModelNormal):
         self.rule_membership: bool = None
         self.update_membership_on_rule_update: bool = None
         self.notify_members_on_update: bool = None
-        self.can_belong_to_multiple_group: bool = None
+        self.can_belong_to_multiple_group: bool = True
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/group_model/profile_control.py
+++ b/symphony/bdk/gen/group_model/profile_control.py
@@ -276,7 +276,7 @@ class ProfileControl(ModelNormal):
         self.wall_support: bool = None
         self.profile_fields: List[str] = None
         self.search_fields: List[str] = None
-        self.can_have_public_profile: bool = None
+        self.can_have_public_profile: bool = True
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/password_reset.py
+++ b/symphony/bdk/gen/pod_model/password_reset.py
@@ -245,7 +245,7 @@ class PasswordReset(ModelNormal):
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
 
-        self.type: str = None
+        self.type: str = "EMAIL"
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/symphony/bdk/gen/pod_model/user_app_entitlement_patch.py
+++ b/symphony/bdk/gen/pod_model/user_app_entitlement_patch.py
@@ -279,8 +279,8 @@ class UserAppEntitlementPatch(ModelNormal):
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
 
         self.app_id: str = app_id
-        self.listed: str = None
-        self.install: str = None
+        self.listed: str = "KEEP"
+        self.install: str = "KEEP"
         self.product: Product = None
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \

--- a/tests/core/service/datafeed/datafeed_loop_v2_test.py
+++ b/tests/core/service/datafeed/datafeed_loop_v2_test.py
@@ -138,7 +138,7 @@ async def test_start(datafeed_loop, datafeed_api, session_service, read_df_side_
     assert datafeed_api.read_datafeed.call_args_list[0].kwargs == {"session_token": "session_token",
                                                                    "key_manager_token": "km_token",
                                                                    "datafeed_id": "test_id",
-                                                                   "ack_id": AckId(ack_id="")}
+                                                                   "ack_id": AckId(ack_id="", update_presence=True)}
     assert datafeed_loop._datafeed_id == "test_id"
     assert datafeed_loop._ack_id == "ack_id"
 
@@ -165,7 +165,7 @@ async def test_start_old_datafeed_format_exist(datafeed_loop, datafeed_api, read
     assert datafeed_api.read_datafeed.call_args_list[0].kwargs == {"session_token": "session_token",
                                                                    "key_manager_token": "km_token",
                                                                    "datafeed_id": "abc_f",
-                                                                   "ack_id": AckId(ack_id="")}
+                                                                   "ack_id": AckId(ack_id="", update_presence=True)}
     assert datafeed_loop._datafeed_id == "abc_f"
     assert datafeed_loop._ack_id == "ack_id"
 
@@ -185,7 +185,7 @@ async def test_start_datafeed_exist(datafeed_loop, datafeed_api, read_df_side_ef
     assert datafeed_api.read_datafeed.call_args_list[0].kwargs == {"session_token": "session_token",
                                                                    "key_manager_token": "km_token",
                                                                    "datafeed_id": "abc_f_def",
-                                                                   "ack_id": AckId(ack_id="")}
+                                                                   "ack_id": AckId(ack_id="", update_presence=True)}
     assert datafeed_loop._datafeed_id == "abc_f_def"
     assert datafeed_loop._ack_id == "ack_id"
 
@@ -206,7 +206,7 @@ async def test_read_datafeed_bad_id(datafeed_loop, datafeed_api, read_df_side_ef
     assert datafeed_api.read_datafeed.call_args_list[0].kwargs == {"session_token": "session_token",
                                                                    "key_manager_token": "km_token",
                                                                    "datafeed_id": "abc_f_def",
-                                                                   "ack_id": AckId(ack_id="")}
+                                                                   "ack_id": AckId(ack_id="", update_presence=True)}
 
     datafeed_api.create_datafeed.assert_called_once()
 
@@ -259,13 +259,13 @@ async def test_start_datafeed_stale_datafeed(datafeed_loop, datafeed_api, sessio
             session_token="session_token",
             key_manager_token="km_token",
             datafeed_id="abc_f_def",
-            ack_id=AckId(ack_id="")
+            ack_id=AckId(ack_id="", update_presence=True)
         ),
         call(
             session_token="session_token",
             key_manager_token="km_token",
             datafeed_id="test_id",
-            ack_id=AckId(ack_id="")
+            ack_id=AckId(ack_id="", update_presence=True)
         )
     ])
 


### PR DESCRIPTION
### Description
Closes #295 
When using DF2, the bot presence is handled in Agent side. The datafeed ackId has been previously updated to include a boolean field update_presence in addition to the ackId string. This boolean field allows Agent to update bot presence along with the DF heartbeat. The field default value is True and cannot be changed by the bot (it is only customisable via API calls).

The issue preventing the presence update was happening because the default value of update_presence, which is True, was generated as None in BDK Python, which in turn is mapped to False in Agent side. Consequently, Agent was skipping bot presence update.

In this commit, we updated the generated code to use the latest that we changed to set the default value for optiona vars, if provided, otherwise None is used. Previously, None was always set in any case.

### Checklist
- [x] Referenced an issue in the PR title or description
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [ ] Docstrings added or updated
- [ ] Updated the documentation in [docsrc folder](../tree/main/docsrc)
