### PR TITLE
Fixed bug with message.data in InputTokenizer

### DIFF
--- a/symphony/bdk/core/activity/parsing/input_tokenizer.py
+++ b/symphony/bdk/core/activity/parsing/input_tokenizer.py
@@ -23,7 +23,7 @@ class InputTokenizer:
         :param message: message to be tokenized.
         """
         self._document = fromstring(message.message)
-        json_data = message.data if message.data else "{}"
+        json_data = message.data if hasattr(message, 'data') and message.data else "{}"
         self._data_node = json.loads(json_data)
         self._buffer = ""
         self._tokens = []

--- a/tests/core/activity/parsing/input_tokenizer_test.py
+++ b/tests/core/activity/parsing/input_tokenizer_test.py
@@ -1,3 +1,4 @@
+from lib2to3.pgen2.tokenize import tokenize
 from symphony.bdk.core.activity.parsing.message_entities import Cashtag, Hashtag, Mention
 from symphony.bdk.core.activity.parsing.input_tokenizer import InputTokenizer
 from symphony.bdk.gen.agent_model.v4_message import V4Message
@@ -129,6 +130,13 @@ def test_one_cashtag():
 
     assert under_test.tokens == [Cashtag("$mycashtag", "mycashtag")]
 
+class PartialV4Message:
+    def __init__(self, message: str):
+        self.message = message
+
+def test_partial_message():
+    tokenizer = InputTokenizer(PartialV4Message(message=build_v4_message("hello").message))
+    assert tokenizer.tokens == ["hello"]
 
 def build_tokenizer(content):
     return build_tokenizer_with_data(content, "{}")
@@ -143,3 +151,4 @@ def build_v4_message(content, data="{}"):
         message="<div data-format=\"PresentationML\" data-version=\"2.0\" class=\"wysiwyg\"><p>" + content +
                 "</p></div>",
         data=data)
+


### PR DESCRIPTION
### Description
Closes #304

Incoming `message` payload might not have `data` field, causing `InputTokenizer` to throw error