### PR TITLE
fix(config): read the config file as UTF-8 rather than the platform codec

### DIFF
--- a/symphony/bdk/core/config/loader.py
+++ b/symphony/bdk/core/config/loader.py
@@ -24,7 +24,7 @@ class BdkConfigLoader:
         """
         config_path = Path(config_path)
         if config_path.exists():
-            config_content = config_path.read_text()
+            config_content = config_path.read_text(encoding="utf-8")
             return cls.load_from_content(config_content)
         raise BdkConfigError(f"Config file has not been found at: {config_path.absolute()}")
 

--- a/tests/core/config/bdk_config_encoding_test.py
+++ b/tests/core/config/bdk_config_encoding_test.py
@@ -1,0 +1,98 @@
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from symphony.bdk.core.config.loader import BdkConfigLoader
+from tests.utils.resource_utils import get_config_resource_filepath
+
+# YAML and JSON are both specified as UTF-8. Reading a config with the platform
+# codec instead produced no error on a codepage that happens to map the bytes:
+# the bot started with a mojibake proxy password and failed later against the
+# proxy with an unrelated-looking error.
+EXPECTED_PASSWORD = "sésame-café"
+EXPECTED_USERNAME = "café-user"
+
+# The importers run in a child interpreter with a legacy locale forced on, so
+# the test is meaningful on a UTF-8 CI host too. Without this it passes whether
+# or not the fix is present, everywhere the locale is already UTF-8.
+LEGACY_LOCALE_ENV = {
+    "PYTHONUTF8": "0",
+    "PYTHONCOERCECLOCALE": "0",
+    "LC_ALL": "C",
+    "LANG": "C",
+}
+
+LOAD_SCRIPT = textwrap.dedent(
+    """
+    import json, sys
+    from symphony.bdk.core.config.loader import BdkConfigLoader
+
+    config = BdkConfigLoader.load_from_file(sys.argv[1])
+    sys.stdout.buffer.write(
+        json.dumps(
+            {"username": config.proxy.username, "password": config.proxy.password},
+            ensure_ascii=False,
+        ).encode("utf-8")
+    )
+    """
+)
+
+
+@pytest.fixture(name="utf8_config_path", params=["config_utf8.json", "config_utf8.yaml"])
+def fixture_utf8_config_path(request):
+    return get_config_resource_filepath(request.param)
+
+
+def test_load_from_file_reads_utf8_under_legacy_locale(utf8_config_path, tmp_path):
+    """A UTF-8 config loads identically regardless of the host locale."""
+    script = tmp_path / "load.py"
+    script.write_text(LOAD_SCRIPT, encoding="utf-8")
+
+    completed = subprocess.run(
+        [sys.executable, str(script), utf8_config_path],
+        capture_output=True,
+        env={**os.environ, **LEGACY_LOCALE_ENV},
+    )
+
+    # Catches the loud failure: on a locale that cannot map the bytes at all,
+    # read_text raises and the bot never starts.
+    assert completed.returncode == 0, completed.stderr.decode("utf-8", "replace")
+
+    # Catches the silent one. Asserting on bytes decoded as UTF-8 is the point:
+    # comparing strings that came back through the same broken default would
+    # round-trip the mojibake and pass either way.
+    import json
+
+    loaded = json.loads(completed.stdout.decode("utf-8"))
+    assert loaded["password"] == EXPECTED_PASSWORD
+    assert loaded["username"] == EXPECTED_USERNAME
+
+
+def test_load_from_file_matches_load_from_content(utf8_config_path):
+    """The two entry points agree.
+
+    load_from_content is handed already-decoded text and was always correct,
+    so it serves as the oracle for what load_from_file should produce.
+    """
+    from pathlib import Path
+
+    from_file = BdkConfigLoader.load_from_file(utf8_config_path)
+    from_content = BdkConfigLoader.load_from_content(
+        Path(utf8_config_path).read_text(encoding="utf-8")
+    )
+
+    assert from_file.proxy.password == from_content.proxy.password
+    assert from_file.proxy.password == EXPECTED_PASSWORD
+
+
+def test_ascii_config_is_unaffected():
+    """The ASCII path the existing fixtures cover is unchanged.
+
+    A control: this passes with and without the fix, so a failure here means
+    the harness broke rather than the encoding handling.
+    """
+    config = BdkConfigLoader.load_from_file(get_config_resource_filepath("config.yaml"))
+    assert config.bot.username == "youbot"

--- a/tests/resources/config/config_utf8.json
+++ b/tests/resources/config/config_utf8.json
@@ -1,0 +1,17 @@
+{
+  "_version": "2.0",
+
+  "pod": { "host": "devx1.symphony.com" },
+  "agent": { "host": "devx1.symphony.com" },
+  "keyManager": { "host": "devx1.symphony.com" },
+  "bot": {
+    "username": "youbot",
+    "privateKey": { "path": "/Users/local/conf/agent/privatekey.pem" }
+  },
+  "proxy": {
+    "host": "proxy.symphony.com",
+    "port": 1234,
+    "username": "café-user",
+    "password": "sésame-café"
+  }
+}

--- a/tests/resources/config/config_utf8.yaml
+++ b/tests/resources/config/config_utf8.yaml
@@ -1,0 +1,21 @@
+_version: '2.0'
+
+pod:
+  host: devx1.symphony.com
+
+agent:
+  host: devx1.symphony.com
+
+keyManager:
+  host: devx1.symphony.com
+
+bot:
+  username: youbot
+  privateKey:
+    path: /Users/local/conf/agent/privatekey.pem
+
+proxy:
+  host: proxy.symphony.com
+  port: 1234
+  username: café-user
+  password: sésame-café


### PR DESCRIPTION
Closes #395.

## The defect

`load_from_file` decoded the config with `locale.getpreferredencoding()`:

```python
# symphony/bdk/core/config/loader.py:27
config_content = config_path.read_text()
```

YAML and JSON are both specified as UTF-8, so on a non-UTF-8 host every non-ASCII value in a config comes back wrong.

**The failure is silent where it matters.** Measured on Windows with cp950, on a config carrying a non-ASCII proxy credential:

| | value |
| --- | --- |
| on disk | `password: "sésame-café"` (`b'...s\xc3\xa9same-caf\xc3\xa9...'`) |
| `load_from_file` | `password='s矇same-caf矇'` — no exception |
| `load_from_content`, same bytes | `password='sésame-café'` |

Nothing errors. The bot starts, authenticates against the proxy with a password that is not the one in the file, and fails with a message that points nowhere near the config. The third row isolates it to the read rather than the parse.

A `LC_ALL=C` host raises instead, which is the loud version of the same bug; cp1252 on en-US Windows mangles it just as quietly as cp950 does.

## The change

One argument on line 27. The repository already uses this pattern at `service/user/user_service.py:798`, so the two reads now agree.

**Two other implicit-encoding reads are deliberately out of scope**, rather than swept in because they matched a grep:

- `bdk_rsa_key_config.py:59` reads a PEM private key, which is base64 and therefore ASCII
- `on_disk_datafeed_id_repository.py:56` reads an id this library wrote itself

Neither can carry non-ASCII in practice. Happy to tighten them in a separate PR if you would like the module clean under `-X warn_default_encoding`, but they are a different question from this bug.

## The test

Two deliberate choices, because the obvious version of this test proves nothing:

**It runs the loader in a child interpreter with `PYTHONUTF8=0 PYTHONCOERCECLOCALE=0 LC_ALL=C LANG=C`.** Without that it passes on a UTF-8 CI host whether or not the fix is present — which is why this has gone unnoticed.

**`load_from_content` is used as the oracle.** It receives already-decoded text and was always correct, so asserting the two entry points agree states the actual invariant rather than hard-coding an expected string.

The fixtures are written as raw bytes, and I verified the UTF-8 sequences survive into the git index (`c3 a9` for `é`) — a fixture silently re-encoded on the way in would quietly disarm the test for everyone else.

Verified by reverting the one-line change: **4 failed / 1 passed** before (both formats × both assertions), **5 passed** after. The always-passing case is an ASCII config, kept as a control so a failure there means the harness broke rather than the encoding handling.

## Checks

Full suite: **558 passed before, 563 after** — exactly my five — with the same 2 pre-existing failures both times. Commit is DCO signed off; our FINOS CLA is on file.
