### PR TITLE
Bump version to 2.11.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "symphony_bdk_python"
-version = "2.11.2"
+version = "2.11.3"
 license = "Apache-2.0"
 description = "Symphony Bot Development Kit for Python"
 readme = "README.md"


### PR DESCRIPTION
## Summary
Bumps the version in `pyproject.toml` from `2.11.2` to `2.11.3` to prepare a patch release.

## Context
The `cryptography` cap on the latest published release (`v2.11.2`) is `^46.0.0`, which does not include the fix for **CVE-2026-34180** (DoS via malformed ASN.1 input, patched in `cryptography 48.0.1`). Bots that depend on `symphony-bdk-python` cannot pin `cryptography>=48.0.1` themselves because pip resolution fails against the transitive cap declared in BDK's own metadata.

The actual fix has already been merged to `main` via [#390](https://github.com/finos/symphony-bdk-python/pull/390) — `cryptography` is now pinned to `>=48.0.1,<49.0.0` and `poetry.lock` is regenerated accordingly. All that's missing to unblock downstream consumers is a published release cut from main.

This PR is just the version bump so that once merged, a maintainer can publish a GitHub Release tagged `v2.11.3` and the existing `release.yml` workflow picks it up and pushes to PyPI.

## Downstream impact
This unblocks CVE remediation on every downstream Symphony bot that depends on `symphony-bdk-python` — Symphony's InfoSec team is currently tracking the vulnerability across multiple bot deployments and the only unblock is a new release.

## Test plan
- [ ] Verified `pyproject.toml` version field is the only change.
- [ ] After merge, a maintainer publishes a `v2.11.3` GitHub Release from `main`.
- [ ] `release.yml` fires, `poetry publish --build` pushes `symphony_bdk_python-2.11.3` to PyPI.
- [ ] Downstream bots pin `symphony-bdk-python>=2.11.3` and verify `pip install` pulls `cryptography 48.0.1`.